### PR TITLE
[BugFix][MoE] Precast gate weight_fp32 for ACLGraph

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -116,6 +116,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
+        # Pre-cast internal-router gate weights at load time. Forward-time
+        # gate.weight.to(fp32) emits an uncapturable aclop Cast (ACLGraph);
+        # same issue fixed for 310P in #14863. Needed after #14872 widened
+        # is_internal_router to `gate is not None` (e.g. Qwen3-VL W8A8).
+        if self.gate is not None and not hasattr(self.gate, "weight_fp32"):
+            self.gate.precast_fp32_weight = True
+
         self.ascend_shared_experts = None
         if shared_experts is not None:
             routed_experts.return_with_event = True


### PR DESCRIPTION
## Summary
- Nightly Qwen3-VL-235B W8A8 fails during ACL graph capture with `Cannot run aclop operators ... Current working aclop is Cast`.
- After #14872, `is_internal_router` is `gate is not None`; gates without `weight_fp32` fall back to `gate.weight.to(float32)` at forward time, which is not ACLGraph-capturable.
- Mirror 310P #14863: set `precast_fp32_weight=True` in `AscendMoERunner.__init__` so `process_weights_after_loading` builds `weight_fp32` at load time.

## Related failure
- https://github.com/vllm-project/vllm-ascend/actions/runs/34372289942/job/102666526384

## Test plan
- [ ] Qwen3-VL-235B-Instruct-W8A8 single-node nightly starts past graph capture
- [ ] cpu-ut / existing fused_moe tests still pass
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
