### PR TITLE
[Performance][Attention] Eliminate AsStrided in MLA/SFA q up-projection via transpose batch matmul

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1430,6 +1430,36 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(q_pe.shape[1], self.impl.num_heads)
         self.assertEqual(q_pe.shape[2], self.impl.qk_rope_head_dim)
 
+    @patch("vllm_ascend.attention.mla_v1.torch_npu.npu_transpose_batchmatmul", create=True)
+    def test_q_proj_and_k_up_proj_transpose_fused_matches_legacy_bmm(self, mock_tbmm):
+        """The transpose-fused path must match the legacy split + bmm result."""
+        batch_size = 4
+        q = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        self.impl.q_proj.return_value = (q,)
+        w_uk_t = torch.randn(self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank)
+        self.impl.W_UK_T = w_uk_t
+        self.impl.W_UK_T_padded = torch.cat(
+            [w_uk_t, torch.zeros(self.impl.num_heads, self.impl.qk_rope_head_dim, self.impl.kv_lora_rank)],
+            dim=1,
+        )
+        # Emulate the CANN op: (B, N, P) x (N, P, L) -> (B, N, L).
+        mock_tbmm.side_effect = lambda x, w, perm_x1, perm_x2, perm_y: torch.einsum("bnp,npl->bnl", x, w)
+
+        ql_nope, q_pe = self.impl._q_proj_and_k_up_proj(torch.randn(batch_size, 7))
+
+        mock_tbmm.assert_called_once()
+        call_args = mock_tbmm.call_args
+        self.assertIs(call_args.args[1], self.impl.W_UK_T_padded)
+        self.assertEqual(call_args.kwargs["perm_x1"], (1, 0, 2))
+        self.assertEqual(call_args.kwargs["perm_x2"], (0, 1, 2))
+        self.assertEqual(call_args.kwargs["perm_y"], (1, 0, 2))
+
+        # Reference: the legacy split + transpose + bmm path on the same q.
+        q_nope_ref, q_pe_ref = q.split([self.impl.qk_nope_head_dim, self.impl.qk_rope_head_dim], dim=-1)
+        ql_nope_ref = torch.bmm(q_nope_ref.transpose(0, 1), w_uk_t).transpose(0, 1)
+        self.assertTrue(torch.allclose(ql_nope, ql_nope_ref, atol=1e-4))
+        self.assertTrue(torch.equal(q_pe, q_pe_ref))
+
     @patch("torch_npu.npu_interleave_rope")
     def test_rope_single(self, mock_npu_interleave_rope):
         batch_size = 2

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -1,8 +1,10 @@
 import sys
+import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
+import torch_npu
 from vllm.config import set_current_vllm_config
 from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
@@ -447,6 +449,61 @@ class TestAscendSFAKVQuantSparseAttention(TestBase):
         self.assertEqual(call_kwargs["kv_cache_quant_mode"], 3)
         self.assertEqual(call_kwargs["ckvkr_repo_mode"], 1)
         self.assertEqual(call_kwargs["quant_scale_repo_mode"], 1)
