### PR TITLE
[Feature][KV Transfer] Add Mooncake P/D delayed-release metrics

### DIFF
--- a/tests/ut/kv_offload/mooncake_v2/test_connector.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_connector.py
@@ -45,11 +45,13 @@ def test_facade_delegates_scheduler_methods() -> None:
     output = MagicMock()
     connector.connector_scheduler.get_num_new_matched_tokens.return_value = (8, True)
     connector.connector_scheduler.request_finished.return_value = (True, {"remote": True})
+    connector.connector_scheduler.get_kv_connector_stats.return_value = MagicMock()
 
     assert connector.get_num_new_matched_tokens(request, 4) == (8, True)
     connector.update_state_after_alloc(request, blocks, 8)
     connector.update_connector_output(output)
     assert connector.request_finished(request, [1, 2]) == (True, {"remote": True})
+    assert connector.get_kv_connector_stats() is connector.connector_scheduler.get_kv_connector_stats.return_value
 
     connector.connector_scheduler.update_state_after_alloc.assert_called_once_with(request, blocks, 8)
     connector.connector_scheduler.request_finished.assert_called_once_with(request, ([1, 2],))

--- a/tests/ut/kv_offload/mooncake_v2/test_pull_scheduler.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_pull_scheduler.py
@@ -25,6 +25,9 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.pull_scheduler import (
     MooncakeSchedulerRecvingThread,
     MooncakeSchedulerSendingThread,
 )
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+)
 
 from .helpers import make_blocks, make_full_spec, make_mamba_spec, make_request, make_transfer_metadata
 
@@ -66,6 +69,8 @@ def make_pull_scheduler() -> MooncakePullConnectorScheduler:
     scheduler._reqs_recv_info = {}
     scheduler._sending_thread = None
     scheduler._recving_thread = None
+    scheduler._num_delayed_release_blocks = 0
+    scheduler._kv_stats = MooncakeKVConnectorStats()
     return scheduler
 
 
@@ -381,6 +386,10 @@ def test_request_finished_delays_blocks_and_builds_remote_params() -> None:
     assert params["remote_request_id"] == "request-p"
     assert params["last_token_id"] == 123
     scheduler._sending_thread.add_delayed_request.assert_called_once()
+    stats = scheduler.get_kv_connector_stats()
+    assert stats is not None
+    assert stats.data["delayed_release_requests"] == 1
+    assert stats.data["delayed_release_blocks"] == 3
 
 
 def test_update_connector_output_routes_worker_completion_and_scheduler_ack() -> None:
@@ -389,7 +398,8 @@ def test_update_connector_output_routes_worker_completion_and_scheduler_ack() ->
     scheduler._sending_thread = MagicMock()
     scheduler._sending_thread.get_and_clear_finished_requests.return_value = {"request-p"}
     scheduler._reqs_recv_info["request-d"] = ("10.0.0.1", 6000, "request-p")
-    scheduler._reqs_need_send["request-p"] = time.time()
+    scheduler._reqs_need_send["request-p"] = 3
+    scheduler._num_delayed_release_blocks = 3
     output = SimpleNamespace(finished_recving={"request-d"}, finished_sending=None)
 
     scheduler.update_connector_output(output)  # type: ignore[arg-type]
@@ -397,6 +407,10 @@ def test_update_connector_output_routes_worker_completion_and_scheduler_ack() ->
     scheduler._recving_thread.add_request.assert_called_once_with("10.0.0.1", 6000, "request-p")
     assert output.finished_sending == {"request-p"}
     assert scheduler._reqs_need_send == {}
+    stats = scheduler.get_kv_connector_stats()
+    assert stats is not None
+    assert stats.data["delayed_release_requests"] == 0
+    assert stats.data["delayed_release_blocks"] == 0
 
 
 class _StopLoop(BaseException):

--- a/tests/ut/kv_offload/mooncake_v2/test_stats.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_stats.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import MooncakeKVConnectorStats
+from unittest.mock import MagicMock, call
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+    MooncakePromMetrics,
+)
 
 
 def test_stats_record_reduce_and_reset() -> None:
@@ -35,3 +42,31 @@ def test_stats_aggregate_ignores_empty_and_merges_nonempty() -> None:
     assert stats.data["transfer_duration"] == [0.1]
     assert stats.data["bytes_transferred"] == [1024]
     assert stats.data["num_failed_transfers"] == [1]
