### PR TITLE
[BugFix] Precast MoE gate weight_fp32 to avoid aclop Cast

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1886,15 +1886,19 @@ def test_gate_weight_fp32_returns_existing_buffer_without_cast():
     weight.data.to.assert_not_called()
 
 
-def test_gate_weight_fp32_requires_precast_buffer():
+def test_gate_weight_fp32_caches_cast_once():
     runner = AscendMoERunner.__new__(AscendMoERunner)
     weight_fp16 = torch.randn(8, 4, dtype=torch.float16)
     gate = SimpleNamespace(weight=SimpleNamespace(data=weight_fp16))
     runner._gate = gate
     runner.gate = gate
 
-    with pytest.raises(RuntimeError, match="missing weight_fp32"):
-        runner._gate_weight_fp32()
+    first = runner._gate_weight_fp32()
+    second = runner._gate_weight_fp32()
+
+    assert first.dtype == torch.float32
+    assert first is second
+    assert gate.weight_fp32 is first
 
 
 def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1830,6 +1830,7 @@ def _stub_moe_runner_init(monkeypatch, *, gate=None, shared_experts=None):
         runner.routed_experts = experts
         runner._shared_experts = shared_experts_arg
         runner._gate = gate_arg
+        runner.gate = gate_arg
         runner.routed_input_transform = routed_input_transform
         runner.routed_output_transform = routed_output_transform
         runner.routed_scaling_factor = routed_scaling_factor
@@ -1853,15 +1854,15 @@ def _stub_moe_runner_init(monkeypatch, *, gate=None, shared_experts=None):
 
 
 def test_runner_casts_weight_fp32_then_sets_precast(monkeypatch):
-    """Init casts gate.weight → weight_fp32, then sets precast for load refresh."""
+    """Init sets precast, then seeds weight_fp32 from gate.weight."""
     weight = torch.randn(8, 4, dtype=torch.float16)
     gate = SimpleNamespace(weight=weight)
     runner = _stub_moe_runner_init(monkeypatch, gate=gate)
 
     assert runner._gate is gate
+    assert gate.precast_fp32_weight is True
     assert gate.weight_fp32.dtype == torch.float32
     torch.testing.assert_close(gate.weight_fp32, weight.to(torch.float32))
-    assert gate.precast_fp32_weight is True
 
 
 def test_runner_skips_precast_when_weight_fp32_already_exists(monkeypatch):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1853,16 +1853,14 @@ def _stub_moe_runner_init(monkeypatch, *, gate=None, shared_experts=None):
     )
 
 
-def test_runner_casts_weight_fp32_then_sets_precast(monkeypatch):
-    """Init sets precast, then seeds weight_fp32 from gate.weight."""
-    weight = torch.randn(8, 4, dtype=torch.float16)
-    gate = SimpleNamespace(weight=weight)
+def test_runner_sets_precast_fp32_weight(monkeypatch):
+    """Init sets precast so load materializes weight_fp32."""
+    gate = SimpleNamespace(weight=torch.randn(8, 4, dtype=torch.float16))
     runner = _stub_moe_runner_init(monkeypatch, gate=gate)
 
     assert runner._gate is gate
     assert gate.precast_fp32_weight is True
-    assert gate.weight_fp32.dtype == torch.float32
-    torch.testing.assert_close(gate.weight_fp32, weight.to(torch.float32))
+    assert not hasattr(gate, "weight_fp32")
 
 
 def test_runner_skips_precast_when_weight_fp32_already_exists(monkeypatch):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1954,9 +1954,7 @@ def test_forward_impl_shared_experts_uses_gate_weight_fp32(monkeypatch):
         parallel_mode=MagicMock(return_value=None),
         forward=MagicMock(return_value=shared_out),
     )
-    runner.routed_experts = SimpleNamespace(
-        forward_impl=MagicMock(return_value=(routed_out, routed_events))
-    )
+    runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=(routed_out, routed_events)))
     runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
     current_stream = MagicMock()
     monkeypatch.setattr(fused_moe_module.F, "linear", fake_linear)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1886,19 +1886,15 @@ def test_gate_weight_fp32_returns_existing_buffer_without_cast():
     weight.data.to.assert_not_called()
 
 
-def test_gate_weight_fp32_caches_cast_once():
+def test_gate_weight_fp32_requires_precast_buffer():
     runner = AscendMoERunner.__new__(AscendMoERunner)
     weight_fp16 = torch.randn(8, 4, dtype=torch.float16)
     gate = SimpleNamespace(weight=SimpleNamespace(data=weight_fp16))
     runner._gate = gate
     runner.gate = gate
 
-    first = runner._gate_weight_fp32()
-    second = runner._gate_weight_fp32()
-
-    assert first.dtype == torch.float32
-    assert first is second
-    assert gate.weight_fp32 is first
+    with pytest.raises(RuntimeError, match="missing weight_fp32"):
+        runner._gate_weight_fp32()
 
 
 def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1852,11 +1852,15 @@ def _stub_moe_runner_init(monkeypatch, *, gate=None, shared_experts=None):
     )
 
 
-def test_runner_sets_precast_fp32_weight_for_internal_router(monkeypatch):
-    gate = SimpleNamespace()
+def test_runner_casts_weight_fp32_then_sets_precast(monkeypatch):
+    """Init casts gate.weight → weight_fp32, then sets precast for load refresh."""
+    weight = torch.randn(8, 4, dtype=torch.float16)
+    gate = SimpleNamespace(weight=weight)
     runner = _stub_moe_runner_init(monkeypatch, gate=gate)
 
     assert runner._gate is gate