+
+
+class TestAscendSFAQUpProjTransposeBMM(TestBase):
+    """q up-projection via the transpose-fused batch matmul."""
+
+    def _make_impl(self, num_tokens=3):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.local_num_heads = 2
+        impl.qk_nope_head_dim = 8
+        impl.qk_rope_head_dim = 4
+        impl.qk_head_dim = 12
+        impl.kv_lora_rank = 6
+        impl.W_UK_T = torch.randn(impl.local_num_heads, impl.qk_nope_head_dim, impl.kv_lora_rank)
+        impl.W_UK_T_padded = None
+        q = torch.randn(num_tokens, impl.local_num_heads, impl.qk_head_dim)
+        impl.q_proj = MagicMock(return_value=(q,))
+        return impl, q
+
+    def _legacy_reference(self, q, impl):
+        q_nope, q_pe = q.split([impl.qk_nope_head_dim, impl.qk_rope_head_dim], dim=-1)
+        ql_nope = torch.bmm(q_nope.transpose(0, 1), impl.W_UK_T).transpose(0, 1)
+        return ql_nope, q_pe
+
+    @patch("vllm_ascend.attention.sfa_v1.torch_npu.npu_transpose_batchmatmul", create=True)
+    def test_transpose_fused_path_matches_legacy_bmm(self, mock_tbmm):
+        impl, q = self._make_impl()
+        impl.W_UK_T_padded = torch.cat(
+            [impl.W_UK_T, torch.zeros(impl.local_num_heads, impl.qk_rope_head_dim, impl.kv_lora_rank)],
+            dim=1,
+        )
+        # Emulate the CANN op: (B, N, P) x (N, P, L) -> (B, N, L).
+        mock_tbmm.side_effect = lambda x, w, perm_x1, perm_x2, perm_y: torch.einsum("bnp,npl->bnl", x, w)
+
+        ql_nope, q_pe = impl._q_proj_and_k_up_proj(torch.randn(3, 5))
+
+        mock_tbmm.assert_called_once()
+        call_args = mock_tbmm.call_args
+        self.assertEqual(call_args.args[0].shape, (3, impl.local_num_heads, impl.qk_head_dim))
+        self.assertIs(call_args.args[1], impl.W_UK_T_padded)
+        self.assertEqual(call_args.kwargs["perm_x1"], (1, 0, 2))
+        self.assertEqual(call_args.kwargs["perm_x2"], (0, 1, 2))
+        self.assertEqual(call_args.kwargs["perm_y"], (1, 0, 2))
+
+        ql_nope_ref, q_pe_ref = self._legacy_reference(q, impl)
+        self.assertTrue(torch.allclose(ql_nope, ql_nope_ref, atol=1e-4))
+        self.assertTrue(torch.equal(q_pe, q_pe_ref))
+
+    def test_fallback_without_padded_weight_uses_bmm(self):
+        impl, q = self._make_impl()
+
+        ql_nope, q_pe = impl._q_proj_and_k_up_proj(torch.randn(3, 5))
+
+        ql_nope_ref, q_pe_ref = self._legacy_reference(q, impl)
+        self.assertTrue(torch.allclose(ql_nope, ql_nope_ref, atol=1e-4))
+        self.assertTrue(torch.equal(q_pe, q_pe_ref))
 
 
 class TestAscendSFAMetadata(TestBase):
@@ -917,6 +974,41 @@ class TestAscendSFAImpl(TestBase):
 
         mock_dispose.assert_called_once()
         mock_maybe_trans_nz.assert_called_once()
+
+    @patch("vllm_ascend.attention.sfa_v1.maybe_trans_nz")
+    @patch("vllm_ascend.attention.sfa_v1.dispose_layer")
+    @patch("torch_npu.npu_format_cast")
+    @unittest.skipIf(
+        not hasattr(torch_npu, "npu_transpose_batchmatmul"),
+        "torch_npu.npu_transpose_batchmatmul is unavailable",
+    )
+    def test_process_weights_after_loading_builds_padded_w_uk_t(
+        self, mock_format_cast, mock_dispose, mock_maybe_trans_nz
+    ):
+        """W_UK_T_padded keeps W_UK_T in its nope rows and zeroes the rope rows."""
+        layer = self._setup_kv_b_proj()
+        mock_format_cast.return_value = layer.weight
+        mock_maybe_trans_nz.side_effect = lambda x: x
+
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        padded = self.impl.W_UK_T_padded
+        self.assertIsNotNone(padded)
+        self.assertEqual(padded.shape[0], self.impl.num_heads)
+        self.assertEqual(padded.shape[1], self.impl.qk_head_dim)
+        self.assertEqual(padded.shape[2], self.impl.kv_lora_rank)
+        self.assertTrue(torch.equal(padded[:, : self.impl.qk_nope_head_dim, :], self.impl.W_UK_T))
+        self.assertTrue(
+            torch.equal(
+                padded[:, self.impl.qk_nope_head_dim :, :],
+                torch.zeros(
+                    self.impl.num_heads,
+                    self.impl.qk_rope_head_dim,
+                    self.impl.kv_lora_rank,
+                    dtype=padded.dtype,
+                ),
+            )
+        )
 
     # ============ _process_weights_for_fused_prolog_v3 ============
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -66,6 +66,9 @@ if TYPE_CHECKING:
 BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 
+# npu_transpose_batchmatmul rejects operand dimensions >= 65536.
+TRANSPOSE_BMM_MAX_SUPPORTED_DIM = 65536
+
 
 def _npu_mla_prolog_v3_no_rope(**kwargs):
     """Call the AscendC MLA prolog with optional RoPE inputs omitted."""
