### PR TITLE
[Feature][Platform]: Patch use sp moe

### DIFF
--- a/tests/ut/patch/platform/test_patch_parallel_config.py
+++ b/tests/ut/patch/platform/test_patch_parallel_config.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+import pytest
+from vllm.config.parallel import ParallelConfig
+
+import vllm_ascend.patch.platform.patch_parallel_config  # noqa: F401
+
+
+def _make_parallel_config(**overrides) -> ParallelConfig:
+    kwargs = {
+        "tensor_parallel_size": 2,
+        "data_parallel_size": 1,
+        "enable_expert_parallel": True,
+        "all2all_backend": "allgather_reducescatter",
+    }
+    kwargs.update(overrides)
+    return ParallelConfig(**kwargs)
+
+
+def test_sp_moe_enabled_with_single_dp_rank():
+    config = _make_parallel_config(data_parallel_size=1)
+    assert config.use_sequence_parallel_moe is True
+
+
+def test_sp_moe_still_enabled_with_multiple_dp_ranks():
+    config = _make_parallel_config(data_parallel_size=2)
+    assert config.use_sequence_parallel_moe is True
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"all2all_backend": "flashinfer_all2allv"}, id="non-sp-backend"),
+        pytest.param({"enable_expert_parallel": False}, id="ep-disabled"),
+        pytest.param({"tensor_parallel_size": 1}, id="tp1"),
+    ],
+)
+def test_sp_moe_off_conditions_unchanged(overrides):
+    config = _make_parallel_config(data_parallel_size=1, **overrides)
+    assert config.use_sequence_parallel_moe is False

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -47,6 +47,7 @@ import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 import vllm_ascend.patch.platform.patch_eplb  # noqa
 import vllm_ascend.patch.platform.patch_fused_moe  # noqa
 import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
+import vllm_ascend.patch.platform.patch_parallel_config  # noqa
 import vllm_ascend.patch.platform.patch_glm5next_config  # noqa
 
 # ** File: platform/patch_kv_cache_utils.py **

--- a/vllm_ascend/patch/platform/patch_parallel_config.py
+++ b/vllm_ascend/patch/platform/patch_parallel_config.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Allow sequence-parallel MoE with a single data-parallel rank.
+#
+# Upstream vLLM gates ParallelConfig.use_sequence_parallel_moe on
+# data_parallel_size > 1. Ascend's SP dispatch (EP-group all-gather /
+# reduce-scatter in vllm_ascend.ops.fused_moe with dp_size guards, TP-based
+# sp_shard in models, DP-tolerant DPMetadata in forward_context) is valid
+# with DP=1, so this patch drops only the DP requirement. Every reader
+# (models, enable_sp, ascend_config gates, use_all2all) keys off this one
+# property, keeping the switch consistent.
+
+from vllm.config.parallel import ParallelConfig
+
+
+@property  # type: ignore[misc]
+def _ascend_use_sequence_parallel_moe(self) -> bool:
+    return (
+        self.all2all_backend
+        in (
+            "allgather_reducescatter",
+            "deepep_high_throughput",
+            "deepep_low_latency",
+            "mori_high_throughput",
+            "mori_low_latency",
+            "nixl_ep",
+        )
+        and self.enable_expert_parallel
+        and self.tensor_parallel_size > 1
+    )
+
+
+ParallelConfig.use_sequence_parallel_moe = _ascend_use_sequence_parallel_moe


### PR DESCRIPTION
### What this PR does / why we need it?
Currently, SP uses upstream SP moe function to judge SP is enabled or not. However, upstream SP option only supports DP>1.
### Does this PR introduce _any_ user-facing change?
When DP=1, SP is functionable
### How was this patch tested?
Tested on A5, with SP on.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