+
+
+def test_stats_aggregate_uses_latest_delayed_release_snapshot() -> None:
+    stats = MooncakeKVConnectorStats(data={})
+    entered = MooncakeKVConnectorStats(data={})
+    entered.set_delayed_release(2, 7)
+    released = MooncakeKVConnectorStats(data={})
+    released.set_delayed_release(0, 0)
+
+    stats.aggregate(entered).aggregate(released)
+
+    assert stats.data["delayed_release_requests"] == 0
+    assert stats.data["delayed_release_blocks"] == 0
+    assert not stats.is_empty()
+
+
+def test_prom_metrics_observes_delayed_release_snapshot() -> None:
+    gauge_cls = MagicMock()
+    metric_types = {Gauge: gauge_cls, Counter: MagicMock(), Histogram: MagicMock()}
+    metrics = MooncakePromMetrics(MagicMock(), metric_types, ["model_name"], {0: ["test-model"]})
+
+    metrics.observe({"delayed_release_requests": 2, "delayed_release_blocks": 7})
+
+    assert [metric.kwargs["name"] for metric in gauge_cls.call_args_list] == [
+        "vllm:mooncake_pd_delayed_release_requests",
+        "vllm:mooncake_pd_delayed_release_blocks",
+    ]
+    assert gauge_cls.return_value.labels.return_value.set.call_args_list == [call(2), call(7)]

--- a/tests/ut/kv_offload/mooncake_v2/test_stats.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_stats.py
@@ -62,8 +62,10 @@ def test_prom_metrics_observes_delayed_release_snapshot() -> None:
     gauge_cls = MagicMock()
     metric_types = {Gauge: gauge_cls, Counter: MagicMock(), Histogram: MagicMock()}
     metrics = MooncakePromMetrics(MagicMock(), metric_types, ["model_name"], {0: ["test-model"]})
+    stats = MooncakeKVConnectorStats()
+    stats.set_delayed_release(2, 7)
 