@@ -845,6 +848,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.mlapo_num_heads = self.num_heads
         self.mlapo_weight_quant_mode = 3
         self._mlapo_uses_native_weights = False
+        # (N, qk_head_dim, kv_lora_rank) copy of W_UK_T whose rope rows are
+        # zero, built in process_weights_after_loading for the transpose-fused
+        # q up-projection (see _q_proj_and_k_up_proj). None when unsupported.
+        self.W_UK_T_padded: torch.Tensor | None = None
 
     @staticmethod
     def update_graph_params(
@@ -988,13 +995,52 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.num_heads * self.v_head_dim,
         )
 
+    def _build_w_uk_t_padded(self, act_dtype: torch.dtype) -> None:
+        """Build the rope-zero-padded W_UK_T for the transpose-fused q up-projection.
+
+        ``_q_proj_and_k_up_proj`` feeds the full contiguous (B, N, qk_head_dim)
+        query to ``npu_transpose_batchmatmul`` by padding the rope rows of
+        W_UK_T with zeros, which keeps the q_nope view (and its extra
+        AsStrided materialization inside torch.bmm) out of the hot path.
+        """
+        if not (
+            act_dtype in (torch.float16, torch.bfloat16)
+            and hasattr(torch_npu, "npu_transpose_batchmatmul")
+            and self.num_heads * self.qk_head_dim < TRANSPOSE_BMM_MAX_SUPPORTED_DIM
+            and self.kv_lora_rank < TRANSPOSE_BMM_MAX_SUPPORTED_DIM
+        ):
+            return
+        # Zero-pad dim 1 (qk_nope_head_dim -> qk_head_dim); the rope part of q
+        # multiplies these zero rows and is dropped by the matmul. Build via
+        # zeros + copy_ instead of F.pad: on CPU tensors the npu backend
+        # autoload can misroute F.pad in test environments.
+        padded = self.W_UK_T_padded
+        if padded is None:
+            padded = self.W_UK_T.new_zeros(self.W_UK_T.shape[0], self.qk_head_dim, self.W_UK_T.shape[2])
+            self.W_UK_T_padded = padded
+        padded[:, : self.qk_nope_head_dim, :].copy_(self.W_UK_T)
+
     # Return `ql_nope`, `q_pe`
     def _q_proj_and_k_up_proj(self, x):
-        q_nope, q_pe = (
-            self.q_proj(x)[0]
-            .view(-1, self.num_heads, self.qk_head_dim)
-            .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        )
+        q = self.q_proj(x)[0].view(-1, self.num_heads, self.qk_head_dim)
+        if self.W_UK_T_padded is not None and q.shape[0] < TRANSPOSE_BMM_MAX_SUPPORTED_DIM:
+            # (B, N, P + rope) x (N, P + rope, L) -> (B, N, L) in one fused
+            # kernel; the zero-padded rope rows of the weight drop the rope
+            # part of q inside the matmul. torch.bmm on the non-contiguous
+            # q_nope view instead makes aclnnBatchMatMul launch an extra
+            # AsStrided kernel and return a head-major output that needs
+            # another transpose before the attention kernel consumes it.
+            ql_nope = torch_npu.npu_transpose_batchmatmul(
+                q,
+                self.W_UK_T_padded,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+            )
+            q_pe = q[..., self.qk_nope_head_dim :]
+            return ql_nope, q_pe
+
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
         # Convert from (B, N, P) to (N, B, P)
         q_nope = q_nope.transpose(0, 1)
@@ -1038,6 +1084,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.W_UV.copy_(W_UV.transpose(0, 1).contiguous())
             self.W_UK_T.copy_(W_UK.permute(1, 2, 0).contiguous())
         self.mlapo_W_UK_T = self.W_UK_T
+
+        self._build_w_uk_t_padded(act_dtype)
 
         # TODO(zzzzwwjj): Currently, torch.ops._C_ascend.batch_matmul_transpose cannot support weight nz
         # self.W_UV = maybe_trans_nz(self.W_UV)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -67,6 +67,9 @@ if TYPE_CHECKING:
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
 
+# npu_transpose_batchmatmul rejects operand dimensions >= 65536.
+TRANSPOSE_BMM_MAX_SUPPORTED_DIM = 65536
+
 
 class PreprocessType(enum.Enum):
     NATIVE = "native"
