### PR TITLE
[BugFix] Allgather backend to gather ep inputids

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -630,7 +630,7 @@ def test_hash_router_uses_explicit_input_ids(monkeypatch):
     router_logits = torch.randn(2, 4)
     topk_weights = torch.randn(2, 2)
     topk_ids = torch.zeros(2, 2, dtype=torch.int32)
-    prepare_finalize = SimpleNamespace(all_gather_input_id_with_dp_group=MagicMock(side_effect=lambda value: value))
+    prepare_finalize = SimpleNamespace(all_gather_input_ids=MagicMock(side_effect=lambda value: value))
     monkeypatch.setattr(
         fused_topk_router_module,
         "_EXTRA_CTX",
@@ -665,7 +665,7 @@ def test_hash_router_uses_explicit_input_ids(monkeypatch):
     assert weights is topk_weights
     assert ids is topk_ids
     torch.testing.assert_close(hash_op.call_args.kwargs["input_ids"], input_ids.to(torch.int64))
-    prepare_finalize.all_gather_input_id_with_dp_group.assert_called_once()
+    prepare_finalize.all_gather_input_ids.assert_called_once()
 
     with pytest.raises(ValueError, match="hash MoE routing requires input_ids"):
         router._compute_routing(hidden_states, router_logits, torch.int32)

--- a/tests/ut/ops/test_prepare_finalize.py
+++ b/tests/ut/ops/test_prepare_finalize.py
@@ -247,3 +247,23 @@ class TestPrepareAndFinalize(unittest.TestCase):
 
         result_with_tp = layer.finalize(h_out, reduce_results=True)
         self.assertEqual(result_with_tp.shape[0], 3)
+
+    def test_all_gather_input_ids_with_ep_group(self):
+        self.moe_config.is_sequence_parallel = True
+        layer = PrepareAndFinalizeWithAllGather(self.moe_config)
+        input_ids = torch.tensor([11, 22])
+        with patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", create=True) as mock_gather:
+            mock_gather.side_effect = lambda x: x.repeat(2, 1)
+            gathered = layer.all_gather_input_ids(input_ids)
+        mock_gather.assert_called_once()
+        self.moe_config.dp_group.all_gather.assert_not_called()
+        torch.testing.assert_close(gathered, torch.tensor([11, 22, 11, 22]))
+
+    def test_all_gather_input_ids_with_dp_group_no_sp(self):
+        self.moe_config.is_sequence_parallel = False
+        layer = PrepareAndFinalizeWithAllGather(self.moe_config)
+        input_ids = torch.tensor([11, 22])
+        with patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", create=True) as mock_gather:
+            gathered = layer.all_gather_input_ids(input_ids)
+        mock_gather.assert_not_called()
+        torch.testing.assert_close(gathered, input_ids)

--- a/vllm_ascend/ops/fused_moe/prepare_finalize.py
+++ b/vllm_ascend/ops/fused_moe/prepare_finalize.py
@@ -507,6 +507,21 @@ class PrepareAndFinalizeWithAllGather(PrepareAndFinalize):
             pertoken_scale=None,
         )
 
+    def all_gather_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self._use_ep_sequence_parallel():
+            return self.all_gather_input_id_with_ep_group(input_ids)
+        return self.all_gather_input_id_with_dp_group(input_ids)
+
+    def all_gather_input_id_with_ep_group(self, input_ids: torch.Tensor) -> torch.Tensor:
+        input_ids = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_ids.reshape(-1, 1)).reshape(-1)
+        if self.moe_config.pcp_size > 1:
+            max_tokens_across_pcp = _EXTRA_CTX.max_tokens_across_pcp
+            pad_size = max_tokens_across_pcp - input_ids.numel()
+            if pad_size > 0:
+                input_ids = nn.functional.pad(input_ids, (0, pad_size))
+            input_ids = get_pcp_group().all_gather(input_ids, dim=0)
+        return input_ids
+
     def all_gather_input_id_with_dp_group(self, input_ids: torch.Tensor) -> torch.Tensor:
         if self.moe_config.dp_size > 1:
             max_tokens_across_dp = _EXTRA_CTX.max_tokens_across_dp

--- a/vllm_ascend/ops/fused_moe/router/fused_topk_router.py
+++ b/vllm_ascend/ops/fused_moe/router/fused_topk_router.py
@@ -163,7 +163,7 @@ class AscendFusedTopKRouter(AscendGroupedTopKRouter):
                 tid2eid_ones = self.tid2eid.to(torch.int32) if self.tid2eid is not None else None
                 if _EXTRA_CTX.moe_comm_type == MoECommType.ALLGATHER:
                     prepare_finalize = _EXTRA_CTX.moe_comm_method.prepare_finalize
-                    input_ids = prepare_finalize.all_gather_input_id_with_dp_group(input_ids)
+                    input_ids = prepare_finalize.all_gather_input_ids(input_ids)
                 else:
                     input_ids = _EXTRA_CTX.moe_comm_method.pad_and_split_input_ids(input_ids)
                 if _EXTRA_CTX.moe_comm_type != MoECommType.ALLGATHER and input_ids.numel() != router_logits.shape[0]:


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, Allgather backend for EP does not allgather EP group input ids, resulting in problem when starting DS v4 series. 
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Tested on A5, which uses allgather backend

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
