### PR TITLE
[CI] Keep Kimi dual-node on internal DP after v0.28

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K2_5-W4A8-A2-dual-nodes.yaml
@@ -28,7 +28,6 @@ deployment:
         --seed 42
         --data-parallel-size 2
         --data-parallel-size-local 1
-        --data-parallel-start-rank 0
         --data-parallel-address $LOCAL_IP
         --data-parallel-rpc-port 13389
         --tensor-parallel-size 8
@@ -56,6 +55,7 @@ deployment:
         --trust-remote-code
         --no-enable-prefix-caching
         --seed 42
+        --headless
         --data-parallel-size 2
         --data-parallel-size-local 1
         --data-parallel-start-rank 1


### PR DESCRIPTION
## Summary
- Nightly Kimi dual-node Output Token Throughput dropped to **703** vs baseline **1347** (~half).
- Log shows autoswitch to `data_parallel_external_lb` after v0.28 treats `--data-parallel-start-rank 0` as set; benchmark only hits node0 so Engine 001 is idle.
- Fix: omit start-rank 0 on primary; restore `--headless` on secondary (classic internal DP).

## Related failure
- https://github.com/vllm-project/vllm-ascend/actions/runs/34372285587/job/102538196924

## Test plan
- [ ] Kimi dual-node nightly no longer logs hybrid→external autoswitch
- [ ] Output token throughput recovers near baseline (~1347)
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