-    metrics.observe({"delayed_release_requests": 2, "delayed_release_blocks": 7})
+    metrics.observe(stats.data)
 
     assert [metric.kwargs["name"] for metric in gauge_cls.call_args_list] == [
         "vllm:mooncake_pd_delayed_release_requests",

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
@@ -172,11 +172,9 @@ class MooncakeBaseConnectorScheduler:
         params["_p_side_truncated"] = True
 
     def get_kv_connector_stats(self) -> MooncakeKVConnectorStats | None:
-        if "delayed_release_requests" not in self._kv_stats.data:
+        if self._kv_stats.is_empty():
             return None
-        stats = self._kv_stats
-        self._kv_stats = MooncakeKVConnectorStats()
-        return stats
+        return self._kv_stats.clone_and_reset()
 
     def on_new_request(self, request: "Request") -> None:
         raise NotImplementedError

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_scheduler.py
@@ -25,6 +25,9 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import (
+    MooncakeKVConnectorStats,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -85,6 +88,7 @@ class MooncakeBaseConnectorScheduler:
         self.group_block_size = [group.kv_cache_spec.block_size for group in self.kv_cache_groups]
         self.group_unique_specs = [self._get_group_unique_specs(group) for group in self.kv_cache_groups]
         self.need_truncate = self._needs_prefill_token_truncation()
+        self._kv_stats = MooncakeKVConnectorStats()
 
         logger.info("Initializing Mooncake Scheduler %s", engine_id)
 
@@ -166,6 +170,13 @@ class MooncakeBaseConnectorScheduler:
         request.num_prompt_tokens -= 1
         request.max_tokens = 1
         params["_p_side_truncated"] = True
+
+    def get_kv_connector_stats(self) -> MooncakeKVConnectorStats | None:
+        if "delayed_release_requests" not in self._kv_stats.data:
+            return None
+        stats = self._kv_stats
+        self._kv_stats = MooncakeKVConnectorStats()
+        return stats
 
     def on_new_request(self, request: "Request") -> None:
         raise NotImplementedError

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/connector.py
@@ -177,9 +177,11 @@ class MooncakeBaseConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_worker.get_block_ids_with_load_errors()
 
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
-        if self.connector_worker is None:
-            return None
-        return self.connector_worker.get_kv_connector_stats()
+        if self.connector_scheduler is not None:
+            return self.connector_scheduler.get_kv_connector_stats()
+        if self.connector_worker is not None:
+            return self.connector_worker.get_kv_connector_stats()
+        return None
 
     @classmethod
     def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/pull_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/pull_scheduler.py
@@ -457,7 +457,8 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
         # Requests waiting for the worker to start a READ transfer.
         self._reqs_need_recv: dict[str, tuple[Request, BlockIds, BlockIds, int]] = {}
         # Producer requests whose blocks must remain allocated until read.
-        self._reqs_need_send: dict[str, float] = {}
+        self._reqs_need_send: dict[str, int] = {}
+        self._num_delayed_release_blocks = 0
         self._reqs_in_batch: set[str] = set()
         # D request -> (P scheduler host, port, P request id).
         self._reqs_recv_info: dict[str, tuple[str, int, str]] = {}
@@ -623,12 +624,18 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
                 request.request_id,
             )
             delay_start_time = time.time()
-            self._reqs_need_send[request.request_id] = delay_start_time
+            num_delayed_release_blocks = sum(len(group_block_ids) for group_block_ids in block_ids)
+            self._reqs_need_send[request.request_id] = num_delayed_release_blocks
+            self._num_delayed_release_blocks += num_delayed_release_blocks
             if self._sending_thread is None:
                 raise RuntimeError("Mooncake scheduler metadata has not been initialized")
             self._sending_thread.add_delayed_request(
                 request.request_id,
                 delay_start_time,
+            )
+            self._kv_stats.set_delayed_release(
+                len(self._reqs_need_send),
+                self._num_delayed_release_blocks,
             )
 
         return delay_free_blocks, {
@@ -667,7 +674,11 @@ class MooncakePullConnectorScheduler(MooncakeBaseConnectorScheduler):
         )
         if finished_sending:
             for req_id in finished_sending:
-                self._reqs_need_send.pop(req_id, None)
+                self._num_delayed_release_blocks -= self._reqs_need_send.pop(req_id, 0)
+            self._kv_stats.set_delayed_release(
+                len(self._reqs_need_send),
+                self._num_delayed_release_blocks,
+            )
             if connector_output.finished_sending is None:
                 connector_output.finished_sending = finished_sending
             else:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
@@ -28,7 +28,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
     def reset(self) -> None:
         # Values must remain serializable because worker stats are aggregated
         # outside of the worker process.
-        self.data: dict[str, list[float | int]] = {
+        self.data = {
             "transfer_duration": [],
             "bytes_transferred": [],
             "num_failed_transfers": [],
@@ -51,21 +51,27 @@ class MooncakeKVConnectorStats(KVConnectorStats):
         return previous
 
     def is_empty(self) -> bool:
-        return self.num_successful_transfers == 0 and not self.data["num_failed_transfers"]
+        return (
+            self.num_successful_transfers == 0
+            and not self.data.get("num_failed_transfers")
+            and "delayed_release_requests" not in self.data
+        )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
-        if not other.is_empty():
-            for key, values in other.data.items():
-                accumulator = self.data[key]
-                assert isinstance(accumulator, list)
-                accumulator.extend(values)
+        for key in ("transfer_duration", "bytes_transferred", "num_failed_transfers"):
+            if values := other.data.get(key):
+                self.data.setdefault(key, []).extend(values)
+        for key in ("delayed_release_requests", "delayed_release_blocks"):
+            if key in other.data:
+                self.data[key] = other.data[key]
         return self
 
     def reduce(self) -> dict[str, int | float]:
+        num_failed_transfers = len(self.data.get("num_failed_transfers", []))
         if self.num_successful_transfers == 0:
             return {
                 "Num successful transfers": 0,
-                "Num failed transfers": len(self.data["num_failed_transfers"]),
+                "Num failed transfers": num_failed_transfers,
                 "Avg xfer time (ms)": 0,
                 "P90 xfer time (ms)": 0,
                 "Avg MB per transfer": 0,
@@ -79,16 +85,20 @@ class MooncakeKVConnectorStats(KVConnectorStats):
 
         return {
             "Num successful transfers": self.num_successful_transfers,
-            "Num failed transfers": len(self.data["num_failed_transfers"]),
+            "Num failed transfers": num_failed_transfers,
             "Avg xfer time (ms)": round(durations.mean() * 1e3, 3),
             "P90 xfer time (ms)": round(np.percentile(durations, 90).item() * 1e3, 3),
             "Avg MB per transfer": round(megabytes.mean(), 3),
             "Throughput (MB/s)": round(float(throughput), 3),
         }
 
+    def set_delayed_release(self, num_requests: int, num_blocks: int) -> None:
+        self.data["delayed_release_requests"] = num_requests
+        self.data["delayed_release_blocks"] = num_blocks
+
     @property
     def num_successful_transfers(self) -> int:
-        return len(self.data["transfer_duration"])
+        return len(self.data.get("transfer_duration", []))
 
 
 class MooncakePromMetrics(KVConnectorPromMetrics):
@@ -144,10 +154,39 @@ class MooncakePromMetrics(KVConnectorPromMetrics):
         )
         self.failed_transfers = create_metric_per_engine(failed_transfers, self.per_engine_labelvalues)
 
+        delayed_release_requests = self._gauge_cls(
+            name="vllm:mooncake_pd_delayed_release_requests",
+            documentation=(
+                "Number of finished prefill requests whose KV cache blocks "
+                "are retained until Mooncake P/D transfer completes."
+            ),
+            labelnames=labelnames,
+        )
+        self.delayed_release_requests = create_metric_per_engine(
+            delayed_release_requests,
+            self.per_engine_labelvalues,
+        )
+
+        delayed_release_blocks = self._gauge_cls(
+            name="vllm:mooncake_pd_delayed_release_blocks",
+            documentation=(
+                "Number of KV cache block references retained for finished "
+                "prefill requests until Mooncake P/D transfer completes."
+            ),
+            labelnames=labelnames,
+        )
+        self.delayed_release_blocks = create_metric_per_engine(
+            delayed_release_blocks,
+            self.per_engine_labelvalues,
+        )
+
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0) -> None:
-        for duration in transfer_stats_data["transfer_duration"]:
+        for duration in transfer_stats_data.get("transfer_duration", ()):
             self.transfer_duration[engine_idx].observe(duration)
-        for num_bytes in transfer_stats_data["bytes_transferred"]:
+        for num_bytes in transfer_stats_data.get("bytes_transferred", ()):
             self.bytes_transferred[engine_idx].observe(num_bytes)
-        for failure in transfer_stats_data["num_failed_transfers"]:
+        for failure in transfer_stats_data.get("num_failed_transfers", ()):
             self.failed_transfers[engine_idx].inc(failure)
+        if "delayed_release_requests" in transfer_stats_data:
+            self.delayed_release_requests[engine_idx].set(transfer_stats_data["delayed_release_requests"])
+            self.delayed_release_blocks[engine_idx].set(transfer_stats_data["delayed_release_blocks"])

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/stats.py
@@ -28,7 +28,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
     def reset(self) -> None:
         # Values must remain serializable because worker stats are aggregated
         # outside of the worker process.
-        self.data = {
+        self.data: dict[str, Any] = {
             "transfer_duration": [],
             "bytes_transferred": [],
             "num_failed_transfers": [],
@@ -53,25 +53,24 @@ class MooncakeKVConnectorStats(KVConnectorStats):
     def is_empty(self) -> bool:
         return (
             self.num_successful_transfers == 0
-            and not self.data.get("num_failed_transfers")
+            and not self.data["num_failed_transfers"]
             and "delayed_release_requests" not in self.data
         )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
-        for key in ("transfer_duration", "bytes_transferred", "num_failed_transfers"):
-            if values := other.data.get(key):
-                self.data.setdefault(key, []).extend(values)
-        for key in ("delayed_release_requests", "delayed_release_blocks"):
-            if key in other.data:
-                self.data[key] = other.data[key]
+        if not other.is_empty():
+            for key, value in other.data.items():
+                if isinstance(value, list):
+                    self.data[key].extend(value)
+                else:
+                    self.data[key] = value
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        num_failed_transfers = len(self.data.get("num_failed_transfers", []))
         if self.num_successful_transfers == 0:
             return {
                 "Num successful transfers": 0,
-                "Num failed transfers": num_failed_transfers,
+                "Num failed transfers": len(self.data["num_failed_transfers"]),
                 "Avg xfer time (ms)": 0,
                 "P90 xfer time (ms)": 0,
                 "Avg MB per transfer": 0,
@@ -85,7 +84,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
 
         return {
             "Num successful transfers": self.num_successful_transfers,
-            "Num failed transfers": num_failed_transfers,
+            "Num failed transfers": len(self.data["num_failed_transfers"]),
             "Avg xfer time (ms)": round(durations.mean() * 1e3, 3),
             "P90 xfer time (ms)": round(np.percentile(durations, 90).item() * 1e3, 3),
             "Avg MB per transfer": round(megabytes.mean(), 3),
@@ -98,7 +97,7 @@ class MooncakeKVConnectorStats(KVConnectorStats):
 
     @property
     def num_successful_transfers(self) -> int:
-        return len(self.data.get("transfer_duration", []))
+        return len(self.data["transfer_duration"])
 
 
 class MooncakePromMetrics(KVConnectorPromMetrics):
@@ -181,11 +180,11 @@ class MooncakePromMetrics(KVConnectorPromMetrics):
         )
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0) -> None:
-        for duration in transfer_stats_data.get("transfer_duration", ()):
+        for duration in transfer_stats_data["transfer_duration"]:
             self.transfer_duration[engine_idx].observe(duration)
-        for num_bytes in transfer_stats_data.get("bytes_transferred", ()):
+        for num_bytes in transfer_stats_data["bytes_transferred"]:
             self.bytes_transferred[engine_idx].observe(num_bytes)
-        for failure in transfer_stats_data.get("num_failed_transfers", ()):
+        for failure in transfer_stats_data["num_failed_transfers"]:
             self.failed_transfers[engine_idx].inc(failure)
         if "delayed_release_requests" in transfer_stats_data:
             self.delayed_release_requests[engine_idx].set(transfer_stats_data["delayed_release_requests"])


### PR DESCRIPTION
### What this PR does / why we need it?

This PR exposes the current MooncakeConnectorV2 P/D delayed-release state through two Prometheus gauges:

- `vllm:mooncake_pd_delayed_release_requests`: finished prefill requests whose KV blocks remain allocated until the Mooncake P/D read completes.
- `vllm:mooncake_pd_delayed_release_blocks`: KV block references retained by those requests.

The scheduler records a snapshot only when a request enters the existing delayed-release set or when the existing `finished_sending` ACK removes requests from that set. A zero snapshot is preserved so the gauges return to zero. Idle scheduler steps return no stats.

The implementation reuses the existing KV connector stats and Prometheus pipeline, following the upstream vLLM connector metrics design in https://github.com/vllm-project/vllm/pull/43392. It complements the existing AscendStore pool metrics introduced in https://github.com/vllm-project/vllm-ascend/pull/16137:

- standalone P/D exposes the two Mooncake gauges;
- standalone pooling continues to expose the two AscendStore delayed-release gauges;
- `MultiConnector` P/D + pooling exposes both connector-specific gauge pairs through the existing aggregation path.

This PR does not change block release decisions, ACK handling, transfer ordering, RPCs. It also does not add locks, logging, background threads, request-ID labels, or NPU synchronization.

### Does this PR introduce _any_ user-facing change?

Yes. The vLLM `/metrics` endpoint exposes two additional MooncakeConnectorV2 gauges:

```text
vllm:mooncake_pd_delayed_release_requests
vllm:mooncake_pd_delayed_release_blocks
```

### How was this patch tested?

End-to-end validation used vLLM 0.27.1, DP1/TP2, eager mode, prefix caching disabled, and the Qwen3.8-27B-w8a8 model on Ascend NPUs. All three modes were rerun after the final ponytail simplification:

| Deployment | Delayed snapshot | Final snapshot | Result |
|---|---:|---:|---|
| standalone Mooncake P/D | Mooncake `1 request / 13 blocks` | Mooncake `0 / 0` | P and D HTTP 200 |
| standalone AscendStore pool | AscendStore `1 request / 40 blocks` | AscendStore `0 / 0` | HTTP 200 |
| `MultiConnector` P/D + pool | Mooncake `1 / 40`, AscendStore `1 / 40` | all four gauges `0` | P and D HTTP 200 |

In the combined test, each of the four gauges produced 76 non-zero samples before returning to zero. The connector-specific values must not be summed because the same request can be retained by both connectors.


- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