+    assert gate.weight_fp32.dtype == torch.float32
+    torch.testing.assert_close(gate.weight_fp32, weight.to(torch.float32))
     assert gate.precast_fp32_weight is True
 
 
@@ -1873,35 +1877,8 @@ def test_runner_skips_precast_without_internal_router(monkeypatch):
     assert runner._gate is None
 
 
-def test_gate_weight_fp32_returns_existing_buffer_without_cast():
-    runner = AscendMoERunner.__new__(AscendMoERunner)
-    weight_fp32 = torch.randn(8, 4, dtype=torch.float32)
-    weight = MagicMock()
-    weight.data.to = MagicMock(side_effect=AssertionError("hot-path Cast must not run"))
-    gate = SimpleNamespace(weight=weight, weight_fp32=weight_fp32)
-    runner._gate = gate
-    runner.gate = gate
-
-    assert runner._gate_weight_fp32() is weight_fp32
-    weight.data.to.assert_not_called()
-
-
-def test_gate_weight_fp32_caches_cast_once():
-    runner = AscendMoERunner.__new__(AscendMoERunner)
-    weight_fp16 = torch.randn(8, 4, dtype=torch.float16)
-    gate = SimpleNamespace(weight=SimpleNamespace(data=weight_fp16))
-    runner._gate = gate
-    runner.gate = gate
-
-    first = runner._gate_weight_fp32()
-    second = runner._gate_weight_fp32()
-
-    assert first.dtype == torch.float32
-    assert first is second
-    assert gate.weight_fp32 is first
-
-
-def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):
+def test_forward_impl_uses_gate_weight_fp32(monkeypatch):
+    """Hot path only reads gate.weight_fp32; judgment lives in __init__."""
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     hidden_states = torch.randn(2, 4, dtype=torch.float16)
@@ -1909,7 +1886,7 @@ def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):
     router_logits = torch.randn(2, 3, dtype=torch.float16)
     weight_fp32 = torch.randn(3, 4, dtype=torch.float32)
     weight = MagicMock()
-    weight.data.to = MagicMock(side_effect=AssertionError("forward must not Cast gate.weight"))
+    weight.to = MagicMock(side_effect=AssertionError("forward must not Cast gate.weight"))
     gate = SimpleNamespace(weight=weight, weight_fp32=weight_fp32)
     routed_out = torch.randn(2, 4)
     recomputed_logits = torch.randn(2, 3, dtype=torch.float32)
@@ -1934,9 +1911,68 @@ def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):
     )
 
     assert result is routed_out
-    weight.data.to.assert_not_called()
+    weight.to.assert_not_called()
     runner.routed_experts.forward_impl.assert_called_once_with(
         hidden_states=hidden_states,
         router_logits=recomputed_logits,
         input_ids=None,
     )
+
+
+def test_forward_impl_shared_experts_uses_gate_weight_fp32(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.float16)
+    router_logits = torch.randn(2, 3, dtype=torch.float16)
+    weight_fp32 = torch.randn(3, 4, dtype=torch.float32)
+    weight = MagicMock()
+    weight.to = MagicMock(side_effect=AssertionError("forward must not Cast gate.weight"))
+    gate = SimpleNamespace(weight=weight, weight_fp32=weight_fp32)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 4)
+    recomputed_logits = torch.randn(2, 3, dtype=torch.float32)
+    routed_events = FusedMoEEvents(
+        before_routed_experts=None,
+        after_routed_experts=None,
+        before_dispatch=None,
+        before_gmm2=None,
+        before_combine=None,
+    )
+
+    def fake_linear(x, w):
+        assert w is weight_fp32
+        assert x.dtype == torch.float32
+        return recomputed_logits
+
+    runner._gate = gate
+    runner.gate = gate
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=False,
+        parallel_mode=MagicMock(return_value=None),
+        forward=MagicMock(return_value=shared_out),
+    )
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=(routed_out, routed_events))
+    )
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    current_stream = MagicMock()
+    monkeypatch.setattr(fused_moe_module.F, "linear", fake_linear)
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
+
+    result = runner._forward_impl(
+        hidden_states,
+        router_logits,
+        shared_experts_input=None,
+        input_ids=None,
+    )
+
+    assert result == (shared_out, routed_out)
+    weight.to.assert_not_called()
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=recomputed_logits,
+        input_ids=None,
+    )
+    runner.ascend_shared_experts.forward.assert_called_once()

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1798,3 +1798,145 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
     }
     assert result[0] is shared_out
     assert result[1] is routed_out
