### PR TITLE
[CI] Set HCCL_IF_BASE_PORT for GLM-5.1 128k/198k nightly

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
@@ -4,6 +4,7 @@ num_nodes: 2
 npu_per_node: 16
 env_common: &env_common
   HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_IF_BASE_PORT: "60200"
   OMP_PROC_BIND: "false"
   VLLM_USE_MODELSCOPE: "true"
   OMP_NUM_THREADS: "1"

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
@@ -5,6 +5,7 @@ num_nodes: 2
 npu_per_node: 16
 env_common: &env_common
   HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_IF_BASE_PORT: "60100"
   OMP_PROC_BIND: "false"
   VLLM_USE_MODELSCOPE: "true"
   OMP_NUM_THREADS: "1"


### PR DESCRIPTION
## Summary
- GLM-5.1 198k and 128k nightlies fail with `Communication_Error_Bind_IP_Port(EI0019)` on default HCCL ports 60000+, then NPU `507034` vector-core timeout.
- Not API-server port competition from dropping `--headless` (these cases use `local=4` hybrid LB).
- Set `HCCL_IF_BASE_PORT` to `60100` (198k) and `60200` (128k) to avoid collisions when jobs share a NIC.

## Related failures
- https://github.com/vllm-project/vllm-ascend/actions/runs/34372289942/job/102608839662 (198k)
- https://github.com/vllm-project/vllm-ascend/actions/runs/34372289942/job/102607553971 (128k)

## Test plan
- [ ] 198k / 128k no longer log EI0019 on :60000
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
