### PR TITLE
[Performance][Attention] Use npu_transpose_batchmatmul for SFA q up-projection

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -65,6 +65,9 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
+# npu_transpose_batchmatmul rejects operand dimensions >= 65536
+TRANSPOSE_BMM_MAX_SUPPORTED_DIM = 65536
+
 
 class PreprocessType(enum.Enum):
     NATIVE = "native"
@@ -864,7 +867,11 @@ class AscendSFAImpl(MLAAttentionImpl):
             .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         )
 
-        if hasattr(torch_npu, "npu_transpose_batchmatmul"):
+        if (
+            q_nope.dtype in [torch.float16, torch.bfloat16]
+            and hasattr(torch_npu, "npu_transpose_batchmatmul")
+            and q_nope.shape[0] < TRANSPOSE_BMM_MAX_SUPPORTED_DIM
+        ):
             # Convert from (B, N, P) to (N, B, P) and multiply
             # (N, B, P) x (N, P, L) -> (B, N, L)
             ql_nope = torch_npu.npu_transpose_batchmatmul(
@@ -875,6 +882,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                 perm_y=(1, 0, 2),
             )
         else:
+            # Fallback for torch_npu builds without the fused op, unsupported
+            # dtypes, or a token dim beyond the operand limit.
             # Convert from (B, N, P) to (N, B, P)
             q_nope = q_nope.transpose(0, 1)
             # Multiply (N, B, P) x (N, P, L) -> (N, B, L)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -864,12 +864,24 @@ class AscendSFAImpl(MLAAttentionImpl):
             .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         )
 
-        # Convert from (B, N, P) to (N, B, P)
-        q_nope = q_nope.transpose(0, 1)
-        # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-        ql_nope = torch.bmm(q_nope, self.W_UK_T)
-        # Convert from (N, B, L) to (B, N, L)
-        return ql_nope.transpose(0, 1), q_pe
+        if hasattr(torch_npu, "npu_transpose_batchmatmul"):
+            # Convert from (B, N, P) to (N, B, P) and multiply
+            # (N, B, P) x (N, P, L) -> (B, N, L)
+            ql_nope = torch_npu.npu_transpose_batchmatmul(
+                q_nope,
+                self.W_UK_T,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+            )
+        else:
+            # Convert from (B, N, P) to (N, B, P)
+            q_nope = q_nope.transpose(0, 1)
+            # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
+            ql_nope = torch.bmm(q_nope, self.W_UK_T)
+            # Convert from (N, B, L) to (B, N, L)
+            ql_nope = ql_nope.transpose(0, 1)
+        return ql_nope, q_pe
 
     def _v_up_proj(self, x):
         num_input_tokens, _, _ = x.shape


### PR DESCRIPTION
### What this PR does / why we need it?

`AscendSFAImpl._q_proj_and_k_up_proj` computes the SFA Q up-projection with
`transpose -> torch.bmm -> transpose`:

```python
q_nope = q_nope.transpose(0, 1)
ql_nope = torch.bmm(q_nope, self.W_UK_T)
return ql_nope.transpose(0, 1), q_pe
```

This PR folds both permutes into the matmul: a single
`torch_npu.npu_transpose_batchmatmul` call (`perm_x1=(1, 0, 2)`,
`perm_x2=(0, 1, 2)`, `perm_y=(1, 0, 2)`) does the layout conversion inside the
NPU op, following the pattern already used by `_v_up_proj` in the same file.

The original `transpose + torch.bmm` path is kept as a fallback for torch_npu
builds that do not provide the fused op, so behavior elsewhere is unchanged.

Note: #16071 also targets this op, with a larger change (padded `W_UK_T`, which
additionally removes the `split`); this PR intentionally keeps the change minimal.

### Does this PR introduce _any_ user-facing change?

No. Numerics are unchanged; only the op dispatch on the SFA q up-projection
path changes.

### How was this patch tested?

- Local latency of the SFA q up-projection on GLM-5.2-w4a4c8:
  `59.5us -> 37.7us` (~37% lower, ~21.8us saved per call).
- Accuracy: GSM8K on GLM-5.2-w4a4c8 shows no accuracy issue with the fused path.
- CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