+
+
+def _stub_moe_runner_init(monkeypatch, *, gate=None, shared_experts=None):
+    """Construct AscendMoERunner with a lightweight MoERunner.__init__ stub."""
+    moe_config = SimpleNamespace(hidden_dim=4, ep_size=1)
+    routed_experts = SimpleNamespace(
+        quant_type=QuantType.NONE,
+        quant_method=object(),
+        return_with_event=False,
+        router=None,
+    )
+
+    def init_base_runner(
+        runner,
+        layer_name,
+        config,
+        _router,
+        experts,
+        _enable_dbo,
+        gate_arg,
+        shared_experts_arg,
+        _shared_expert_gate,
+        routed_input_transform,
+        routed_output_transform,
+        routed_scaling_factor,
+    ):
+        nn.Module.__init__(runner)
+        runner.layer_name = layer_name
+        runner.moe_config = config
+        runner.routed_experts = experts
+        runner._shared_experts = shared_experts_arg
+        runner._gate = gate_arg
+        runner.routed_input_transform = routed_input_transform
+        runner.routed_output_transform = routed_output_transform
+        runner.routed_scaling_factor = routed_scaling_factor
+        runner._forward_entry = object()
+
+    monkeypatch.setattr(fused_moe_module.MoERunner, "__init__", init_base_runner)
+    monkeypatch.setattr(fused_moe_module, "AscendSharedExperts", MagicMock(return_value=SimpleNamespace()))
+    monkeypatch.setattr(fused_moe_module, "get_tp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "get_dp_group", MagicMock(return_value=object()))
+    monkeypatch.setattr(fused_moe_module, "setup_moe_comm_method", MagicMock())
+    monkeypatch.setattr(fused_moe_module, "get_moe_comm_method", MagicMock(return_value=None))
+
+    return AscendMoERunner(
+        "model.layers.0.mlp",
+        moe_config,
+        router=object(),
+        routed_experts=routed_experts,
+        gate=gate,
+        shared_experts=shared_experts,
+    )
+
+
+def test_runner_sets_precast_fp32_weight_for_internal_router(monkeypatch):
+    gate = SimpleNamespace()
+    runner = _stub_moe_runner_init(monkeypatch, gate=gate)
+
+    assert runner._gate is gate
+    assert gate.precast_fp32_weight is True
+
+
+def test_runner_skips_precast_when_weight_fp32_already_exists(monkeypatch):
+    gate = SimpleNamespace(weight_fp32=torch.randn(8, 4, dtype=torch.float32))
+    runner = _stub_moe_runner_init(monkeypatch, gate=gate)
+
+    assert runner._gate is gate
+    assert not hasattr(gate, "precast_fp32_weight")
+
+
+def test_runner_skips_precast_without_internal_router(monkeypatch):
+    runner = _stub_moe_runner_init(monkeypatch, gate=None)
+    assert runner._gate is None
+
+
+def test_gate_weight_fp32_returns_existing_buffer_without_cast():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    weight_fp32 = torch.randn(8, 4, dtype=torch.float32)
+    weight = MagicMock()
+    weight.data.to = MagicMock(side_effect=AssertionError("hot-path Cast must not run"))
+    gate = SimpleNamespace(weight=weight, weight_fp32=weight_fp32)
+    runner._gate = gate
+    runner.gate = gate
+
+    assert runner._gate_weight_fp32() is weight_fp32
+    weight.data.to.assert_not_called()
+
+
+def test_gate_weight_fp32_caches_cast_once():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    weight_fp16 = torch.randn(8, 4, dtype=torch.float16)
+    gate = SimpleNamespace(weight=SimpleNamespace(data=weight_fp16))
+    runner._gate = gate
+    runner.gate = gate
+
+    first = runner._gate_weight_fp32()
+    second = runner._gate_weight_fp32()
+
+    assert first.dtype == torch.float32
+    assert first is second
+    assert gate.weight_fp32 is first
+
+
+def test_forward_impl_uses_precast_gate_weight_fp32(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.float16)
+    # FP16 router_logits forces the path that uses hidden_states.float() + gate weight.
+    router_logits = torch.randn(2, 3, dtype=torch.float16)
+    weight_fp32 = torch.randn(3, 4, dtype=torch.float32)
+    weight = MagicMock()
+    weight.data.to = MagicMock(side_effect=AssertionError("forward must not Cast gate.weight"))
+    gate = SimpleNamespace(weight=weight, weight_fp32=weight_fp32)
+    routed_out = torch.randn(2, 4)
+    recomputed_logits = torch.randn(2, 3, dtype=torch.float32)
+
+    def fake_linear(x, w):
+        assert w is weight_fp32
+        assert x.dtype == torch.float32
+        return recomputed_logits
+
+    runner._gate = gate
+    runner.gate = gate
+    runner.ascend_shared_experts = None
+    runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=routed_out))
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    monkeypatch.setattr(fused_moe_module.F, "linear", fake_linear)
+
+    result = runner._forward_impl(
+        hidden_states,
+        router_logits,
+        shared_experts_input=None,
+        input_ids=None,
+    )
+
+    assert result is routed_out
+    weight.data.to.assert_not_called()
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=recomputed_logits,
+        input_ids=None,
+    )

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -59,7 +59,6 @@ class TestAscendGateLinear(TestBase):
         )
 
         self.assertEqual(gate.weight.dtype, torch.float32)
-        self.assertTrue(gate.precast_fp32_weight)
         self.assertEqual(gate.out_dtype, torch.float32)
 
         hidden_states = torch.randn(2, 16, dtype=torch.bfloat16)

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -54,16 +54,29 @@ class TestAscendGateLinear(TestBase):
             input_size=16,
             output_size=4,
             bias=False,
+            out_dtype=torch.float32,
             prefix="test.gate",
         )
 
         self.assertEqual(gate.weight.dtype, torch.float32)
