### PR TITLE
[CI] Temporarily skip Qwen3.6 MTP e2e test

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -70,6 +70,8 @@ skip_tests:
   - tests/e2e/pull_request/two_card/aclgraph/test_aclgraph_capture_replay.py
   # Temporarily skip this DeepSeek V4 test
   - tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+  # Temporarily skip the Qwen3.6 MTP e2e test
+  - tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py
   # Temporarily skipped: this test is currently broken
   - tests/e2e/pull_request/four_card/spec_decode/test_mtp_step3p5.py
 


### PR DESCRIPTION
What this PR does / why we need it?
Temporarily disable test_qwen3_6_mtp.py in CI by adding it to skip_tests. The test file is retained so it can be re-enabled later.
Does this PR introduce any user-facing change?
No. This only changes CI test scheduling.
How was this patch tested?
- Ran select_tests.py --explicit-e2e-tests tests/e2e/pull_request/two_card/model_runner_v2/test_qwen3_6_mtp.py and confirmed test_groups=[] and has_tests=false.
- git diff --check passed.
- Full formatting checks could not run because pre-commit was unavailable.
No new tests were added because this change only updates the existing CI skip list.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
