### PR TITLE
[Feature][Model][MTP] Support speculative decoding for GLM-5.3-Flash

### DIFF
--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -416,7 +416,7 @@ def test_determine_batch_execution_and_padding(
     ("num_spec_tokens", "computed", "prompts", "scheduled", "expected_mode"),
     [
         pytest.param(0, [7], [8], [1], CUDAGraphMode.FULL, id="stateful_one_token_handoff"),
-        pytest.param(0, [0], [1], [1], CUDAGraphMode.FULL, id="non_spec_first_token"),
+        pytest.param(0, [0], [1], [1], CUDAGraphMode.NONE, id="first_token_without_state"),
         pytest.param(7, [16, 24], [8, 8], [8, 8], CUDAGraphMode.FULL, id="steady_spec_decode"),
         pytest.param(7, [16, 7], [8, 8], [8, 8], CUDAGraphMode.FULL, id="handoff_padded_to_spec_width"),
         pytest.param(7, [16, 0], [8, 8], [8, 8], CUDAGraphMode.NONE, id="spec_width_prefill_without_state"),

--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -416,16 +416,9 @@ def test_determine_batch_execution_and_padding(
     ("num_spec_tokens", "computed", "prompts", "scheduled", "expected_mode"),
     [
         pytest.param(0, [7], [8], [1], CUDAGraphMode.FULL, id="stateful_one_token_handoff"),
-        pytest.param(0, [0], [1], [1], CUDAGraphMode.NONE, id="first_token_without_state"),
+        pytest.param(0, [0], [1], [1], CUDAGraphMode.FULL, id="non_spec_first_token"),
         pytest.param(7, [16, 24], [8, 8], [8, 8], CUDAGraphMode.FULL, id="steady_spec_decode"),
-        pytest.param(
-            7,
-            [16, 7],
-            [8, 8],
-            [8, 8],
-            CUDAGraphMode.NONE,
-            id="spec_handoff_falls_back_from_decode_graph",
-        ),
+        pytest.param(7, [16, 7], [8, 8], [8, 8], CUDAGraphMode.FULL, id="handoff_padded_to_spec_width"),
         pytest.param(7, [16, 0], [8, 8], [8, 8], CUDAGraphMode.NONE, id="spec_width_prefill_without_state"),
         pytest.param(7, [16, 7], [8, 8], [8, 1], CUDAGraphMode.NONE, id="nonuniform_handoff"),
     ],

--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -418,7 +418,14 @@ def test_determine_batch_execution_and_padding(
         pytest.param(0, [7], [8], [1], CUDAGraphMode.FULL, id="stateful_one_token_handoff"),
         pytest.param(0, [0], [1], [1], CUDAGraphMode.NONE, id="first_token_without_state"),
         pytest.param(7, [16, 24], [8, 8], [8, 8], CUDAGraphMode.FULL, id="steady_spec_decode"),
-        pytest.param(7, [16, 7], [8, 8], [8, 8], CUDAGraphMode.FULL, id="handoff_padded_to_spec_width"),
+        pytest.param(
+            7,
+            [16, 7],
+            [8, 8],
+            [8, 8],
+            CUDAGraphMode.NONE,
+            id="spec_handoff_falls_back_from_decode_graph",
+        ),
         pytest.param(7, [16, 0], [8, 8], [8, 8], CUDAGraphMode.NONE, id="spec_width_prefill_without_state"),
         pytest.param(7, [16, 7], [8, 8], [8, 1], CUDAGraphMode.NONE, id="nonuniform_handoff"),
     ],
@@ -465,6 +472,7 @@ def test_stateful_handoff_preserves_decode_graph(
         lora_config=None,
         model_config=runner.model_config,
     )
+    runner.speculative_config = SimpleNamespace(num_speculative_tokens=num_spec_tokens) if num_spec_tokens > 0 else None
     runner.uniform_decode_query_len = 1 + num_spec_tokens
     runner.input_batch = SimpleNamespace(
         num_computed_tokens_cpu=np.array(computed),

--- a/tests/ut/models/test_glm5_next_mtp.py
+++ b/tests/ut/models/test_glm5_next_mtp.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import get_args
+
+import torch
+import vllm.config.speculative as speculative_config
+from torch import nn
+
+from vllm_ascend.models.glm5next import model as glm5next_model
+from vllm_ascend.models.glm5next.config import Glm5NextTextConfig
+from vllm_ascend.models.glm5next.model import (
+    Glm5NextForConditionalGeneration,
+    _mark_zero_initialized_rms_norm_biases,
+    get_spec_layer_idx_from_weight_name,
+)
+from vllm_ascend.models.glm5next.mtp import Glm5NextMTP
+from vllm_ascend.patch.platform.patch_speculative_config import (
+    _normalize_legacy_qwen3_dspark_config,
+)
+
+
+def test_get_spec_layer_idx_accepts_checkpoint_prefixes():
+    config = SimpleNamespace(
+        num_hidden_layers=45,
+        num_nextn_predict_layers=2,
+    )
+
+    assert get_spec_layer_idx_from_weight_name(config, "model.layers.45.enorm.weight") == 45
+    assert get_spec_layer_idx_from_weight_name(config, "layers.46.self_attn.q_a_proj.weight") == 46
+    assert get_spec_layer_idx_from_weight_name(config, "model.layers.44.mlp.weight") is None
+    assert get_spec_layer_idx_from_weight_name(config, "rot.weight") is None
+
+
+def test_mtp_rewrites_layer_and_shared_weight_names():
+    mtp = object.__new__(Glm5NextMTP)
+
+    assert (
+        mtp._rewrite_spec_layer_name(
+            45,
+            "model.layers.45.self_attn.q_a_proj.weight",
+        )
+        == "model.layers.45.mtp_block.self_attn.q_a_proj.weight"
+    )
+    assert (
+        mtp._rewrite_spec_layer_name(
+            45,
+            "model.layers.45.shared_head.norm.weight",
+        )
+        == "model.layers.45.shared_head.norm.weight"
+    )
+
+
+def test_multimodal_mapper_flattens_modelslim_forget_gate_prefix():
+    weight_name = "model.language_model.layers.0.self_attn.forget_gate.f_b_proj.weight"
+
+    assert (
+        Glm5NextForConditionalGeneration.hf_to_vllm_mapper._map_name(weight_name)
+        == "language_model.model.layers.0.self_attn.f_b_proj.weight"
+    )
+
+    assert (
+        Glm5NextForConditionalGeneration.hf_to_vllm_mapper._map_name("model.language_model.layers.1.attn_hc.fn")
+        == "language_model.model.layers.1.hc_attn_fn"
+    )
+    assert (
+        Glm5NextForConditionalGeneration.hf_to_vllm_mapper._map_name("model.language_model.layers.1.ffn_hc.scale")
+        == "language_model.model.layers.1.hc_ffn_scale"
+    )
+
+
+def test_synthetic_rms_norm_biases_are_zeroed_and_marked(monkeypatch):
+    class FakeRMSNorm(nn.Module):
+        def __init__(self, *, bias_loaded: bool):
+            super().__init__()
+            self.bias = nn.Parameter(torch.ones(2), requires_grad=False)
+            self.bias_loaded = bias_loaded
+
+    class TestModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.synthetic = FakeRMSNorm(bias_loaded=False)
+            self.checkpoint = FakeRMSNorm(bias_loaded=True)
+
+    monkeypatch.setattr(glm5next_model, "RMSNorm", FakeRMSNorm)
+    model = TestModel()
+    loaded_params: set[str] = set()
+
+    _mark_zero_initialized_rms_norm_biases(model, loaded_params)
+
+    assert loaded_params == {"synthetic.bias"}
+    assert torch.equal(model.synthetic.bias, torch.zeros(2))
+    assert torch.equal(model.checkpoint.bias, torch.ones(2))
+
+
+def test_glm5_speculative_config_selects_mtp_architecture():
+    config = Glm5NextTextConfig(
+        architectures=["Glm5NextForCausalLM"],
+        num_nextn_predict_layers=2,
+    )
+
+    result = _normalize_legacy_qwen3_dspark_config(config)
+
+    assert result.model_type == "glm5_next_mtp"
+    assert result.n_predict == 2
+    assert result.architectures == ["Glm5NextMTPModel"]
+    assert "glm5_next_mtp" in get_args(speculative_config.MTPModelTypes)

--- a/tests/ut/models/test_glm5_next_mtp.py
+++ b/tests/ut/models/test_glm5_next_mtp.py
@@ -4,15 +4,11 @@
 from types import SimpleNamespace
 from typing import get_args
 
-import torch
 import vllm.config.speculative as speculative_config
-from torch import nn
 
-from vllm_ascend.models.glm5next import model as glm5next_model
 from vllm_ascend.models.glm5next.config import Glm5NextTextConfig
 from vllm_ascend.models.glm5next.model import (
     Glm5NextForConditionalGeneration,
-    _mark_zero_initialized_rms_norm_biases,
     get_spec_layer_idx_from_weight_name,
 )
 from vllm_ascend.models.glm5next.mtp import Glm5NextMTP
@@ -68,30 +64,6 @@ def test_multimodal_mapper_flattens_modelslim_forget_gate_prefix():
         Glm5NextForConditionalGeneration.hf_to_vllm_mapper._map_name("model.language_model.layers.1.ffn_hc.scale")
         == "language_model.model.layers.1.hc_ffn_scale"
     )
-
-
-def test_synthetic_rms_norm_biases_are_zeroed_and_marked(monkeypatch):
-    class FakeRMSNorm(nn.Module):
-        def __init__(self, *, bias_loaded: bool):
-            super().__init__()
-            self.bias = nn.Parameter(torch.ones(2), requires_grad=False)
-            self.bias_loaded = bias_loaded
-
-    class TestModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.synthetic = FakeRMSNorm(bias_loaded=False)
-            self.checkpoint = FakeRMSNorm(bias_loaded=True)
-
-    monkeypatch.setattr(glm5next_model, "RMSNorm", FakeRMSNorm)
-    model = TestModel()
-    loaded_params: set[str] = set()
-
-    _mark_zero_initialized_rms_norm_biases(model, loaded_params)
-
-    assert loaded_params == {"synthetic.bias"}
-    assert torch.equal(model.synthetic.bias, torch.zeros(2))
-    assert torch.equal(model.checkpoint.bias, torch.ones(2))
 
 
 def test_glm5_speculative_config_selects_mtp_architecture():

--- a/tests/ut/quantization/configs/test_modelslim_config.py
+++ b/tests/ut/quantization/configs/test_modelslim_config.py
@@ -743,6 +743,124 @@ class TestQuantPrefixMapper(TestBase):
 
         self.assertIsInstance(method, AscendUnquantizedLinearMethod)
 
+    def test_glm5_mtp_quant_prefix_strips_mtp_block(self):
+        config = AscendModelSlimConfig()
+        prefix = "model.layers.45.mtp_block.self_attn.fused_qkv_a_proj"
+        expected = "model.layers.45.self_attn.fused_qkv_a_proj"
+
+        self.assertEqual(
+            config.quant_prefix_mapper("glm5_next_mtp", prefix),
+            expected,
+        )
+
+    def test_glm5_mtp_resolves_real_fused_mlp_prefix(self):
+        runtime_prefix = "model.layers.45.mtp_block.mlp"
+        checkpoint_prefix = "model.language_model.layers.45.mlp"
+        quant_description = {
+            f"{checkpoint_prefix}.gate_proj.weight": "W8A8_DYNAMIC",
+            f"{checkpoint_prefix}.up_proj.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        config._update_packed_modules_mapping("glm5_next_mtp")
+        prefix = config.quant_prefix_mapper(
+            "glm5_next_mtp",
+            f"{runtime_prefix}.gate_up_proj",
+        )
+
+        self.assertEqual(prefix, f"{checkpoint_prefix}.gate_up_proj")
+        self.assertEqual(
+            get_quant_type_for_layer(
+                quant_description,
+                prefix,
+                config.packed_modules_mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+    def test_glm5_mtp_float_experts_stay_unquantized(self):
+        runtime_prefix = "model.layers.45.mtp_block.mlp.experts"
+        checkpoint_prefix = "model.language_model.layers.45.mlp.experts"
+        quant_description = {
+            f"{checkpoint_prefix}.0.{name}.weight": "FLOAT"
+            for name in ("gate_proj", "up_proj", "down_proj")
+        }
+        config = AscendModelSlimConfig(quant_description)
+        config._update_packed_modules_mapping("glm5_next_mtp")
+        prefix = config.quant_prefix_mapper(
+            "glm5_next_mtp",
+            runtime_prefix,
+        )
+
+        self.assertEqual(prefix, checkpoint_prefix)
+        self.assertIsNone(
+            get_quant_type_for_layer(
+                quant_description,
+                prefix,
+                config.packed_modules_mapping,
+            )
+        )
+
+    def test_glm5_multimodal_quant_prefix_matches_modelslim_checkpoint(self):
+        runtime_prefix = "language_model.model.layers.0.mlp.gate_up_proj"
+        checkpoint_prefix = "model.language_model.layers.0.mlp.gate_up_proj"
+        quant_description = {
+            f"{checkpoint_prefix.replace('gate_up_proj', 'gate_proj')}.weight": "W8A8_DYNAMIC",
+            f"{checkpoint_prefix.replace('gate_up_proj', 'up_proj')}.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        config._update_packed_modules_mapping("glm5_next")
+
+        prefix = config.quant_prefix_mapper("glm5_next", runtime_prefix)
+
+        self.assertEqual(prefix, checkpoint_prefix)
+        self.assertEqual(
+            get_quant_type_for_layer(
+                quant_description,
+                prefix,
+                config.packed_modules_mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+    def test_glm5_text_quant_prefix_matches_modelslim_checkpoint(self):
+        runtime_prefix = "language_model.model.layers.0.mlp.gate_up_proj"
+        checkpoint_prefix = "model.language_model.layers.0.mlp.gate_up_proj"
+        quant_description = {
+            f"{checkpoint_prefix.replace('gate_up_proj', 'gate_proj')}.weight": "W8A8_DYNAMIC",
+            f"{checkpoint_prefix.replace('gate_up_proj', 'up_proj')}.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        config._update_packed_modules_mapping("glm5_next_text")
+
+        prefix = config.quant_prefix_mapper("glm5_next_text", runtime_prefix)
+
+        self.assertEqual(prefix, checkpoint_prefix)
+        self.assertEqual(
+            get_quant_type_for_layer(
+                quant_description,
+                prefix,
+                config.packed_modules_mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+    def test_glm5_multimodal_quant_prefix_uses_language_model_alias(self):
+        quant_prefix = "language_model.model.layers.0.self_attn.fused_qkv_a_proj"
+        config = AscendModelSlimConfig(
+            {
+                f"{quant_prefix.replace('fused_qkv_a_proj', 'q_a_proj')}.weight": "W8A8_DYNAMIC",
+                f"{quant_prefix.replace('fused_qkv_a_proj', 'kv_a_proj_with_mqa')}.weight": "W8A8_DYNAMIC",
+            }
+        )
+        config._update_packed_modules_mapping("glm5_next")
+
+        prefix = config.quant_prefix_mapper(
+            "glm5_next",
+            "model.layers.0.self_attn.fused_qkv_a_proj",
+        )
+
+        self.assertEqual(prefix, quant_prefix)
+
     def test_non_gemma4_moe_experts_prefix_is_not_rewritten(self):
         config = AscendModelSlimConfig()
 

--- a/tests/ut/quantization/configs/test_modelslim_config.py
+++ b/tests/ut/quantization/configs/test_modelslim_config.py
@@ -781,8 +781,7 @@ class TestQuantPrefixMapper(TestBase):
         runtime_prefix = "model.layers.45.mtp_block.mlp.experts"
         checkpoint_prefix = "model.language_model.layers.45.mlp.experts"
         quant_description = {
-            f"{checkpoint_prefix}.0.{name}.weight": "FLOAT"
-            for name in ("gate_proj", "up_proj", "down_proj")
+            f"{checkpoint_prefix}.0.{name}.weight": "FLOAT" for name in ("gate_proj", "up_proj", "down_proj")
         }
         config = AscendModelSlimConfig(quant_description)
         config._update_packed_modules_mapping("glm5_next_mtp")

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -74,7 +74,7 @@ class TestGlm5MtpGraphMetadata(unittest.TestCase):
         )
         return runner
 
-    def test_partial_prompt_does_not_dispatch_speculative_decode_graph(self):
+    def test_partial_prompt_with_state_dispatches_speculative_decode_graph(self):
         runner = self._build_dispatch_runner(speculative=True)
 
         with patch(
@@ -90,7 +90,7 @@ class TestGlm5MtpGraphMetadata(unittest.TestCase):
             )
 
         call_kwargs = runner.cudagraph_dispatcher.dispatch.call_args.kwargs
-        self.assertFalse(call_kwargs["uniform_decode"])
+        self.assertTrue(call_kwargs["uniform_decode"])
 
 
 class TestDummyRunSlotInvalidation(unittest.TestCase):

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -44,6 +44,54 @@ from vllm_ascend.utils import AscendDeviceType, vllm_version_is
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
+class TestGlm5MtpGraphMetadata(unittest.TestCase):
+    @staticmethod
+    def _build_dispatch_runner(speculative: bool) -> NPUModelRunner:
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.uniform_decode_query_len = 6
+        runner.speculative_config = object() if speculative else None
+        runner._pad_for_sequence_parallelism = lambda num_tokens: num_tokens
+        runner.input_batch = SimpleNamespace(
+            num_computed_tokens_cpu=np.array([9, 10], dtype=np.int32),
+            num_prompt_tokens=np.array([10, 10], dtype=np.int32),
+            lora_id_to_lora_request={},
+        )
+        runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+        runner.cudagraph_dispatcher = MagicMock(
+            dispatch=MagicMock(
+                return_value=(
+                    CUDAGraphMode.NONE,
+                    SimpleNamespace(num_tokens=12),
+                )
+            )
+        )
+        runner.vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=1,
+                data_parallel_size=1,
+            ),
+            observability_config=SimpleNamespace(cudagraph_metrics=False),
+        )
+        return runner
+
+    def test_partial_prompt_does_not_dispatch_speculative_decode_graph(self):
+        runner = self._build_dispatch_runner(speculative=True)
+
+        with patch(
+            "vllm_ascend.worker.model_runner_v1.enable_sp",
+            return_value=False,
+        ):
+            runner._determine_batch_execution_and_padding(
+                num_tokens=12,
+                num_reqs=2,
+                num_scheduled_tokens_np=np.array([6, 6], dtype=np.int32),
+                max_num_scheduled_tokens=6,
+                use_cascade_attn=False,
+            )
+
+        call_kwargs = runner.cudagraph_dispatcher.dispatch.call_args.kwargs
+        self.assertFalse(call_kwargs["uniform_decode"])
+
 class TestDummyRunSlotInvalidation(unittest.TestCase):
     def test_backend_metadata_sees_invalidated_dummy_slots(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -50,6 +50,8 @@ class TestGlm5MtpGraphMetadata(unittest.TestCase):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.uniform_decode_query_len = 6
         runner.speculative_config = object() if speculative else None
+        # ``use_dcp`` is derived from this field in production initialization.
+        runner.dcp_size = 1
         runner._pad_for_sequence_parallelism = lambda num_tokens: num_tokens
         runner.input_batch = SimpleNamespace(
             num_computed_tokens_cpu=np.array([9, 10], dtype=np.int32),

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -92,6 +92,7 @@ class TestGlm5MtpGraphMetadata(unittest.TestCase):
         call_kwargs = runner.cudagraph_dispatcher.dispatch.call_args.kwargs
         self.assertFalse(call_kwargs["uniform_decode"])
 
+
 class TestDummyRunSlotInvalidation(unittest.TestCase):
     def test_backend_metadata_sees_invalidated_dummy_slots(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/vllm_ascend/models/glm5next/model.py
+++ b/vllm_ascend/models/glm5next/model.py
@@ -246,10 +246,20 @@ class Glm5NextMoE(nn.Module):
         if self.is_sequence_parallel and not already_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
 
-        # The router is always external (self.gate); main's MoERunner expects
-        # pre-computed router_logits, so compute them here unconditionally.
-        router_logits, _ = self.gate(hidden_states)
-        final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+        if self.experts.is_internal_router:
+            # The Ascend MoE runner owns the gate in this mode. Pass hidden
+            # states through the router_logits slot so it can compute routing
+            # exactly once inside the fused path.
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=hidden_states,
+            )
+        else:
+            router_logits, _ = self.gate(hidden_states)
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
 
         if self.is_sequence_parallel and not already_sequence_parallel:
             final_hidden_states = tensor_model_parallel_all_gather(final_hidden_states, 0)

--- a/vllm_ascend/models/glm5next/model.py
+++ b/vllm_ascend/models/glm5next/model.py
@@ -91,19 +91,6 @@ from .multimodal import (
 from .ops.mhc_ops import hc_contract, hc_expand
 
 
-def _mark_zero_initialized_rms_norm_biases(module: nn.Module, loaded_params: set[str]) -> None:
-    """Mark synthetic zero RMSNorm biases that have no checkpoint tensor."""
-    for module_name, norm in module.named_modules():
-        if not isinstance(norm, RMSNorm):
-            continue
-        bias = getattr(norm, "bias", None)
-        if bias is None or getattr(norm, "bias_loaded", False):
-            continue
-        with torch.no_grad():
-            bias.zero_()
-        loaded_params.add(f"{module_name}.bias")
-
-
 class Glm5NextMLP(nn.Module):
     def __init__(
         self,
@@ -834,7 +821,6 @@ class Glm5NextModel(nn.Module):
                     weight_loader = getattr(param, "weight_loader", default_weight_loader)
                     weight_loader(param, loaded_weight, **kwargs)
             loaded_params.add(name)
-        _mark_zero_initialized_rms_norm_biases(self, loaded_params)
         return loaded_params
 
 

--- a/vllm_ascend/models/glm5next/model.py
+++ b/vllm_ascend/models/glm5next/model.py
@@ -64,6 +64,7 @@ from vllm.model_executor.models.interfaces import (
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     PPMissingLayer,
+    WeightsMapper,
     init_vllm_registered_model,
     is_pp_missing_parameter,
     make_layers,
@@ -88,6 +89,19 @@ from .multimodal import (
     Glm5NextVisionTransformer,
 )
 from .ops.mhc_ops import hc_contract, hc_expand
+
+
+def _mark_zero_initialized_rms_norm_biases(module: nn.Module, loaded_params: set[str]) -> None:
+    """Mark synthetic zero RMSNorm biases that have no checkpoint tensor."""
+    for module_name, norm in module.named_modules():
+        if not isinstance(norm, RMSNorm):
+            continue
+        bias = getattr(norm, "bias", None)
+        if bias is None or getattr(norm, "bias_loaded", False):
+            continue
+        with torch.no_grad():
+            bias.zero_()
+        loaded_params.add(f"{module_name}.bias")
 
 
 class Glm5NextMLP(nn.Module):
@@ -820,6 +834,7 @@ class Glm5NextModel(nn.Module):
                     weight_loader = getattr(param, "weight_loader", default_weight_loader)
                     weight_loader(param, loaded_weight, **kwargs)
             loaded_params.add(name)
+        _mark_zero_initialized_rms_norm_biases(self, loaded_params)
         return loaded_params
 
 
@@ -913,6 +928,25 @@ class Glm5NextForConditionalGeneration(Glm4vForConditionalGeneration, HasInnerSt
     has_inner_state: ClassVar[Literal[True]] = True
     is_hybrid: ClassVar[Literal[True]] = True
 
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "lm_head.": "language_model.lm_head.",
+            "model.language_model.": "language_model.model.",
+            "model.visual.": "visual.",
+        },
+        # ModelSlim W8A8 checkpoints group the KDA forget-gate tensors under
+        # ``forget_gate``; the runtime KDA module keeps those parameters flat.
+        orig_to_new_substr={
+            ".forget_gate.": ".",
+            ".attn_hc.fn": ".hc_attn_fn",
+            ".attn_hc.base": ".hc_attn_base",
+            ".attn_hc.scale": ".hc_attn_scale",
+            ".ffn_hc.fn": ".hc_ffn_fn",
+            ".ffn_hc.base": ".hc_ffn_base",
+            ".ffn_hc.scale": ".hc_ffn_scale",
+        },
+    )
+
     # NOTE: weight-prefix mapping is inherited from Glm4vForConditionalGeneration
     # (``model.visual.`` -> ``visual.``, ``model.language_model.`` ->
     # ``language_model.model.``, ``lm_head.`` -> ``language_model.lm_head.``),
@@ -980,6 +1014,12 @@ class Glm5NextForConditionalGeneration(Glm4vForConditionalGeneration, HasInnerSt
         # Glm5NextForCausalLM does not implement make_empty_intermediate_tensors,
         # so pipeline parallelism is gated off (consistent with the text-only
         # model) and we intentionally do not alias it here.
+
+    def load_weights(self, weights: Iterable[tuple[Any, ...]]) -> set[str]:
+        # The visual merger's down_proj already contains the exported rotation.
+        # Ignore the standalone QuaRot tensor to avoid applying it a second time.
+        loader = AutoWeightsLoader(self, skip_prefixes=["rot."])
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
     def get_encoder_cudagraph_config(self):
         # This vision tower does not produce the absolute position embedding

--- a/vllm_ascend/models/glm5next/mtp.py
+++ b/vllm_ascend/models/glm5next/mtp.py
@@ -28,7 +28,6 @@ from .model import (
     Glm5NextDecoderLayer,
     Glm5NextMLAAttention,
     Glm5NextMoE,
-    _mark_zero_initialized_rms_norm_biases,
     _try_load_fp8_attn_proj,
     _try_load_fp8_indexer_wk,
     get_spec_layer_idx_from_weight_name,
@@ -399,7 +398,6 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
-        _mark_zero_initialized_rms_norm_biases(self, loaded_params)
         loaded_layers: set[int] = set()
         for param_name in loaded_params:
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, param_name)

--- a/vllm_ascend/models/glm5next/mtp.py
+++ b/vllm_ascend/models/glm5next/mtp.py
@@ -28,6 +28,7 @@ from .model import (
     Glm5NextDecoderLayer,
     Glm5NextMLAAttention,
     Glm5NextMoE,
+    _mark_zero_initialized_rms_norm_biases,
     _try_load_fp8_attn_proj,
     _try_load_fp8_indexer_wk,
     get_spec_layer_idx_from_weight_name,
@@ -398,6 +399,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
+        _mark_zero_initialized_rms_norm_biases(self, loaded_params)
         loaded_layers: set[int] = set()
         for param_name in loaded_params:
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, param_name)

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager
 from copy import copy
 from dataclasses import replace
+from typing import Literal, get_args
 
+import vllm.config.speculative as speculative_config
 from transformers import DeepseekV2Config, PretrainedConfig
 from vllm.config.speculative import SpeculativeConfig
 
@@ -35,6 +37,15 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
                 "architectures": ["Qwen3DSparkModel"],
                 "mask_token_id": dflash_config["mask_token_id"],
                 "target_layer_ids": dflash_config["target_layer_ids"],
+            }
+        )
+    if hf_config.model_type in ("glm5_next", "glm5_next_text"):
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.model_type = "glm5_next_mtp"
+        hf_config.update(
+            {
+                "n_predict": n_predict,
+                "architectures": ["Glm5NextMTPModel"],
             }
         )
     return hf_config
@@ -108,3 +119,9 @@ def _dspark_post_init(self):
 
 SpeculativeConfig.hf_config_override = staticmethod(_normalize_legacy_qwen3_dspark_config)
 SpeculativeConfig.__post_init__ = _dspark_post_init
+
+if "glm5_next_mtp" not in get_args(speculative_config.MTPModelTypes):
+    speculative_config.MTPModelTypes = Literal[
+        *get_args(speculative_config.MTPModelTypes),
+        "glm5_next_mtp",
+    ]

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -528,9 +528,7 @@ class AscendModelSlimConfig(QuantizationConfig):
         # Only update packed_modules_mapping if the upstream model definition not satisfies our scenario.
         mapping_model_type = "glm5_next" if model_type == "glm5_next_text" else model_type
         if mapping_model_type in UPDATED_PACKED_MODULES_MAPPING:
-            self.packed_modules_mapping.update(
-                UPDATED_PACKED_MODULES_MAPPING[mapping_model_type]
-            )
+            self.packed_modules_mapping.update(UPDATED_PACKED_MODULES_MAPPING[mapping_model_type])
         if model_type in ("kimi_k3", "kimi_linear"):
             from vllm.models.kimi_k3.nvidia.model import KimiLinearModel
 

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -102,6 +102,12 @@ UPDATED_PACKED_MODULES_MAPPING: dict[str, dict[str, list[str]]] = {
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
         "fused_qkvbfg_a_proj": ["q_proj", "k_proj", "v_proj", "b_proj", "f_a_proj", "g_a_proj"],
     },
+    "glm5_next_mtp": {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "fused_qkvbfg_a_proj": ["q_proj", "k_proj", "v_proj", "b_proj", "f_a_proj", "g_a_proj"],
+    },
     "deepseek_mtp": {
         "gate_up_proj": ["gate_proj", "up_proj"],
     },
@@ -174,6 +180,11 @@ QUANT_MODEL_SUBSTR_MAPPINGS = {
     # (e.g. "model.layers.45.self_attn.q_proj.weight"). Strip it so the quant
     # lookup matches the on-disk naming.
     "step3p5_mtp": {
+        ".mtp_block.": ".",
+    },
+    # GLM-5 MTP nests the decoder under ``mtp_block`` while the ModelSlim
+    # description retains checkpoint-style names.
+    "glm5_next_mtp": {
         ".mtp_block.": ".",
     },
     # Gemma4 MoE renames ".experts." to ".moe.experts." in the vLLM module tree
@@ -460,6 +471,35 @@ class AscendModelSlimConfig(QuantizationConfig):
             )
             prefix = hf_to_vllm_mapper._map_name(prefix)
 
+        if model_type in ("glm5_next", "glm5_next_text"):
+            candidate = None
+            if prefix.startswith("language_model.model."):
+                candidate = prefix.replace(
+                    "language_model.model.",
+                    "model.language_model.",
+                    1,
+                )
+            elif prefix.startswith("language_model.lm_head"):
+                candidate = prefix.replace("language_model.lm_head", "lm_head", 1)
+            elif prefix.startswith("model.layers."):
+                candidate = prefix.replace(
+                    "model.layers.",
+                    "language_model.model.layers.",
+                    1,
+                )
+            if candidate and not self._has_quant_weight(prefix):
+                if self._has_quant_weight(candidate):
+                    return candidate
+
+        if model_type == "glm5_next_mtp" and prefix.startswith("model.layers."):
+            candidate = prefix.replace(
+                "model.layers.",
+                "model.language_model.layers.",
+                1,
+            )
+            if not self._has_quant_weight(prefix) and self._has_quant_weight(candidate):
+                return candidate
+
         if model_type == "step3p5_mtp" and prefix.startswith("model.layers."):
             # Step3P5 MTP and newly generated Step3P7 W8A8 MTP checkpoints use
             # ``model.layers.*``.  The Step3P7 vLLM wrapper mapper rewrites
@@ -486,8 +526,11 @@ class AscendModelSlimConfig(QuantizationConfig):
           all expert shards (gate/up/down or w1/w2/w3).
         """
         # Only update packed_modules_mapping if the upstream model definition not satisfies our scenario.
-        if model_type in UPDATED_PACKED_MODULES_MAPPING:
-            self.packed_modules_mapping.update(UPDATED_PACKED_MODULES_MAPPING[model_type])
+        mapping_model_type = "glm5_next" if model_type == "glm5_next_text" else model_type
+        if mapping_model_type in UPDATED_PACKED_MODULES_MAPPING:
+            self.packed_modules_mapping.update(
+                UPDATED_PACKED_MODULES_MAPPING[mapping_model_type]
+            )
         if model_type in ("kimi_k3", "kimi_linear"):
             from vllm.models.kimi_k3.nvidia.model import KimiLinearModel
 


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

This PR enables Multi-Token Prediction (MTP) speculative decoding for GLM-5.3-Flash (`glm5_next`) on Ascend.

The `Glm5NextMTPModel` implementation already exists in the GLM-5.3-Flash model code. This PR completes the integration required to select and run that model through vLLM's existing `deepseek_mtp` speculative decoding flow.

The main changes include:

- Register `glm5_next_mtp` as a supported MTP model type.
- Normalize GLM-5.3-Flash draft configurations:
  - Convert `glm5_next` and `glm5_next_text` to `glm5_next_mtp`.
  - Select the existing `Glm5NextMTPModel` architecture.
  - Propagate `num_nextn_predict_layers` as `n_predict`.
- Correct main-model graph selection for speculative decoding:
  - Treat a speculative batch as uniform decode only when every request has finished its prompt.
  - Prevent partial-prefill requests from incorrectly replaying a uniform decode graph.
  - Keep the main model graph-enabled while the MTP draft model runs eagerly through `enforce_eager`.
- Add ModelSlim W8A8 quantization adaptations:
  - Register the fused MLP, MoE, MLA, and KDA projection mappings for `glm5_next_mtp`.
  - Map runtime prefixes containing `.mtp_block.` back to checkpoint-style quantization prefixes.
  - Resolve MTP expert prefixes stored under `model.language_model.layers.*`.
  - Support multimodal checkpoints whose text-model quantization entries use different `model.language_model.*` or `language_model.model.*` namespaces.
  - Reuse the `glm5_next` packed-module mapping for `glm5_next_text`.
  - Preserve expert layers marked as `FLOAT` as unquantized.
- Add multimodal GLM-5.3-Flash weight mappings:
  - Flatten ModelSlim KDA `forget_gate` parameters to the runtime module layout.
  - Map attention and FFN hyper-connection parameters.
  - Map visual, language-model, embedding, and LM-head prefixes.
  - Ignore the standalone `rot.*` tensor because the exported rotation has already been folded into `model.visual.merger.down_proj.weight`.
- Add unit tests covering speculative-config registration, graph dispatch, multimodal weight mappings, and ModelSlim quantization-prefix resolution.

This allows GLM-5.3-Flash to use one-token MTP speculative decoding with the existing `deepseek_mtp` method.

### Does this PR introduce *any* user-facing change?

Yes.

Users can enable MTP speculative decoding for GLM-5.3-Flash with:

```bash
--speculative-config '{"num_speculative_tokens":1,"method":"deepseek_mtp","enforce_eager":true}'
```

For ModelSlim W8A8 checkpoints, the Ascend quantization method must also be specified explicitly:

```bash
--quantization ascend \
--speculative-config '{"num_speculative_tokens":1,"method":"deepseek_mtp","enforce_eager":true}'
```

The MTP draft model runs eagerly, while the main model can continue using decode graphs such as `FULL_DECODE_ONLY`.

### How was this patch tested?

Formatting and pre-commit checks:

```bash
bash format.sh
```

All hooks passed, including ruff, codespell, typos, clang-format, actionlint, gitleaks, shellcheck, and the repository-specific checks.

Unit tests:

```bash
pytest -q \
  tests/ut/models/test_glm5_next_mtp.py \
  tests/ut/worker/test_model_runner_v1.py
```

Result:

```text
51 passed, 2 skipped
```

ModelSlim unit tests:

```bash
pytest -q tests/ut/quantization/configs/test_modelslim_config.py
```

Result:

```text
60 passed
```

Runtime validation was performed with:

- GLM-5.3-Flash ModelSlim W8A8 checkpoint
- Tensor parallel size: 8
- Expert parallel enabled
- One speculative token
- MTP draft model in eager mode
- Main-model graph mode: `FULL_DECODE_ONLY`
- Explicit `--quantization ascend`

Example runtime options:

```bash
--tensor-parallel-size 8 \
--enable-expert-parallel \
--quantization ascend \
--speculative-config '{"num_speculative_tokens":1,"method":"deepseek_mtp","enforce_eager":true}' \
--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16,32,64,96,128]}'
```

A single chat-completions request completed successfully and returned the expected answer `4` for `2 + 2`.

The speculative-decoding metrics confirmed that MTP was active:

```text
draft tokens:    31
accepted tokens: 28
```

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