+        self.assertTrue(gate.precast_fp32_weight)
+        self.assertEqual(gate.out_dtype, torch.float32)
 
         hidden_states = torch.randn(2, 16, dtype=torch.bfloat16)
         output, output_bias = gate(hidden_states)
 
         self.assertEqual(output.dtype, torch.float32)
         self.assertIsNone(output_bias)
+
+    def test_set_out_dtype(self):
+        gate = AscendGateLinear(
+            input_size=16,
+            output_size=4,
+            bias=False,
+            prefix="test.gate",
+        )
+        gate.set_out_dtype(torch.float32)
+        self.assertEqual(gate.out_dtype, torch.float32)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -68,16 +68,6 @@ class TestAscendGateLinear(TestBase):
         self.assertEqual(output.dtype, torch.float32)
         self.assertIsNone(output_bias)
 
-    def test_set_out_dtype(self):
-        gate = AscendGateLinear(
-            input_size=16,
-            output_size=4,
-            bias=False,
-            prefix="test.gate",
-        )
-        gate.set_out_dtype(torch.float32)
-        self.assertEqual(gate.out_dtype, torch.float32)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -20,9 +20,18 @@ from unittest import mock
 from unittest.mock import patch
 
 import torch
+import torch.nn.functional as F
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
+
+
+def _cpu_unquantized_apply(layer, x, bias=None):
+    """Stand in for AscendUnquantizedLinearMethod.apply on CPU.
+
+    Production apply dispatches vllm::unquantized_gemm (PrivateUse1 / NPU only).
+    """
+    return F.linear(x, layer.weight, bias)
 
 
 class TestAscendGateLinear(TestBase):
@@ -66,9 +75,11 @@ class TestAscendGateLinear(TestBase):
         self.assertEqual(gate.out_dtype, torch.float32)
 
         hidden_states = torch.randn(2, 16, dtype=torch.bfloat16)
-        output, output_bias = gate(hidden_states)
+        with patch.object(gate.quant_method, "apply", side_effect=_cpu_unquantized_apply):
+            output, output_bias = gate(hidden_states)
 
         self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.shape, (2, 4))
         self.assertIsNone(output_bias)
 
 

--- a/tests/ut/ops/test_gate_linear.py
+++ b/tests/ut/ops/test_gate_linear.py
@@ -38,6 +38,10 @@ class TestAscendGateLinear(TestBase):
                 "vllm.distributed.parallel_state.get_tp_group",
                 return_value=self.mock_group,
             ),
+            patch(
+                "vllm_ascend.ops.linear_op.get_tp_group",
+                return_value=self.mock_group,
+            ),
         ]
 
         for p in self.patches:

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -96,10 +96,16 @@ class TestAscendUnquantizedLinearMethod(TestBase):
         mock_get_config.return_value = mock_config
         self.layer.skip_weight_nz_conversion = True
         self.layer.precast_fp32_weight = True
+        # Real tensor so precast can materialize weight_fp32 alongside the NZ skip.
+        weight = torch.randn(8, 4, dtype=torch.float16)
+        self.layer.weight.data = weight
+        self.layer.prefix = "model.layers.0.mlp.gate"
 
         self.method.process_weights_after_loading(self.layer)
 
         mock_format_cast.assert_not_called()
+        self.assertEqual(self.layer.weight_fp32.dtype, torch.float32)
+        torch.testing.assert_close(self.layer.weight_fp32, weight.to(torch.float32))
 
     @patch("vllm_ascend.utils.get_ascend_config")
     @mock.patch("vllm_ascend.ops.linear.maybe_trans_nz", side_effect=lambda x: x)

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -101,6 +101,29 @@ class TestAscendUnquantizedLinearMethod(TestBase):
 
         mock_format_cast.assert_not_called()
 
+    @patch("vllm_ascend.utils.get_ascend_config")
+    @mock.patch("vllm_ascend.ops.linear.maybe_trans_nz", side_effect=lambda x: x)
+    @mock.patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_precasts_fp32_weight(
+        self, mock_format_cast, mock_maybe_trans_nz, mock_get_config
+    ):
+        mock_config = MagicMock()
+        mock_config.weight_nz_mode = 0
+        mock_get_config.return_value = mock_config
+
+        weight = torch.randn(8, 4, dtype=torch.float16)
+        layer = mock.MagicMock()
+        layer.weight.data = weight
+        layer.prefix = "model.layers.0.mlp.gate"
+        layer.precast_fp32_weight = True
+        layer.skip_weight_nz_conversion = True
+
+        self.method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight_fp32.dtype, torch.float32)
+        torch.testing.assert_close(layer.weight_fp32, weight.to(torch.float32))
+        mock_format_cast.assert_not_called()
+
 
 class TestAscendRowParallelLinear(BaseLinearTest):
     @patch("vllm_ascend.ops.linear.get_current_vllm_config", return_value=MagicMock())

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -116,13 +116,23 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
-        # Internal-router gates recompute logits in FP32. Ask AscendUnquantizedLinearMethod
-        # to materialize weight_fp32 during process_weights_after_loading so the hot path
-        # (and ACLGraph capture) never emits a per-forward aclop Cast via weight.to(fp32).
+        # Internal-router gates recompute logits in FP32. Resolve the weight
+        # choice here (the old forward-time
+        # `weight_fp32 if hasattr else weight.to(fp32)` judgment) so ACLGraph
+        # capture never emits a per-forward aclop Cast.
         # Use the ctor `gate` arg directly: nn.Module.__getattr__ can shadow
         # `@property is_internal_router` / `gate` while __init__ is still running.