@@ -465,6 +468,10 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         self.local_num_heads = self.num_heads
         self.layer_name = kwargs.get("layer_name")
+        # (N, qk_head_dim, kv_lora_rank) copy of W_UK_T whose rope rows are
+        # zero, built in process_weights_after_loading for the transpose-fused
+        # q up-projection (see _q_proj_and_k_up_proj). None when unsupported.
+        self.W_UK_T_padded: torch.Tensor | None = None
         hf_config = self.vllm_config.model_config.hf_config
         hf_text_config = getattr(self.vllm_config.model_config, "hf_text_config", None)
         config_candidates = (hf_config, hf_text_config)
@@ -603,6 +610,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         else:
             self.W_UV.copy_(W_UV.transpose(0, 1).contiguous())
             self.W_UK_T.copy_(W_UK.permute(1, 2, 0).contiguous())
+
+        self._build_w_uk_t_padded(act_dtype)
 
         # TODO(zzzzwwjj): Currently, torch.ops._C_ascend.batch_matmul_transpose cannot support weight nz
         # self.W_UV = maybe_trans_nz(self.W_UV)
@@ -889,13 +898,52 @@ class AscendSFAImpl(MLAAttentionImpl):
         )
         return None, None
 
+    def _build_w_uk_t_padded(self, act_dtype: torch.dtype) -> None:
+        """Build the rope-zero-padded W_UK_T for the transpose-fused q up-projection.
+
+        ``_q_proj_and_k_up_proj`` feeds the full contiguous (B, N, qk_head_dim)
+        query to ``npu_transpose_batchmatmul`` by padding the rope rows of
+        W_UK_T with zeros, which keeps the q_nope view (and its extra
+        AsStrided materialization inside torch.bmm) out of the hot path.
+        """
+        if not (
+            act_dtype in (torch.float16, torch.bfloat16)
+            and hasattr(torch_npu, "npu_transpose_batchmatmul")
+            and self.local_num_heads * self.qk_head_dim < TRANSPOSE_BMM_MAX_SUPPORTED_DIM
+            and self.kv_lora_rank < TRANSPOSE_BMM_MAX_SUPPORTED_DIM
+        ):
+            return
+        # Zero-pad dim 1 (qk_nope_head_dim -> qk_head_dim); the rope part of q
+        # multiplies these zero rows and is dropped by the matmul. Build via
+        # zeros + copy_ instead of F.pad: on CPU tensors the npu backend
+        # autoload can misroute F.pad in test environments.
+        padded = self.W_UK_T_padded
+        if padded is None:
+            padded = self.W_UK_T.new_zeros(self.W_UK_T.shape[0], self.qk_head_dim, self.W_UK_T.shape[2])
+            self.W_UK_T_padded = padded
+        padded[:, : self.qk_nope_head_dim, :].copy_(self.W_UK_T)
+
     # Return `ql_nope`, `q_pe`
     def _q_proj_and_k_up_proj(self, x):
-        q_nope, q_pe = (
-            self.q_proj(x)[0]
-            .view(-1, self.local_num_heads, self.qk_head_dim)
-            .split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        )
+        q = self.q_proj(x)[0].view(-1, self.local_num_heads, self.qk_head_dim)
+        if self.W_UK_T_padded is not None and q.shape[0] < TRANSPOSE_BMM_MAX_SUPPORTED_DIM:
+            # (B, N, P + rope) x (N, P + rope, L) -> (B, N, L) in one fused
+            # kernel; the zero-padded rope rows of the weight drop the rope
+            # part of q inside the matmul. torch.bmm on the non-contiguous
+            # q_nope view instead makes aclnnBatchMatMul launch an extra
+            # AsStrided kernel and return a head-major output that needs
+            # another transpose before the attention kernel consumes it.
+            ql_nope = torch_npu.npu_transpose_batchmatmul(
+                q,
+                self.W_UK_T_padded,
+                perm_x1=(1, 0, 2),
+                perm_x2=(0, 1, 2),
+                perm_y=(1, 0, 2),
+            )
+            q_pe = q[..., self.qk_nope_head_dim :]
+            return ql_nope, q_pe
+
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
 
         # Convert from (B, N, P) to (N, B, P)
         q_nope = q_nope.transpose(0, 1)


### PR DESCRIPTION
### What this PR does / why we need it?