-        if gate is not None and not hasattr(gate, "weight_fp32"):
-            gate.precast_fp32_weight = True
+        if gate is not None:
+            if hasattr(gate, "weight_fp32"):
+                # Already materialized (e.g. DeepSeek-V4 sets it itself).
+                pass
+            else:
+                # Resolve fp32 weight up front when Parameter already exists, then
+                # still request load-time refresh so process_weights_after_loading
+                # overwrites with the real checkpoint values (init-time Parameter
+                # would otherwise freeze stale random weights).
+                gate.weight_fp32 = gate.weight.to(torch.float32)
+                gate.precast_fp32_weight = True
 
         self.ascend_shared_experts = None
         if shared_experts is not None:
@@ -153,18 +163,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # DeepseekV2MoE.forward, always passing router_logits=hidden_states.
         # The runner must recompute router_logits via the gate.
         return self.gate is not None
-
-    def _gate_weight_fp32(self) -> torch.Tensor:
-        """Return the internal-router gate weight in FP32 without a hot-path Cast."""
-        gate = self.gate
-        assert gate is not None
-        weight_fp32 = getattr(gate, "weight_fp32", None)
-        if weight_fp32 is not None:
-            return weight_fp32
-        # Unexpected load path: cache once so later forwards do not keep casting.
-        weight_fp32 = gate.weight.data.to(torch.float32)
-        gate.weight_fp32 = weight_fp32
-        return weight_fp32
 
     @property
     def use_dp_chunking(self) -> bool:
@@ -323,10 +321,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             shared_hidden_states = shared_experts_input if shared_experts_input is not None else hidden_states
             if self.ascend_shared_experts is None:
                 if self.is_internal_router:
+                    gate = self.gate
+                    assert gate is not None
                     hidden_states_fp32 = (
                         router_logits if router_logits.dtype == torch.float32 else hidden_states.float()
                     )
-                    router_logits = F.linear(hidden_states_fp32, self._gate_weight_fp32())
+                    # weight_fp32 is ensured in __init__ (precast / already present).
+                    router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
                 return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -340,13 +341,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
             )
             if self.is_internal_router:
+                gate = self.gate
+                assert gate is not None
                 # Reuse the fused RMSNorm FP32 output when supplied. Otherwise,
                 # retain the standalone cast for other model call sites.
                 hidden_states_fp32 = (
                     router_logits if router_logits.dtype == torch.float32 else shared_hidden_states.float()
                 )
                 before_routed_experts = torch.npu.current_stream().record_event()
-                router_logits = F.linear(hidden_states_fp32, self._gate_weight_fp32())
+                # weight_fp32 is ensured in __init__ (precast / already present).
+                router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
                 after_routed_experts = torch.npu.current_stream().record_event()
             else:
                 before_routed_experts = torch.npu.current_stream().record_event()

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -116,23 +116,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
-        # Internal-router gates recompute logits in FP32. Resolve the weight
-        # choice here (the old forward-time
-        # `weight_fp32 if hasattr else weight.to(fp32)` judgment) so ACLGraph
-        # capture never emits a per-forward aclop Cast.
-        # Use the ctor `gate` arg (same as is_internal_router): nn.Module.__getattr__
-        # can shadow `@property is_internal_router` / `gate` while __init__ runs,
-        # which breaks cpu-ut construction stubs that only set `_gate`.
-        if gate is not None:
-            if hasattr(gate, "weight_fp32"):
-                # Already materialized (e.g. DeepSeek-V4 sets it itself).
-                pass
-            else:
-                # Request load-time refresh, then seed weight_fp32 so the hot
-                # path can read it even before process_weights_after_loading.
-                # precast overwrites this buffer with checkpoint values on load.
-                gate.precast_fp32_weight = True
-                gate.weight_fp32 = gate.weight.to(torch.float32)
+        # Internal-router: seed weight_fp32 + precast for load refresh (avoid hot-path Cast).
+        # Use ctor `gate` (not self.is_internal_router): Module.__getattr__ shadows during init.
+        if gate is not None and not hasattr(gate, "weight_fp32"):
+            gate.precast_fp32_weight = True
+            gate.weight_fp32 = gate.weight.to(torch.float32)
 
         self.ascend_shared_experts = None
         if shared_experts is not None:
@@ -326,7 +314,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     hidden_states_fp32 = (
                         router_logits if router_logits.dtype == torch.float32 else hidden_states.float()
                     )
-                    # weight_fp32 is ensured in __init__ (precast / already present).
                     router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
                 return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
@@ -349,7 +336,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     router_logits if router_logits.dtype == torch.float32 else shared_hidden_states.float()
                 )
                 before_routed_experts = torch.npu.current_stream().record_event()
-                # weight_fp32 is ensured in __init__ (precast / already present).
                 router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
                 after_routed_experts = torch.npu.current_stream().record_event()
             else:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -159,11 +159,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         gate = self.gate
         assert gate is not None
         weight_fp32 = getattr(gate, "weight_fp32", None)