GLM-5.2 / DeepSeek MLA/SFA profiling shows `torch.bmm(q_nope.transpose(0, 1), W_UK_T)` in
`_q_proj_and_k_up_proj` launching an extra `AsStridedAiCore` kernel per layer (648 times per
profile window on 8 ranks, ~30us per decode step layer at TP16): the non-contiguous
`q_nope` slice forces `aclnnBatchMatMul` to materialize a contiguous copy first, and the
head-major `(N, B, L)` output requires yet another transpose before the attention kernel
consumes it.

This PR replaces the `split → transpose → bmm → transpose` sequence with a single
`torch_npu.npu_transpose_batchmatmul` call, following the pattern already used by
`_v_up_proj` and sglang's NPU path:

- **`_build_w_uk_t_padded`** (new, called from `process_weights_after_loading`): builds a
  `(N, qk_head_dim, kv_lora_rank)` copy of `W_UK_T` whose rope rows (the extra 64 dims) are
  zero. This allows the full contiguous `(B, N, 192)` query to enter the fused kernel
  directly — the zero rows drop the rope part of q inside the matmul, eliminating the need
  to split q into nope/pe views.

- **`_q_proj_and_k_up_proj`** (modified): when the padded weight is available and
  dimensions are within the operator's 65536 limit, a single
  `npu_transpose_batchmatmul(q, W_UK_T_padded, perm_x1=(1,0,2), perm_x2=(0,1,2),
  perm_y=(1,0,2))` computes the up-projection and returns a batch-major `(B, N, L)` output
  directly — no AsStrided, no downstream transpose.

- The legacy `split + bmm` path is retained as fallback for unsupported dtypes, missing
  ops, or operand dimensions >= 65536.

**Why padded weight instead of strided input (sglang approach)?** Device measurements on
Ascend 910B (CANN 9.1) show that feeding the strided `q_nope` slice directly causes
`aclnnTransposeBatchMatMul` to internally launch an additional `SliceAiCore` materialization
kernel (3.0-7.1us per layer), making it functionally equivalent to the AsStrided it
replaces. The padded-weight approach achieves true zero-materialization at the cost of
~0.2% extra HBM per rank.

**Verification results** (GLM-5.2-w4a8c8, TP8×DP2, 910B×16):

| Metric | Before | After |
|---|---|---|
| AsStrided kernel count (8-rank aggregate) | 648 | **0** |
| BatchMatMulV2 count | 1896 | **0** (replaced by TransposeBatchMatMul) |
| Downstream Transpose count | 712 | **64** (-648) |
| Downstream Slice count | 10744 | **9496** (-1248) |
| All other 70 op types | — | **±0** (identical workload verified) |
| Operator-level numerics (bf16, all shapes) | — | **bit-exact** (max_abs_diff = 0.0) |
| Operator latency (T=2048, N=8) | 37.9 us | **18.2 us** (-52%) |
| E2E greedy logprob comparison (10 prompts) | — | No differences beyond same-code noise baseline |

### Does this PR introduce _any_ user-facing change?

No functional changes. Models using MLA/SFA attention (DeepSeek, GLM) produce bit-identical
outputs. The only observable difference is reduced kernel count and improved decode step
latency (~30us × num_layers per decode step at the profiled configuration).

### How was this patch tested?

- **Unit tests** (new, 120 total passed):
  - `test_transpose_fused_path_matches_legacy_bmm`: fused output == legacy bmm reference
  - `test_fallback_without_padded_weight_uses_bmm`: fallback path correctness
  - `test_process_weights_after_loading_builds_padded_w_uk_t`: padded weight layout
  - `test_q_proj_and_k_up_proj_transpose_fused_matches_legacy_bmm`: MLA implementation

- **Operator-level microbenchmark** (Ascend 910B, bf16):
  - Numerics: bit-exact across N∈{4,8} × T∈{1..2048}
  - Latency: +9~19.6us per layer improvement for T≥4

- **Serving A/B test** (same container, same vllm v0.27.1, main vs branch):
  - Profile kernel counts: AsStrided 648→0, all other op types unchanged
  - E2E accuracy: 10 fixed prompts, greedy decoding, per-token logprob comparison —
    no differences beyond the inherent serving noise baseline
  - TTFT: no regression (benefit ~0.35% per request, below measurement noise)
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