-        if weight_fp32 is not None:
-            return weight_fp32
-        # Unexpected load path: cache once so later forwards do not keep casting.
-        weight_fp32 = gate.weight.data.to(torch.float32)
-        gate.weight_fp32 = weight_fp32
+        if weight_fp32 is None:
+            # Do not fall back to gate.weight.to(fp32): that emits an
+            # uncapturable aclop Cast during ACLGraph capture. Precast must
+            # happen in process_weights_after_loading via precast_fp32_weight.
+            raise RuntimeError(
+                "Internal-router MoE gate is missing weight_fp32 after weight "
+                "loading. Ensure gate.precast_fp32_weight=True before "
+                "process_weights_after_loading so ACLGraph capture does not "
+                "emit an uncapturable aclop Cast."
+            )
         return weight_fp32
 
     @property

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -159,16 +159,11 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         gate = self.gate
         assert gate is not None
         weight_fp32 = getattr(gate, "weight_fp32", None)
-        if weight_fp32 is None:
-            # Do not fall back to gate.weight.to(fp32): that emits an
-            # uncapturable aclop Cast during ACLGraph capture. Precast must
-            # happen in process_weights_after_loading via precast_fp32_weight.
-            raise RuntimeError(
-                "Internal-router MoE gate is missing weight_fp32 after weight "
-                "loading. Ensure gate.precast_fp32_weight=True before "
-                "process_weights_after_loading so ACLGraph capture does not "
-                "emit an uncapturable aclop Cast."
-            )
+        if weight_fp32 is not None:
+            return weight_fp32
+        # Unexpected load path: cache once so later forwards do not keep casting.
+        weight_fp32 = gate.weight.data.to(torch.float32)
+        gate.weight_fp32 = weight_fp32
         return weight_fp32
 
     @property

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -120,9 +120,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # choice here (the old forward-time
         # `weight_fp32 if hasattr else weight.to(fp32)` judgment) so ACLGraph
         # capture never emits a per-forward aclop Cast.
-        if self.is_internal_router:
-            gate = self.gate
-            assert gate is not None
+        # Use the ctor `gate` arg (same as is_internal_router): nn.Module.__getattr__
+        # can shadow `@property is_internal_router` / `gate` while __init__ runs,
+        # which breaks cpu-ut construction stubs that only set `_gate`.
+        if gate is not None:
             if hasattr(gate, "weight_fp32"):
                 # Already materialized (e.g. DeepSeek-V4 sets it itself).
                 pass

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -120,19 +120,18 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # choice here (the old forward-time
         # `weight_fp32 if hasattr else weight.to(fp32)` judgment) so ACLGraph
         # capture never emits a per-forward aclop Cast.
-        # Use the ctor `gate` arg directly: nn.Module.__getattr__ can shadow
-        # `@property is_internal_router` / `gate` while __init__ is still running.
-        if gate is not None:
+        if self.is_internal_router:
+            gate = self.gate
+            assert gate is not None
             if hasattr(gate, "weight_fp32"):
                 # Already materialized (e.g. DeepSeek-V4 sets it itself).
                 pass
             else:
-                # Resolve fp32 weight up front when Parameter already exists, then
-                # still request load-time refresh so process_weights_after_loading
-                # overwrites with the real checkpoint values (init-time Parameter
-                # would otherwise freeze stale random weights).
-                gate.weight_fp32 = gate.weight.to(torch.float32)
+                # Request load-time refresh, then seed weight_fp32 so the hot
+                # path can read it even before process_weights_after_loading.
+                # precast overwrites this buffer with checkpoint values on load.
                 gate.precast_fp32_weight = True
+                gate.weight_fp32 = gate.weight.to(torch.float32)
 
         self.ascend_shared_experts = None
         if shared_experts is not None:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -116,11 +116,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
-        # Internal-router: seed weight_fp32 + precast for load refresh (avoid hot-path Cast).
+        # Internal-router: precast weight_fp32 at load to avoid hot-path Cast.
         # Use ctor `gate` (not self.is_internal_router): Module.__getattr__ shadows during init.
         if gate is not None and not hasattr(gate, "weight_fp32"):
             gate.precast_fp32_weight = True
-            gate.weight_fp32 = gate.weight.to(torch.float32)
 
         self.ascend_shared_experts = None
         if shared_experts is not None:

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -116,6 +116,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
+        # Internal-router gates recompute logits in FP32. Ask AscendUnquantizedLinearMethod
+        # to materialize weight_fp32 during process_weights_after_loading so the hot path
+        # (and ACLGraph capture) never emits a per-forward aclop Cast via weight.to(fp32).
+        if self.is_internal_router and self.gate is not None and not hasattr(self.gate, "weight_fp32"):
+            self.gate.precast_fp32_weight = True
+
         self.ascend_shared_experts = None
         if shared_experts is not None:
             routed_experts.return_with_event = True
@@ -145,6 +151,18 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # DeepseekV2MoE.forward, always passing router_logits=hidden_states.
         # The runner must recompute router_logits via the gate.
         return self.gate is not None
+
+    def _gate_weight_fp32(self) -> torch.Tensor:
+        """Return the internal-router gate weight in FP32 without a hot-path Cast."""
+        gate = self.gate
+        assert gate is not None
+        weight_fp32 = getattr(gate, "weight_fp32", None)
+        if weight_fp32 is not None:
+            return weight_fp32
+        # Unexpected load path: cache once so later forwards do not keep casting.
+        weight_fp32 = gate.weight.data.to(torch.float32)
+        gate.weight_fp32 = weight_fp32
+        return weight_fp32
 
     @property
     def use_dp_chunking(self) -> bool:
@@ -303,15 +321,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             shared_hidden_states = shared_experts_input if shared_experts_input is not None else hidden_states
             if self.ascend_shared_experts is None:
                 if self.is_internal_router:
-                    gate = self.gate
-                    assert gate is not None
                     hidden_states_fp32 = (
                         router_logits if router_logits.dtype == torch.float32 else hidden_states.float()
                     )
-                    router_logits = F.linear(
-                        hidden_states_fp32,
-                        gate.weight_fp32 if hasattr(gate, "weight_fp32") else gate.weight.to(torch.float32),
-                    )
+                    router_logits = F.linear(hidden_states_fp32, self._gate_weight_fp32())
                 return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -325,20 +338,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
             )
             if self.is_internal_router:
-                gate = self.gate
-                assert gate is not None
                 # Reuse the fused RMSNorm FP32 output when supplied. Otherwise,
                 # retain the standalone cast for other model call sites.
                 hidden_states_fp32 = (
                     router_logits if router_logits.dtype == torch.float32 else shared_hidden_states.float()
                 )
                 before_routed_experts = torch.npu.current_stream().record_event()
-                # main (cdc4824a21): is_internal_router only checks self.gate,
-                # weight_fp32 may be absent, fall back to gate.weight.
-                router_logits = F.linear(
-                    hidden_states_fp32,
-                    gate.weight_fp32 if hasattr(gate, "weight_fp32") else gate.weight.to(torch.float32),
-                )
+                router_logits = F.linear(hidden_states_fp32, self._gate_weight_fp32())
                 after_routed_experts = torch.npu.current_stream().record_event()
             else:
                 before_routed_experts = torch.npu.current_stream().record_event()

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -119,8 +119,10 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # Internal-router gates recompute logits in FP32. Ask AscendUnquantizedLinearMethod
         # to materialize weight_fp32 during process_weights_after_loading so the hot path
         # (and ACLGraph capture) never emits a per-forward aclop Cast via weight.to(fp32).
-        if self.is_internal_router and self.gate is not None and not hasattr(self.gate, "weight_fp32"):
-            self.gate.precast_fp32_weight = True
+        # Use the ctor `gate` arg directly: nn.Module.__getattr__ can shadow
+        # `@property is_internal_router` / `gate` while __init__ is still running.
+        if gate is not None and not hasattr(gate, "weight_fp32"):
+            gate.precast_fp32_weight = True
 
         self.ascend_shared_experts = None
         if shared_experts is not None:

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -18,8 +18,8 @@
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
-from vllm.model_executor.layers.linear import ReplicatedLinear
 
 from vllm_ascend.ops.linear import AscendReplicatedLinear
 
@@ -59,6 +59,12 @@ class AscendGateLinear(GateLinear):
         if x.dtype != torch.float32:
             x = x.to(torch.float32)
 
-        output, output_bias = ReplicatedLinear.forward(self, x)
-
+        # Use F.linear for FP32 router logits. AscendUnquantizedLinearMethod
+        # dispatches vllm::unquantized_gemm (PrivateUse1-only), which breaks
+        # cpu-ut and is unnecessary for this small gate GEMM.
+        bias = self.bias if not self.skip_bias_add else None
+        output = F.linear(x, self.weight, bias)
+        if not self.return_bias:
+            return output
+        output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -23,12 +23,10 @@ from vllm.model_executor.layers.linear import ReplicatedLinear
 
 
 class AscendGateLinear(GateLinear):
-    """Ascend replacement for vLLM GateLinear.
-    Router logits are sensitive to numerical precision because they directly
-    affect expert selection in MoE models. On NPU, computing the router gate in
-    lower precision may lead to accuracy issues in some agent workloads.
-    Therefore, this layer forces the gate input and weights to fp32 for the
-    router linear computation, and keeps the router logits in fp32.
+    """Ascend GateLinear: FP32 router weight/compute on NPU.
+
+    Skips GateLinear.__init__ (CUDA/ROCm GEMM probes). Signature matches
+    upstream for drop-in replacement; unused CUDA knobs are ignored.
     """
 
     def __init__(
@@ -37,27 +35,31 @@ class AscendGateLinear(GateLinear):
         output_size: int,
         bias: bool = False,
         out_dtype: torch.dtype | None = None,
-        params_dtype: torch.dtype | None = None,
-        force_fp32_compute: bool = False,
+        params_dtype: torch.dtype | None = None,  # noqa: ARG002
+        force_fp32_compute: bool = False,  # noqa: ARG002
         prefix: str = "",
     ):
-        super().__init__(
-            input_size=input_size,
-            output_size=output_size,
+        ReplicatedLinear.__init__(
+            self,
+            input_size,
+            output_size,
             bias=bias,
             params_dtype=torch.float32,
-            out_dtype=out_dtype,
-            force_fp32_compute=True,
+            quant_config=None,
             prefix=prefix,
         )
+        self.out_dtype = out_dtype
+        self.precast_fp32_weight = True
+
+    def set_out_dtype(self, out_dtype: torch.dtype) -> None:
+        if self.out_dtype is not None:
+            raise ValueError("out_dtype has already been set")
+        self.out_dtype = out_dtype
 
     def forward(self, x: torch.Tensor):
-        # TODO: Remove this workaround after upgrading to a vLLM version that
-        # no longer forces router logits to bf16 via
-        # self.gate.set_out_dtype(torch.bfloat16).
         if x.dtype != torch.float32:
             x = x.to(torch.float32)
-
         output, output_bias = ReplicatedLinear.forward(self, x)
-
+        if self.out_dtype is not None and output.dtype != self.out_dtype:
+            output = output.to(self.out_dtype)
         return output, output_bias

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -21,6 +21,8 @@ import torch
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.linear import ReplicatedLinear
 
+from vllm_ascend.ops.linear import AscendReplicatedLinear
+
 
 class AscendGateLinear(GateLinear):
     """Ascend GateLinear: FP32 router weight/compute on NPU.
@@ -39,7 +41,7 @@ class AscendGateLinear(GateLinear):
         force_fp32_compute: bool = False,  # noqa: ARG002
         prefix: str = "",
     ):
-        ReplicatedLinear.__init__(
+        AscendReplicatedLinear.__init__(
             self,
             input_size,
             output_size,

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -49,7 +49,6 @@ class AscendGateLinear(GateLinear):
             prefix=prefix,
         )
         self.out_dtype = out_dtype
-        self.precast_fp32_weight = True
 
     def forward(self, x: torch.Tensor):
         # TODO: Remove this workaround after upgrading to a vLLM version that

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -51,15 +51,13 @@ class AscendGateLinear(GateLinear):
         self.out_dtype = out_dtype
         self.precast_fp32_weight = True
 
-    def set_out_dtype(self, out_dtype: torch.dtype) -> None:
-        if self.out_dtype is not None:
-            raise ValueError("out_dtype has already been set")
-        self.out_dtype = out_dtype
-
     def forward(self, x: torch.Tensor):
+        # TODO: Remove this workaround after upgrading to a vLLM version that
+        # no longer forces router logits to bf16 via
+        # self.gate.set_out_dtype(torch.bfloat16).
         if x.dtype != torch.float32:
             x = x.to(torch.float32)
+
         output, output_bias = ReplicatedLinear.forward(self, x)
-        if self.out_dtype is not None and output.dtype != self.out_dtype:
-            output = output.to(self.out_dtype)
+
         return output, output_bias

--- a/vllm_ascend/ops/fused_moe/gate_linear.py
+++ b/vllm_ascend/ops/fused_moe/gate_linear.py
@@ -18,8 +18,8 @@
 from __future__ import annotations
 
 import torch
-import torch.nn.functional as F
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+from vllm.model_executor.layers.linear import ReplicatedLinear
 
 from vllm_ascend.ops.linear import AscendReplicatedLinear
 
@@ -59,12 +59,6 @@ class AscendGateLinear(GateLinear):
         if x.dtype != torch.float32:
             x = x.to(torch.float32)
 
-        # Use F.linear for FP32 router logits. AscendUnquantizedLinearMethod
-        # dispatches vllm::unquantized_gemm (PrivateUse1-only), which breaks
-        # cpu-ut and is unnecessary for this small gate GEMM.
-        bias = self.bias if not self.skip_bias_add else None
-        output = F.linear(x, self.weight, bias)
-        if not self.return_bias:
-            return output
-        output_bias = self.bias if self.skip_bias_add else None
+        output, output_bias = ReplicatedLinear.forward(self, x)
+
         return output, output_bias

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -731,6 +731,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
     from vllm_ascend.ops.bailing_moe_linear_attn import AscendBailingMoELinearAttention
     from vllm_ascend.ops.conv import AscendConv3dLayer
     from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+    from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
     from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
     from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
     from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated, AscendGemmaRMSNorm, AscendRMSNorm, AscendRMSNormGated
@@ -789,6 +790,7 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
         "BailingMoELinearAttention": AscendBailingMoELinearAttention,
         "MoERunner": AscendMoERunner,
         "RoutedExperts": AscendRoutedExperts,
+        "GateLinear": AscendGateLinear,
     }
     if vllm_config is None:
         try:
@@ -797,10 +799,6 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
             vllm_config = get_current_vllm_config()
         except AssertionError:
             vllm_config = None
-    if vllm_config is not None and vllm_config.model_config.is_deepseek_mla:
-        from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
-
-        REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
 
     # Override selected ops when the compatibility implementations are required.
     if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):


### PR DESCRIPTION
### What this PR does / why we need it?

Nightly `qwen3-vl-235b-a22b-instruct-w8a8` (A3, `FULL_DECODE_ONLY` ACLGraph) fails because internal-router MoE recomputes logits with:

`gate.weight.to(torch.float32)`

That emits a per-forward `aclop Cast`. DeepSeek-V4 and 310P already avoid this by setting `gate.precast_fp32_weight = True` so `AscendUnquantizedLinearMethod.process_weights_after_loading` materializes `weight_fp32` at load time.

This PR applies the same precast in `AscendMoERunner.__init__` for all Ascend platforms, and routes the hot path through `_gate_weight_fp32()` so ACLGraph capture no longer depends on a live Cast.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Code-path review against 310P `AscendMoERunner310` and DeepSeek-V4 `precast_fp32_weight`.
- Nightly should re-run `Qwen3-VL-235B-A22B-Instruct-W8A8`.

Made with [Cursor](https://cursor.com)

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
