### PR TITLE
[Feature][Sparse KV Offload] Support non-memfabric fused-overlap membership staging and d2h graph writeback

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2536,6 +2536,180 @@ int64_t compute_lru_resident_addrs(const at::Tensor& miss_count, const at::Tenso
 
 namespace {
 
+void check_current_kv_index_tensor(const at::Tensor& tensor, const torch::ScalarType dtype, const char* name) {
+  TORCH_CHECK(tensor.device().is_cpu(), name, " must be a CPU tensor");
+  TORCH_CHECK(tensor.scalar_type() == dtype, name, " has an invalid dtype");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+struct CurrentKvIndexCopyPayload {
+  at::Tensor slot_mapping;
+  at::Tensor src_idx_buffer;
+  at::Tensor dst_idx_buffer;
+  at::Tensor count_buffer;
+  int64_t num_actual_tokens;
+  int64_t max_num_tokens;
+  int64_t num_host_slots;
+  bool delete_after_run;
+};
+
+std::unique_ptr<CurrentKvIndexCopyPayload> make_current_kv_index_copy_payload(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  check_current_kv_index_tensor(slot_mapping, torch::kInt64, "slot_mapping");
+  check_current_kv_index_tensor(src_idx_buffer, torch::kInt64, "src_idx_buffer");
+  check_current_kv_index_tensor(dst_idx_buffer, torch::kInt64, "dst_idx_buffer");
+  check_current_kv_index_tensor(count_buffer, torch::kInt32, "count_buffer");
+  TORCH_CHECK(num_actual_tokens >= 0, "num_actual_tokens must not be negative");
+  TORCH_CHECK(max_num_tokens > 0, "max_num_tokens must be positive");
+  TORCH_CHECK(max_num_tokens <= std::numeric_limits<int32_t>::max(), "max_num_tokens exceeds int32 capacity");
+  TORCH_CHECK(num_actual_tokens <= max_num_tokens, "num_actual_tokens exceeds max_num_tokens");
+  TORCH_CHECK(num_host_slots > 0, "num_host_slots must be positive");
+  TORCH_CHECK(slot_mapping.numel() >= num_actual_tokens, "slot_mapping is smaller than num_actual_tokens");
+  TORCH_CHECK(src_idx_buffer.numel() >= max_num_tokens, "src_idx_buffer is too small");
+  TORCH_CHECK(dst_idx_buffer.numel() >= max_num_tokens, "dst_idx_buffer is too small");
+  TORCH_CHECK(count_buffer.numel() >= 1, "count_buffer is empty");
+
+  return std::make_unique<CurrentKvIndexCopyPayload>(CurrentKvIndexCopyPayload{
+      slot_mapping, src_idx_buffer, dst_idx_buffer, count_buffer, num_actual_tokens, max_num_tokens, num_host_slots,
+      false});
+}
+
+void build_current_kv_index_copy_descriptors(CurrentKvIndexCopyPayload* payload) noexcept {
+  if (payload == nullptr) {
+    return;
+  }
+  const auto* slots = payload->slot_mapping.data_ptr<int64_t>();
+  auto* src_idx = payload->src_idx_buffer.data_ptr<int64_t>();
+  auto* dst_idx = payload->dst_idx_buffer.data_ptr<int64_t>();
+  auto* count = payload->count_buffer.data_ptr<int32_t>();
+  int32_t num_copies = 0;
+
+  for (int64_t token_idx = 0; token_idx < payload->num_actual_tokens; ++token_idx) {
+    const int64_t slot = slots[token_idx];
+    if (slot < 0 || slot >= payload->num_host_slots) {
+      continue;
+    }
+    src_idx[num_copies] = token_idx;
+    dst_idx[num_copies] = slot;
+    ++num_copies;
+  }
+
+  if (num_copies > 0) {
+    const int64_t last_src = src_idx[num_copies - 1];
+    const int64_t last_dst = dst_idx[num_copies - 1];
+    for (int64_t i = num_copies; i < payload->max_num_tokens; ++i) {
+      src_idx[i] = last_src;
+      dst_idx[i] = last_dst;
+    }
+  } else {
+    std::fill_n(src_idx, payload->max_num_tokens, 0);
+    std::fill_n(dst_idx, payload->max_num_tokens, 0);
+  }
+  count[0] = num_copies;
+}
+
+int64_t compute_current_kv_index_copy_descriptors(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  auto payload = make_current_kv_index_copy_payload(slot_mapping, num_actual_tokens, max_num_tokens, num_host_slots,
+                                                    src_idx_buffer, dst_idx_buffer, count_buffer);
+  build_current_kv_index_copy_descriptors(payload.get());
+  return count_buffer.data_ptr<int32_t>()[0];
+}
+
+struct CurrentKvIndexCopyGraphPayloadRegistry {
+  aclmdlRI model_ri;
+  std::vector<std::unique_ptr<CurrentKvIndexCopyPayload>> payloads;
+};
+
+std::mutex& current_kv_index_copy_graph_registry_mutex() {
+  static auto* mutex = new std::mutex();
+  return *mutex;
+}
+
+std::unordered_map<aclmdlRI, std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry>>&
+current_kv_index_copy_graph_registries() {
+  static auto* registries =
+      new std::unordered_map<aclmdlRI, std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry>>();
+  return *registries;
+}
+
+void delete_current_kv_index_copy_graph_payloads(void* args) noexcept {
+  auto* registry = static_cast<CurrentKvIndexCopyGraphPayloadRegistry*>(args);
+  std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry> owned_registry;
+  {
+    std::lock_guard<std::mutex> lock(current_kv_index_copy_graph_registry_mutex());
+    auto& registries = current_kv_index_copy_graph_registries();
+    const auto it = registries.find(registry->model_ri);
+    if (it != registries.end() && it->second.get() == registry) {
+      owned_registry = std::move(it->second);
+      registries.erase(it);
+    }
+  }
+}
+
+CurrentKvIndexCopyPayload* retain_current_kv_index_copy_graph_payload(
+    aclmdlRI model_ri, std::unique_ptr<CurrentKvIndexCopyPayload> payload) {
+  auto* raw_payload = payload.get();
+  std::lock_guard<std::mutex> lock(current_kv_index_copy_graph_registry_mutex());
+  auto& registries = current_kv_index_copy_graph_registries();
+  auto it = registries.find(model_ri);
+  if (it == registries.end()) {
+    auto registry = std::make_unique<CurrentKvIndexCopyGraphPayloadRegistry>();
+    registry->model_ri = model_ri;
+    auto* raw_registry = registry.get();
+    it = registries.emplace(model_ri, std::move(registry)).first;
+    const aclError register_ret =
+        aclmdlRIDestroyRegisterCallback(model_ri, delete_current_kv_index_copy_graph_payloads, raw_registry);
+    if (register_ret != ACL_SUCCESS) {
+      registries.erase(it);
+    }
+    TORCH_CHECK(register_ret == ACL_SUCCESS,
+                "failed to bind current KV index_copy payload registry to graph lifetime, error code: ",
+                register_ret);
+  }
+  it->second->payloads.push_back(std::move(payload));
+  return raw_payload;
+}
+
+void current_kv_index_copy_descriptor_callback(void* args) noexcept {
+  auto* payload = static_cast<CurrentKvIndexCopyPayload*>(args);
+  build_current_kv_index_copy_descriptors(payload);
+  if (payload->delete_after_run) {
+    delete payload;
+  }
+}
+
+void enqueue_current_kv_index_copy_descriptors(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  auto payload = make_current_kv_index_copy_payload(slot_mapping, num_actual_tokens, max_num_tokens, num_host_slots,
+                                                    src_idx_buffer, dst_idx_buffer, count_buffer);
+  const auto stream = c10_npu::getCurrentNPUStream().stream();
+  aclmdlRICaptureStatus capture_status = ACL_MODEL_RI_CAPTURE_STATUS_NONE;
+  aclmdlRI model_ri = nullptr;
+  const aclError capture_ret = aclmdlRICaptureGetInfo(stream, &capture_status, &model_ri);
+  TORCH_CHECK(capture_ret == ACL_SUCCESS,
+              "aclmdlRICaptureGetInfo for current KV index_copy descriptors failed, error code: ", capture_ret);
+  TORCH_CHECK(capture_status != ACL_MODEL_RI_CAPTURE_STATUS_INVALIDATED,
+              "current KV index_copy descriptors cannot enqueue on an invalidated graph capture");
+  const bool graph_lifetime = capture_status == ACL_MODEL_RI_CAPTURE_STATUS_ACTIVE;
+  TORCH_CHECK(!graph_lifetime || model_ri != nullptr, "active graph capture returned a null model runtime instance");
+
+  payload->delete_after_run = !graph_lifetime;
+  auto* raw_payload = payload.get();
+  if (graph_lifetime) {
+    raw_payload = retain_current_kv_index_copy_graph_payload(model_ri, std::move(payload));
+  }
+  const aclError ret = aclrtLaunchHostFunc(stream, current_kv_index_copy_descriptor_callback, raw_payload);
+  if (ret == ACL_SUCCESS && !graph_lifetime) {
+    payload.release();
+  }
+  TORCH_CHECK(ret == ACL_SUCCESS, "aclrtLaunchHostFunc for current KV index_copy descriptors failed, error code: ",
+              ret);
+}
+
 struct LruResidentCompactWithPlanPayload {
   uintptr_t req_ids_ptr;
   uintptr_t last_req_ids_ptr;
@@ -2960,6 +3134,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
                  auto options = torch::TensorOptions().dtype(torch::kInt16).device(torch::kCPU);
                  return at::from_blob(reinterpret_cast<void*>(ptr_val), shape, options);
              });
+
+    ops.def("sparse_kv_compute_current_kv_index_copy_descriptors(Tensor slot_mapping, int num_actual_tokens, "
+            "int max_num_tokens, int num_host_slots, Tensor(a!) src_idx_buffer, Tensor(b!) dst_idx_buffer, "
+            "Tensor(c!) count_buffer) -> int");
+    ops.impl("sparse_kv_compute_current_kv_index_copy_descriptors", torch::kCPU,
+             &vllm_ascend::compute_current_kv_index_copy_descriptors);
+
+    ops.def("sparse_kv_enqueue_current_kv_index_copy_descriptors(Tensor slot_mapping, int num_actual_tokens, "
+            "int max_num_tokens, int num_host_slots, Tensor(a!) src_idx_buffer, Tensor(b!) dst_idx_buffer, "
+            "Tensor(c!) count_buffer) -> ()");
+    ops.impl("sparse_kv_enqueue_current_kv_index_copy_descriptors", torch::kCPU,
+             &vllm_ascend::enqueue_current_kv_index_copy_descriptors);
 #endif
 
     ops.def("device_print(str msg) -> ()");

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,9 @@ disable_error_code = annotation-unchecked
 [mypy-torch_npu.*]
 ignore_missing_imports = True
 
+[mypy-mooncake.*]
+ignore_missing_imports = True
+
 [mypy-npugraph_ex.*]
 ignore_missing_imports = True
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
@@ -29,6 +29,8 @@ def _load_sparse_kv_ops():
         "sparse_kv_compute_lru_resident_addrs",
         "sparse_kv_restore_bfloat16_tensor",
         "sparse_kv_restore_int16_tensor",
+        "sparse_kv_compute_current_kv_index_copy_descriptors",
+        "sparse_kv_enqueue_current_kv_index_copy_descriptors",
     }
     missing = [name for name in required if not hasattr(torch.ops._C_ascend, name)]
     if missing:
@@ -144,6 +146,79 @@ def test_sparse_kv_restore_tensor_views(sparse_kv_ops):
     assert int16_view.data_ptr() == int16.data_ptr()
     assert bf16_view.dtype == torch.bfloat16
     assert int16_view.dtype == torch.int16
+
+
+def test_current_kv_index_copy_descriptors_pad_last_valid(sparse_kv_ops):
+    slot_mapping = torch.tensor([7, -1, 3, 99], dtype=torch.int64)
+    max_num_tokens = 6
+    src_idx = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+    dst_idx = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+    count = torch.zeros(1, dtype=torch.int32)
+
+    result = sparse_kv_ops.sparse_kv_compute_current_kv_index_copy_descriptors(
+        slot_mapping,
+        4,
+        max_num_tokens,
+        16,
+        src_idx,
+        dst_idx,
+        count,
+    )
+
+    assert result == 2
+    assert count.tolist() == [2]
+    assert src_idx.tolist() == [0, 2, 2, 2, 2, 2]
+    assert dst_idx.tolist() == [7, 3, 3, 3, 3, 3]
+
+
+def test_current_kv_index_copy_descriptors_survive_graph_replays(
+    sparse_kv_ops,
+):
+    if not torch_npu.npu.is_available():
+        pytest.skip("Ascend NPU is unavailable")
+
+    max_num_tokens = 4
+    slot_mapping = torch.zeros(max_num_tokens, dtype=torch.int64)
+    src_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
+    dst_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
+    count = torch.zeros(1, dtype=torch.int32)
+    side_stream_marker = torch.zeros(1, device="npu")
+    graph = torch.npu.NPUGraph()
+    current_stream = torch_npu.npu.current_stream()
+    save_stream = torch_npu.npu.Stream()
+    try:
+        with torch.npu.graph(graph):
+            sparse_kv_ops.sparse_kv_enqueue_current_kv_index_copy_descriptors(
+                slot_mapping,
+                max_num_tokens,
+                max_num_tokens,
+                16,
+                src_idx,
+                dst_idx,
+                count,
+            )
+            descriptors_ready = current_stream.record_event()
+            with torch_npu.npu.stream(save_stream):
+                save_stream.wait_event(descriptors_ready)
+            current_stream.wait_stream(save_stream)
+        torch_npu.npu.synchronize()
+
+        slot_mapping.copy_(torch.tensor([7, -1, 3, 99]))
+        graph.replay()
+        torch_npu.npu.synchronize()
+        assert count.tolist() == [2]
+        assert src_idx.tolist() == [0, 2, 2, 2]
+        assert dst_idx.tolist() == [7, 3, 3, 3]
+
+        slot_mapping.copy_(torch.tensor([5, 4, 3, 2]))
+        graph.replay()
+        torch_npu.npu.synchronize()
+        assert count.tolist() == [4]
+        assert src_idx.tolist() == [0, 1, 2, 3]
+        assert dst_idx.tolist() == [5, 4, 3, 2]
+    finally:
+        graph.reset()
+        torch_npu.npu.synchronize()
 
 
 def test_sparse_kv_compute_lru_resident_addrs(sparse_kv_ops):

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -231,6 +231,7 @@ def test_fused_overlap_external_plan_passes_raw_topk_and_full_selection_state():
         _get_offload_layer_id=lambda _: 0,
         get_fused_overlap_cpu_kv_inputs=lambda _: (full_kv_cpu, full_rope_cpu),
         allocate_fused_overlap_membership_map=allocate_membership,
+        is_fused_membership_storage=lambda tensor: tensor.dtype == torch.int16,
         prepare_fused_overlap_external_plan=prepare_plan,
         inject_current_kv_into_selection=inject_current,
         wait_for_current_kv_writeback=wait_for_writeback,

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -936,6 +936,21 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(mock_logger_info.call_count, 2)
 
     @patch(
+        "vllm_ascend.cpu_binding.envs.VLLM_ASCEND_SKIP_MIGRATEPAGES",
+        True,
+    )
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_bind_memory_skips_when_configured(
+        self,
+        mock_execute_command,
+    ):
+        cpu_alloc = make_cpu_alloc()
+
+        cpu_alloc.bind_memory("999", 0)
+
+        mock_execute_command.assert_not_called()
+
+    @patch(
         "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
     )
     @patch("vllm_ascend.cpu_binding.logger.info")

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -1,0 +1,231 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
+    mooncake_host_pool as host_pool_module,
+)
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
+    HostPoolTopology,
+    MooncakeHostPool,
+)
+
+
+class TestMooncakeHostPool(unittest.TestCase):
+
+    def _allocate_region_for_mode(self, *, host_register: bool) -> HostMemoryRegion:
+        raw = MagicMock()
+        raw.reshape.return_value = raw
+        raw.data_ptr.return_value = 0x1000
+        aligned = MagicMock()
+        aligned.device = SimpleNamespace(type="npu")
+        raw.narrow.return_value = aligned
+        segment = MagicMock()
+        segment.tensors.return_value = [raw]
+
+        with (
+            patch.object(
+                host_pool_module,
+                "_select_shared_segment_mode",
+                return_value=(host_register, host_register),
+            ),
+            patch(
+                "mooncake.shared_segment.create_shared_segment",
+                return_value=segment,
+            ),
+        ):
+            return host_pool_module.allocate_mooncake_host_region(
+                size_bytes=32,
+                alignment=16,
+                topology=HostPoolTopology(tp_rank=0, tp_size=1),
+            )
+
+    def test_allocates_aligned_views_from_one_region(self):
+        raw = torch.empty(256, dtype=torch.int8)
+        pool = MooncakeHostPool(
+            HostMemoryRegion(raw),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+
+        first, second = pool.allocate_tensors([17, 23], alignment=32)
+
+        self.assertEqual(first.numel(), 17)
+        self.assertEqual(second.numel(), 23)
+        self.assertEqual(first.data_ptr() % 32, 0)
+        self.assertEqual(second.data_ptr() % 32, 0)
+        self.assertGreaterEqual(second.data_ptr(), first.data_ptr() + first.numel())
+        self.assertEqual(first.untyped_storage().data_ptr(), raw.untyped_storage().data_ptr())
+        self.assertEqual(second.untyped_storage().data_ptr(), raw.untyped_storage().data_ptr())
+
+    def test_exhausted_pool_is_rejected(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(32, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+
+        with self.assertRaisesRegex(MemoryError, "exhausted"):
+            pool.allocate_tensors([64], alignment=16)
+
+    def test_only_owner_registers_and_unregisters_region(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(
+                torch.empty(64, dtype=torch.int8),
+                register_location="npu:0",
+            ),
+            HostPoolTopology(tp_rank=0, tp_size=2, owner_rank=0),
+        )
+        engine = MagicMock()
+        engine.register_memory.return_value = 0
+        engine.unregister_memory.return_value = 0
+
+        pool.register(engine)
+        pool.register(engine)
+        pool.unregister()
+
+        engine.register_memory.assert_called_once_with(
+            pool.data_ptr,
+            pool.nbytes,
+            location="npu:0",
+        )
+        engine.unregister_memory.assert_called_once_with(pool.data_ptr)
+
+    def test_register_without_location_uses_two_argument_api(self):
+        class TwoArgumentEngine:
+            def __init__(self):
+                self.calls = []
+
+            def register_memory(self, ptr, size):
+                self.calls.append(("register", ptr, size))
+                return 0
+
+            def unregister_memory(self, ptr):
+                self.calls.append(("unregister", ptr))
+                return 0
+
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+        engine = TwoArgumentEngine()
+
+        pool.register(engine)
+        pool.unregister()
+
+        self.assertEqual(
+            engine.calls,
+            [
+                ("register", pool.data_ptr, pool.nbytes),
+                ("unregister", pool.data_ptr),
+            ],
+        )
+
+
+    def test_non_owner_cannot_register_region(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=1, tp_size=2, owner_rank=0),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "only the owner rank"):
+            pool.register(MagicMock())
+
+    def test_region_preserves_requested_capacity_after_alignment(self):
+        requested_size = 32
+        alignment = 16
+        raw = MagicMock()
+        raw.reshape.return_value = raw
+        raw.data_ptr.return_value = 0x1001
+        aligned = MagicMock()
+        aligned.device = SimpleNamespace(type="npu")
+        aligned.numel.return_value = requested_size
+        raw.narrow.return_value = aligned
+        segment = MagicMock()
+        segment.tensors.return_value = [raw]
+
+        with (
+            patch.object(
+                host_pool_module,
+                "_select_shared_segment_mode",
+                return_value=(False, False),
+            ),
+            patch(
+                "mooncake.shared_segment.create_shared_segment",
+                return_value=segment,
+            ) as create_segment,
+        ):
+            region = host_pool_module.allocate_mooncake_host_region(
+                size_bytes=requested_size,
+                alignment=alignment,
+                topology=HostPoolTopology(
+                    tp_rank=0,
+                    tp_size=1,
+                    device_id=7,
+                ),
+            )
+
+        block = create_segment.call_args.kwargs["blocks"]["pool"]
+        self.assertEqual(block["shape"], (requested_size + alignment - 1,))
+        raw.narrow.assert_called_once_with(0, alignment - 1, requested_size)
+        self.assertIs(region.tensor, aligned)
+        self.assertEqual(region.tensor.numel(), requested_size)
+        self.assertEqual(region.register_location, "npu:7")
+
+    def test_host_register_sets_migratepages_guard(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(host_pool_module.os.environ, {}, clear=False):
+            host_pool_module.os.environ.pop(key, None)
+
+            self._allocate_region_for_mode(host_register=True)
+
+            self.assertEqual(host_pool_module.os.environ[key], "1")
+
+    def test_host_register_preserves_explicit_migratepages_setting(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(
+            host_pool_module.os.environ,
+            {key: "0"},
+            clear=False,
+        ):
+            self._allocate_region_for_mode(host_register=True)
+
+            self.assertEqual(host_pool_module.os.environ[key], "0")
+
+    def test_non_host_register_mode_does_not_set_migratepages_guard(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(host_pool_module.os.environ, {}, clear=False):
+            host_pool_module.os.environ.pop(key, None)
+
+            self._allocate_region_for_mode(host_register=False)
+
+            self.assertNotIn(key, host_pool_module.os.environ)
+    def test_failed_construction_releases_region(self):
+        release = MagicMock()
+        region = HostMemoryRegion(
+            torch.empty(8, dtype=torch.float32),
+            handle="segment",
+            release_callback=release,
+        )
+
+        with (
+            patch.object(
+                host_pool_module,
+                "allocate_mooncake_host_region",
+                return_value=region,
+            ),
+            self.assertRaisesRegex(TypeError, "int8 byte tensor"),
+        ):
+            MooncakeHostPool.allocate(
+                size_bytes=8,
+                alignment=8,
+                topology=HostPoolTopology(tp_rank=0, tp_size=1),
+            )
+
+        release.assert_called_once_with("segment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -76,68 +76,6 @@ class TestMooncakeHostPool(unittest.TestCase):
         with self.assertRaisesRegex(MemoryError, "exhausted"):
             pool.allocate_tensors([64], alignment=16)
 
-    def test_only_owner_registers_and_unregisters_region(self):
-        pool = MooncakeHostPool(
-            HostMemoryRegion(
-                torch.empty(64, dtype=torch.int8),
-                register_location="npu:0",
-            ),
-            HostPoolTopology(tp_rank=0, tp_size=2, owner_rank=0),
-        )
-        engine = MagicMock()
-        engine.register_memory.return_value = 0
-        engine.unregister_memory.return_value = 0
-
-        pool.register(engine)
-        pool.register(engine)
-        pool.unregister()
-
-        engine.register_memory.assert_called_once_with(
-            pool.data_ptr,
-            pool.nbytes,
-            location="npu:0",
-        )
-        engine.unregister_memory.assert_called_once_with(pool.data_ptr)
-
-    def test_register_without_location_uses_two_argument_api(self):
-        class TwoArgumentEngine:
-            def __init__(self):
-                self.calls = []
-
-            def register_memory(self, ptr, size):
-                self.calls.append(("register", ptr, size))
-                return 0
-
-            def unregister_memory(self, ptr):
-                self.calls.append(("unregister", ptr))
-                return 0
-
-        pool = MooncakeHostPool(
-            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
-            HostPoolTopology(tp_rank=0, tp_size=1),
-        )
-        engine = TwoArgumentEngine()
-
-        pool.register(engine)
-        pool.unregister()
-
-        self.assertEqual(
-            engine.calls,
-            [
-                ("register", pool.data_ptr, pool.nbytes),
-                ("unregister", pool.data_ptr),
-            ],
-        )
-
-    def test_non_owner_cannot_register_region(self):
-        pool = MooncakeHostPool(
-            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
-            HostPoolTopology(tp_rank=1, tp_size=2, owner_rank=0),
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "only the owner rank"):
-            pool.register(MagicMock())
-
     def test_region_preserves_requested_capacity_after_alignment(self):
         requested_size = 32
         alignment = 16
@@ -177,7 +115,6 @@ class TestMooncakeHostPool(unittest.TestCase):
         raw.narrow.assert_called_once_with(0, alignment - 1, requested_size)
         self.assertIs(region.tensor, aligned)
         self.assertEqual(region.tensor.numel(), requested_size)
-        self.assertEqual(region.register_location, "npu:7")
 
     def test_host_register_sets_migratepages_guard(self):
         key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
@@ -207,6 +144,19 @@ class TestMooncakeHostPool(unittest.TestCase):
             self._allocate_region_for_mode(host_register=False)
 
             self.assertNotIn(key, host_pool_module.os.environ)
+
+    def test_no_supported_mode_raises(self):
+        with (
+            patch(
+                "mooncake.shared_segment.shared_segment_supported",
+                return_value=False,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "cannot expose an NPU-addressable",
+            ),
+        ):
+            host_pool_module._select_shared_segment_mode()
 
     def test_failed_construction_releases_region(self):
         release = MagicMock()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -1,5 +1,8 @@
+import sys
+import types
 import unittest
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -7,16 +10,19 @@ import torch
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
     mooncake_host_pool as host_pool_module,
 )
-
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
     HostMemoryRegion,
     HostPoolTopology,
     MooncakeHostPool,
 )
 
+_shared_segment_stub: Any = types.ModuleType("mooncake.shared_segment")
+_shared_segment_stub.create_shared_segment = MagicMock()
+_shared_segment_stub.shared_segment_supported = MagicMock(return_value=True)
+sys.modules.setdefault("mooncake.shared_segment", _shared_segment_stub)
+
 
 class TestMooncakeHostPool(unittest.TestCase):
-
     def _allocate_region_for_mode(self, *, host_register: bool) -> HostMemoryRegion:
         raw = MagicMock()
         raw.reshape.return_value = raw
@@ -123,7 +129,6 @@ class TestMooncakeHostPool(unittest.TestCase):
             ],
         )
 
-
     def test_non_owner_cannot_register_region(self):
         pool = MooncakeHostPool(
             HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
@@ -202,6 +207,7 @@ class TestMooncakeHostPool(unittest.TestCase):
             self._allocate_region_for_mode(host_register=False)
 
             self.assertNotIn(key, host_pool_module.os.environ)
+
     def test_failed_construction_releases_region(self):
         release = MagicMock()
         region = HostMemoryRegion(

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -326,10 +326,14 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                     ),
                     patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
                 ):
-                    SparseKVOffloadManager(
+                    manager = SparseKVOffloadManager(
                         vllm_config,
                         kv_cache_config,
                         offload_config,
+                    )
+                    manager.prepare_host_kv_allocation(
+                        device_id=7,
+                        dp_rank=0,
                     )
 
                 initialized_config = offload_backend.initialize.call_args.args[0]
@@ -344,6 +348,52 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                 self.assertEqual(initialized_config.world_size, 2)
                 self.assertEqual(initialized_config.rank_id, rank)
                 tp_group.barrier.assert_called_once_with()
+
+    def test_layer_allocation_uses_backend_callback_on_non_owner_rank(self):
+        host_k = MagicMock()
+        host_v = MagicMock()
+        allocate_host = MagicMock(return_value=[host_k, host_v])
+
+        result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+            k_tensor_size=128,
+            v_tensor_size=64,
+            alignment=32,
+            tp_rank=1,
+            keep_device_kv_cache=False,
+            npu_kv_cache_allocate_func=MagicMock(),
+            host_kv_cache_allocate_func=allocate_host,
+        )
+
+        self.assertIs(result[2], host_k)
+        self.assertIs(result[3], host_v)
+        allocate_host.assert_called_once_with([128, 64], 32)
+
+    def test_manager_close_releases_host_allocator_once(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        allocator = MagicMock()
+        manager._host_kv_allocator = allocator
+
+        manager.close()
+        manager.close()
+
+        allocator.close.assert_called_once_with()
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_manager_close_retains_host_allocator_when_close_fails(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        allocator = MagicMock()
+        allocator.close.side_effect = [RuntimeError("close failed"), None]
+        manager._host_kv_allocator = allocator
+
+        with self.assertRaisesRegex(RuntimeError, "close failed"):
+            manager.close()
+
+        self.assertIs(manager._host_kv_allocator, allocator)
+
+        manager.close()
+
+        self.assertIsNone(manager._host_kv_allocator)
+        self.assertEqual(allocator.close.call_count, 2)
 
     def test_manager_rejects_pool_larger_than_dram_limit(self):
         vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -1,11 +1,18 @@
+import contextlib
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
     sparse_kv_offload_manager as manager_module,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
+    HostPoolTopology,
+    MooncakeHostPool,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     SparseKVOffloadManager,
@@ -54,6 +61,38 @@ def _make_memory_plan_inputs(max_num_seqs=2):
     vllm_config = SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs))
     alignment_reserve = 2 * manager_module._CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
     return specs, vllm_config, alignment_reserve
+
+
+def _make_manager_init_inputs(dram_size_per_dp_gb=1):
+    spec = _FakeKVCacheSpec(
+        page_size_bytes=1024,
+        max_blocks_per_request=100,
+        store_on_host=True,
+    )
+    kv_cache_config = SimpleNamespace(
+        num_blocks=200,
+        kv_cache_groups=[SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)],
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            get_num_layers=MagicMock(return_value=1),
+            max_model_len=128,
+        ),
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=1,
+            max_num_batched_tokens=1,
+        ),
+        speculative_config=None,
+    )
+    offload_config = SimpleNamespace(
+        topk_buffer_size=1,
+        topk=1,
+        use_fused_overlap=False,
+        host_backend="memfabric",
+        dram_size_per_dp_GB=dram_size_per_dp_gb,
+    )
+    return vllm_config, kv_cache_config, offload_config
 
 
 class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
@@ -245,38 +284,8 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "host-resident"):
             get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config)
 
-    def _make_manager_init_inputs(self, dram_size_per_dp_gb=1):
-        spec = _FakeKVCacheSpec(
-            page_size_bytes=1024,
-            max_blocks_per_request=100,
-            store_on_host=True,
-        )
-        kv_cache_config = SimpleNamespace(
-            num_blocks=200,
-            kv_cache_groups=[SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)],
-        )
-        vllm_config = SimpleNamespace(
-            model_config=SimpleNamespace(
-                get_num_layers=MagicMock(return_value=1),
-                max_model_len=128,
-            ),
-            parallel_config=SimpleNamespace(),
-            scheduler_config=SimpleNamespace(
-                max_num_seqs=1,
-                max_num_batched_tokens=1,
-            ),
-            speculative_config=None,
-        )
-        offload_config = SimpleNamespace(
-            topk_buffer_size=1,
-            topk=1,
-            use_fused_overlap=False,
-            dram_size_per_dp_GB=dram_size_per_dp_gb,
-        )
-        return vllm_config, kv_cache_config, offload_config
-
     def test_manager_initializes_offload_with_planned_pool_size(self):
-        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         planned_pool_size = 4096
         for rank, expected_alloc_size in ((0, planned_pool_size), (1, 0)):
             with self.subTest(rank=rank):
@@ -368,6 +377,72 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertIs(result[3], host_v)
         allocate_host.assert_called_once_with([128, 64], 32)
 
+    def test_manager_prepares_mooncake_host_pool(self):
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
+        offload_config.host_backend = "mooncake"
+        planned_pool_size = 4096
+        allocator = MagicMock()
+        tp_group = SimpleNamespace(barrier=MagicMock())
+
+        with (
+            patch.object(manager_module, "get_tensor_model_parallel_rank", return_value=1),
+            patch.object(manager_module, "get_tensor_model_parallel_world_size", return_value=2),
+            patch.object(manager_module, "get_tp_group", return_value=tp_group),
+            patch.object(
+                manager_module,
+                "get_sparse_kv_offload_cpu_pool_size_bytes",
+                return_value=planned_pool_size,
+            ),
+            patch.object(
+                manager_module.MooncakeHostPool,
+                "allocate",
+                return_value=allocator,
+            ) as allocate_pool,
+            patch.object(manager_module.torch, "zeros", return_value=MagicMock()),
+            patch.object(manager_module.torch, "empty", return_value=MagicMock()),
+            patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
+        ):
+            manager = SparseKVOffloadManager(vllm_config, kv_cache_config, offload_config)
+            manager.prepare_host_kv_allocation(device_id=7, dp_rank=3)
+
+        self.assertIs(manager._host_kv_allocator, allocator)
+        self.assertTrue(manager._host_allocation_prepared)
+        allocate_pool.assert_called_once()
+        call = allocate_pool.call_args
+        self.assertEqual(call.kwargs["size_bytes"], planned_pool_size)
+        self.assertEqual(call.kwargs["alignment"], manager_module._CPU_CACHE_ALIGNMENT)
+        topology = call.kwargs["topology"]
+        self.assertEqual(topology.tp_rank, 1)
+        self.assertEqual(topology.tp_size, 2)
+        self.assertEqual(topology.owner_rank, 0)
+        self.assertEqual(topology.device_id, 7)
+        self.assertEqual(topology.dp_rank, 3)
+        self.assertIs(topology.tp_group, tp_group)
+        tp_group.barrier.assert_not_called()
+
+    def test_failed_mooncake_prepare_remains_retryable(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "mooncake"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        with (
+            patch.object(
+                manager_module.MooncakeHostPool,
+                "allocate",
+                side_effect=RuntimeError("allocation failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "allocation failed"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        self.assertFalse(manager._host_allocation_prepared)
+        self.assertIsNone(manager._host_kv_allocator)
+
     def test_manager_close_releases_host_allocator_once(self):
         manager = object.__new__(SparseKVOffloadManager)
         allocator = MagicMock()
@@ -396,7 +471,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertEqual(allocator.close.call_count, 2)
 
     def test_manager_rejects_pool_larger_than_dram_limit(self):
-        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         offload_backend = SimpleNamespace(
             OffloadConfig=MagicMock(),
             Scene=SimpleNamespace(SHARED="shared"),
@@ -438,6 +513,348 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
 
         offload_backend.OffloadConfig.assert_not_called()
         offload_backend.initialize.assert_not_called()
+
+
+class TestMemFabricHostKVAllocator(unittest.TestCase):
+    def test_owner_rank_delegates_to_empty_aligned_helper(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=0)
+        k, v = MagicMock(), MagicMock()
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors", return_value=[k, v]) as helper:
+            tensors = allocator.allocate_tensors([128, 64], alignment=32)
+        helper.assert_called_once_with([128, 64], 32)
+        self.assertEqual(tensors, [k, v])
+
+    def test_non_owner_rank_returns_none_views_without_allocation(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=1)
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors") as helper:
+            tensors = allocator.allocate_tensors([128, 64], alignment=32)
+        helper.assert_not_called()
+        self.assertEqual(tensors, [None, None])
+
+    def test_close_is_noop_and_idempotent(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=0)
+        allocator.close()
+        allocator.close()  # 不抛异常即可；MemFabric 池由 offload 运行时托管
+
+
+class TestHostBackendSelection(unittest.TestCase):
+    def test_manager_prepares_memfabric_host_allocator(self):
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
+        planned_pool_size = 4096
+        tp_group = SimpleNamespace(barrier=MagicMock())
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=0),
+        )
+
+        with (
+            patch.object(manager_module, "get_tensor_model_parallel_rank", return_value=0),
+            patch.object(manager_module, "get_tensor_model_parallel_world_size", return_value=2),
+            patch.object(manager_module, "get_tp_group", return_value=tp_group),
+            patch.object(
+                manager_module,
+                "get_sparse_kv_offload_cpu_pool_size_bytes",
+                return_value=planned_pool_size,
+            ),
+            patch.object(manager_module, "offload", offload_backend, create=True),
+            patch.object(manager_module.torch, "zeros", return_value=MagicMock()),
+            patch.object(manager_module.torch, "empty", return_value=MagicMock()),
+            patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
+        ):
+            manager = SparseKVOffloadManager(vllm_config, kv_cache_config, offload_config)
+            manager.prepare_host_kv_allocation(device_id=7, dp_rank=0)
+
+        self.assertIsInstance(manager._host_kv_allocator, manager_module.MemFabricHostKVAllocator)
+        self.assertTrue(manager._host_allocation_prepared)
+        tp_group.barrier.assert_called_once_with()
+
+    def test_failed_memfabric_prepare_remains_retryable(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "memfabric"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=1),  # 触发 assert
+        )
+        with (
+            patch.object(manager_module, "offload", offload_backend, create=True),
+            self.assertRaisesRegex(AssertionError, "offload.initialize failed"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        self.assertFalse(manager._host_allocation_prepared)
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_prepare_is_idempotent_across_backends(self):
+        # mooncake
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "mooncake"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+        with patch.object(manager_module.MooncakeHostPool, "allocate", return_value=MagicMock()) as allocate_pool:
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+        allocate_pool.assert_called_once()
+
+        # memfabric
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "memfabric"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=0),
+        )
+        with patch.object(manager_module, "offload", offload_backend, create=True):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+        offload_backend.initialize.assert_called_once()
+
+    def test_prepare_rejects_unknown_host_backend(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "rdma"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        with (
+            patch.object(manager_module.MooncakeHostPool, "allocate") as allocate_pool,
+            patch.object(manager_module, "offload", MagicMock(), create=True) as offload_backend,
+            self.assertRaisesRegex(ValueError, "Unsupported sparse KV offload Host backend"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        allocate_pool.assert_not_called()
+        offload_backend.initialize.assert_not_called()
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_allocate_host_kv_tensors_raises_before_prepare(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = None
+
+        with self.assertRaisesRegex(RuntimeError, "prepare_host_kv_allocation must run"):
+            manager.allocate_host_kv_tensors([128, 64], 32)
+
+    def test_allocate_host_kv_tensors_delegates_to_allocator(self):
+        mooncake = MagicMock()
+        mooncake.allocate_tensors.return_value = [MagicMock()]
+        cases = [
+            ("mooncake", mooncake),
+            ("memfabric_rank0", manager_module.MemFabricHostKVAllocator(0)),
+            ("memfabric_rank1", manager_module.MemFabricHostKVAllocator(1)),
+        ]
+        for name, allocator in cases:
+            with self.subTest(name=name):
+                manager = object.__new__(SparseKVOffloadManager)
+                manager._host_kv_allocator = allocator
+                with patch.object(
+                    manager_module,
+                    "empty_aligned_int8_cpu_tensors",
+                    return_value=[MagicMock(), MagicMock()],
+                ) as helper:
+                    tensors = manager.allocate_host_kv_tensors([128, 64], 32)
+                if name == "mooncake":
+                    self.assertIs(tensors, mooncake.allocate_tensors.return_value)
+                    helper.assert_not_called()
+                elif name == "memfabric_rank0":
+                    self.assertIs(tensors, helper.return_value)
+                else:
+                    self.assertEqual(tensors, [None, None])
+                    helper.assert_not_called()
+
+    def test_close_releases_mooncake_region_via_manager(self):
+        release_callback = MagicMock()
+        pool = MooncakeHostPool(
+            HostMemoryRegion(
+                torch.empty(64, dtype=torch.int8),
+                handle="segment",
+                release_callback=release_callback,
+            ),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = pool
+
+        manager.close()
+
+        release_callback.assert_called_once_with("segment")
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_close_memfabric_allocator_is_noop(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = manager_module.MemFabricHostKVAllocator(0)
+
+        manager.close()
+
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_layer_allocation_none_cpu_on_memfabric_non_owner(self):
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors") as helper:
+            result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+                k_tensor_size=128,
+                v_tensor_size=64,
+                alignment=32,
+                tp_rank=1,
+                keep_device_kv_cache=False,
+                npu_kv_cache_allocate_func=MagicMock(),
+                host_kv_cache_allocate_func=manager_module.MemFabricHostKVAllocator(1).allocate_tensors,
+            )
+        helper.assert_not_called()
+        self.assertIsNone(result[2])
+        self.assertIsNone(result[3])
+
+    def test_layer_allocation_cpu_on_memfabric_owner(self):
+        k_cpu, v_cpu = MagicMock(), MagicMock()
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors", return_value=[k_cpu, v_cpu]) as helper:
+            result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+                k_tensor_size=128,
+                v_tensor_size=64,
+                alignment=32,
+                tp_rank=0,
+                keep_device_kv_cache=False,
+                npu_kv_cache_allocate_func=MagicMock(),
+                host_kv_cache_allocate_func=manager_module.MemFabricHostKVAllocator(0).allocate_tensors,
+            )
+        helper.assert_called_once_with([128, 64], 32)
+        self.assertIs(result[2], k_cpu)
+        self.assertIs(result[3], v_cpu)
+
+    def test_both_allocators_satisfy_hostkvallocator_contract(self):
+        for cls in (
+            manager_module.MooncakeHostPool,
+            manager_module.MemFabricHostKVAllocator,
+        ):
+            with self.subTest(cls=cls):
+                self.assertTrue(hasattr(cls, "allocate_tensors"))
+                self.assertTrue(hasattr(cls, "close"))
+
+
+def _shape_aware_tensor_fake(*args, **kwargs):
+    """最小 torch.Tensor 替身：切片/视图/形状断言全部自洽。"""
+    fake = MagicMock()
+    shape = args[0] if args else kwargs.get("shape", [])
+    if isinstance(shape, int):  # torch.arange(n, ...) 场景
+        shape = [shape]
+    fake.shape = torch.Size(shape)
+    fake._itemsize = getattr(kwargs.get("dtype", torch.int8), "itemsize", 1)
+
+    def _view(*view_args):
+        # .view(dtype): 按元素大小换算第一维；.view(shape...): 直接复用自身。
+        dtype = view_args[0] if view_args else None
+        itemsize = getattr(dtype, "itemsize", 0)
+        if not itemsize:
+            return fake
+        new_shape = list(fake.shape)
+        if new_shape:
+            new_shape[0] = new_shape[0] * fake._itemsize // itemsize
+        return _shape_aware_tensor_fake(new_shape, dtype=dtype)
+
+    def _getitem(key):
+        if not isinstance(key, slice):
+            return fake
+        start = key.start or 0
+        stop = key.stop if key.stop is not None else (fake.shape[0] if fake.shape else 0)
+        new_shape = list(fake.shape)
+        if new_shape:
+            new_shape[0] = stop - start
+        return _shape_aware_tensor_fake(new_shape, dtype=fake.dtype)
+
+    fake.view.side_effect = _view
+    fake.__getitem__.side_effect = _getitem
+    fake.repeat.return_value = fake
+    fake.pin_memory.return_value = fake
+    fake.copy_.return_value = fake
+    fake.item.return_value = 0xFEED
+    fake.data_ptr.return_value = 0x1000
+    fake.numel.return_value = 4096
+    fake.element_size.return_value = 1
+    fake.size.side_effect = lambda dim: fake.shape[dim]
+    fake.dtype = kwargs.get("dtype", torch.int8)
+    fake.device = kwargs.get("device", "cpu")
+    return fake
+
+
+class TestRegisterKvCachesBackendBranch(unittest.TestCase):
+    @staticmethod
+    def _make_register_caches_manager(host_backend, k_cpu, v_cpu):
+        topk = _shape_aware_tensor_fake([1, 1])  # size(-2)==1, size(-1)==1
+        topk.dtype = torch.bfloat16
+        topk.device = "npu"
+        kv_caches = {"host.0": (MagicMock(), MagicMock(), k_cpu, v_cpu, topk, topk)}
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = host_backend
+        manager._host_kv_allocator = None  # 分支只看配置，与 allocator 实例无关
+        manager._register_offload_layers = MagicMock()
+        manager.offload_layer_names = ["host.0"]
+        manager.num_layers = 1
+        manager.tp_size = 2
+        manager.kv_cache_config = SimpleNamespace(num_blocks=8)
+        manager.block_size = 128
+        manager.topk_buffer_size = 256
+        manager.topk = 8
+        manager.max_num_tokens = 4
+        manager.max_num_topk_rows = 4
+        manager.max_model_len = 1024
+        manager.use_fused_overlap = False
+        manager.tp_rank = 1
+        manager.tp_group = MagicMock()
+        return manager, kv_caches
+
+    @staticmethod
+    def _patch_torch_factories() -> contextlib.ExitStack:
+        stack = contextlib.ExitStack()
+        for factory in ("zeros", "empty", "full", "arange"):
+            stack.enter_context(
+                patch.object(
+                    manager_module.torch,
+                    factory,
+                    side_effect=_shape_aware_tensor_fake,
+                )
+            )
+        return stack
+
+    def test_register_kv_caches_uses_local_views_with_mooncake_backend(self):
+        k_cpu = _shape_aware_tensor_fake([64])
+        v_cpu = _shape_aware_tensor_fake([64])
+        manager, kv_caches = self._make_register_caches_manager("mooncake", k_cpu, v_cpu)
+
+        with self._patch_torch_factories():
+            manager.register_kv_caches(kv_caches)
+
+        manager.tp_group.broadcast.assert_not_called()
+        self.assertEqual(len(manager.k_caches_cpu), 1)
+        self.assertEqual(manager.gvas_k_bases, [k_cpu.data_ptr()])
+        self.assertEqual(manager.gvas_v_bases, [v_cpu.data_ptr()])
+
+    def test_register_kv_caches_broadcasts_with_memfabric_backend(self):
+        manager, kv_caches = self._make_register_caches_manager("memfabric", None, None)
+
+        with self._patch_torch_factories():
+            manager.register_kv_caches(kv_caches)
+
+        self.assertEqual(manager.tp_group.broadcast.call_count, 5)
+        self.assertEqual(manager.k_caches_cpu, [])
+        self.assertEqual(len(manager.gvas_k_bases), 1)
 
 
 if __name__ == "__main__":

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -470,6 +470,38 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertIsNone(manager._host_kv_allocator)
         self.assertEqual(allocator.close.call_count, 2)
 
+    def test_manager_close_retries_membership_region_release(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        region = MagicMock()
+        region.release.side_effect = [
+            RuntimeError("release failed"),
+            None,
+        ]
+        membership = MagicMock()
+        planner = MagicMock()
+        device_staging = MagicMock()
+        manager.fused_overlap_membership_region = region
+        manager.fused_overlap_membership_map = membership
+        manager.fused_overlap_planner_membership_map = planner
+        manager.fused_overlap_membership_plan_device_staging = device_staging
+        manager._host_kv_allocator = None
+
+        with self.assertRaisesRegex(RuntimeError, "release failed"):
+            manager.close()
+
+        self.assertIs(manager.fused_overlap_membership_region, region)
+        self.assertIs(manager.fused_overlap_membership_map, membership)
+
+        manager.close()
+
+        self.assertIsNone(manager.fused_overlap_membership_region)
+        self.assertIsNone(manager.fused_overlap_membership_map)
+        self.assertIsNone(manager.fused_overlap_planner_membership_map)
+        self.assertIsNone(
+            manager.fused_overlap_membership_plan_device_staging
+        )
+        self.assertEqual(region.release.call_count, 2)
+
     def test_manager_rejects_pool_larger_than_dram_limit(self):
         vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         offload_backend = SimpleNamespace(

--- a/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
@@ -12,6 +12,9 @@ pytest.importorskip("memfabric_hybrid")
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (  # noqa: E402
     sparse_kv_offload_manager as manager_module,
 )
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (  # noqa: E402
+    MooncakeHostPool,
+)
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (  # noqa: E402
     FSA_EXTERNAL_PLAN_READY_MARKER,
     FSA_PAIRED_SELECTION_COPY_MARKER,
@@ -57,6 +60,10 @@ def _make_plan_manager():
     manager.current_kv_by_layer = {}
     manager.fused_overlap_membership_map = None
     manager.fused_overlap_membership_map_rows = 0
+    manager.fused_overlap_membership_region = None
+    manager.fused_overlap_planner_membership_map = None
+    manager.fused_overlap_membership_plan_device_staging = None
+    manager._host_kv_allocator = None
     manager.fused_overlap_plan_owner_layer_id = None
     manager.fused_overlap_plan_topk = None
     manager.fused_overlap_plan_num_tokens = 0
@@ -157,6 +164,194 @@ def test_mapped_membership_allocation_initializes_external_plan_control():
     assert control[:, 7].tolist() == [FSA_PAIRED_SELECTION_COPY_MARKER] * 3
     manager.tp_group.broadcast.assert_called_once()
     manager.tp_group.barrier.assert_called_once_with()
+
+
+def _enable_mooncake_membership_staging(manager):
+    allocator = object.__new__(MooncakeHostPool)
+    allocator.topology = SimpleNamespace()
+    manager._host_kv_allocator = allocator
+    return allocator
+
+
+def test_mooncake_membership_uses_compact_cpu_and_npu_staging():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.use_fused_overlap = True
+    manager.topk = 2048
+    manager.tp_rank = 0
+    manager.tp_group = MagicMock()
+    manager.fused_overlap_membership_map = None
+    manager.fused_overlap_membership_map_rows = 0
+    manager.fused_overlap_membership_region = None
+    manager.fused_overlap_planner_membership_map = None
+    manager.fused_overlap_membership_plan_device_staging = None
+    _enable_mooncake_membership_staging(manager)
+    region = SimpleNamespace(
+        tensor=torch.empty(
+            3 * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT * 2,
+            dtype=torch.int8,
+        ),
+        release=MagicMock(),
+    )
+    synchronization_order = []
+    manager.tp_group.barrier.side_effect = (
+        lambda: synchronization_order.append("barrier")
+    )
+    current_stream = MagicMock()
+    current_stream.synchronize.side_effect = (
+        lambda: synchronization_order.append("stream_sync")
+    )
+
+    with (
+        patch.object(
+            manager_module,
+            "allocate_mooncake_host_region",
+            return_value=region,
+        ) as allocate,
+        patch.object(
+            manager_module.torch_npu.npu,
+            "current_stream",
+            return_value=current_stream,
+        ),
+    ):
+        membership = manager.allocate_fused_overlap_membership_map(3)
+
+    planner = manager.fused_overlap_planner_membership_map
+    device_staging = manager.fused_overlap_membership_plan_device_staging
+    plan_shape = (
+        3,
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+    )
+    assert membership.shape == (
+        3,
+        FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT,
+    )
+    assert planner is not None
+    assert planner.shape == plan_shape
+    assert planner.is_contiguous()
+    assert planner.stride() == (plan_shape[1], 1)
+    assert device_staging is not None
+    assert device_staging.shape == plan_shape
+    assert device_staging.is_contiguous()
+    assert membership.data_ptr() != planner.data_ptr()
+    assert device_staging.data_ptr() != planner.data_ptr()
+    assert device_staging.data_ptr() != membership.data_ptr()
+    allocate.assert_called_once()
+    current_stream.synchronize.assert_called_once_with()
+    manager.tp_group.barrier.assert_called_once_with()
+    assert synchronization_order == ["stream_sync", "barrier"]
+
+
+def test_mooncake_eager_external_plan_publishes_through_npu_staging():
+    manager = _make_plan_manager()
+    _enable_mooncake_membership_staging(manager)
+    membership = torch.full(
+        (4, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT),
+        -1,
+        dtype=torch.int16,
+    )
+    plan_width = (
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+    )
+    planner_membership = torch.full(
+        (4, plan_width),
+        7,
+        dtype=torch.int16,
+    )
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = planner_membership
+    manager.fused_overlap_membership_plan_device_staging = torch.empty(
+        (4, plan_width),
+        dtype=torch.int16,
+    )
+    sparse_kv_ops = _make_sparse_kv_ops()
+
+    with patch.object(
+        manager_module,
+        "_sparse_kv_ops",
+        return_value=sparse_kv_ops,
+    ):
+        assert manager.prepare_fused_overlap_external_plan(
+            layer_name="layer.0",
+            num_tokens=2,
+            topk_indices_npu=torch.tensor(
+                [[1, 2, 3, 4], [4, 3, 2, 1]],
+                dtype=torch.int32,
+            ),
+            req_ids_npu=torch.tensor([101, 202], dtype=torch.int64),
+            stable_prefix_lens_npu=torch.tensor(
+                [10, 20], dtype=torch.int32
+            ),
+            visible_seq_lens_npu=torch.tensor(
+                [11, 21], dtype=torch.int32
+            ),
+            selection_membership_map=membership,
+            capturing=False,
+        )
+
+    plan_start = (
+        FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - manager.topk
+    )
+    plan_end = plan_start + plan_width
+    torch.testing.assert_close(
+        membership[:2, plan_start:plan_end],
+        planner_membership[:2],
+    )
+    torch.testing.assert_close(
+        manager.fused_overlap_membership_plan_device_staging[:2],
+        planner_membership[:2],
+    )
+    planner = (
+        sparse_kv_ops
+        .sparse_kv_lru_resident_compact_with_plan_stable_rows
+    )
+    assert planner.call_args.args[17] == planner_membership[:2].data_ptr()
+    assert planner.call_args.args[18] == plan_width
+
+
+def test_non_tp0_mooncake_plan_does_not_require_cpu_planner_storage():
+    manager = _make_plan_manager()
+    manager.tp_rank = 1
+    _enable_mooncake_membership_staging(manager)
+    membership = torch.full(
+        (4, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT),
+        -1,
+        dtype=torch.int16,
+    )
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = None
+    sparse_kv_ops = _make_sparse_kv_ops()
+
+    with patch.object(
+        manager_module,
+        "_sparse_kv_ops",
+        return_value=sparse_kv_ops,
+    ):
+        assert manager.prepare_fused_overlap_external_plan(
+            layer_name="layer.0",
+            num_tokens=1,
+            topk_indices_npu=torch.tensor(
+                [[1, 2, 3, 4]], dtype=torch.int32
+            ),
+            req_ids_npu=torch.tensor([101], dtype=torch.int64),
+            stable_prefix_lens_npu=torch.tensor([10], dtype=torch.int32),
+            visible_seq_lens_npu=torch.tensor([11], dtype=torch.int32),
+            selection_membership_map=membership,
+            capturing=False,
+        )
+
+    (
+        sparse_kv_ops
+        .sparse_kv_lru_resident_compact_with_plan_stable_rows
+        .assert_not_called()
+    )
+    (
+        sparse_kv_ops
+        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
+        .assert_not_called()
+    )
+    manager.tp_group.broadcast.assert_called_once_with(
+        manager.fused_plan_metadata_npu, src=0
+    )
 
 
 def test_external_lru_plan_is_reused_by_three_skip_layers_and_replanned_at_owner():
@@ -274,6 +469,21 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
         -1,
         dtype=torch.int16,
     )
+    plan_width = (
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+    )
+    planner_membership = torch.full(
+        (4, plan_width),
+        7,
+        dtype=torch.int16,
+    )
+    _enable_mooncake_membership_staging(manager)
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = planner_membership
+    manager.fused_overlap_membership_plan_device_staging = torch.empty(
+        (4, plan_width),
+        dtype=torch.int16,
+    )
     topk = torch.tensor([[1, 2, 3, 4]], dtype=torch.int32)
     req_ids = torch.tensor([101], dtype=torch.int64)
     stable_prefix_lens = torch.tensor([10], dtype=torch.int32)
@@ -316,9 +526,16 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
     assert current_stream.record_event.call_count == 2
     manager.current_kv_save_stream.wait_event.assert_called_once_with(input_event)
     manager.fused_plan_stream.wait_event.assert_called_once_with(input_event)
-    sparse_kv_ops.sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows.assert_called_once()
+    planner = (
+        sparse_kv_ops
+        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
+    )
+    planner.assert_called_once()
+    assert planner.call_args.args[17] == planner_membership[:1].data_ptr()
+    assert planner.call_args.args[18] == plan_width
     manager.tp_group.broadcast.assert_called_once_with(manager.fused_plan_metadata_npu, src=0)
-    current_stream.wait_stream.assert_called_once_with(manager.current_kv_save_stream)
+    current_stream.wait_stream.assert_any_call(manager.fused_plan_stream)
+    current_stream.wait_stream.assert_any_call(manager.current_kv_save_stream)
     assert manager.current_kv_by_layer[0][0].numel() == 1
     assert manager.current_kv_by_layer[0][1].numel() == 1
 

--- a/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
@@ -456,7 +456,7 @@ def test_eager_external_plan_copies_inputs_and_preserves_cpp_argument_order():
     manager.tp_group.broadcast.assert_called_once_with(manager.fused_plan_metadata_npu, src=0)
 
 
-def test_capture_external_plan_and_current_kv_use_separate_side_streams():
+def test_capture_external_plan_side_stream_and_mooncake_writeback_wait():
     manager = _make_plan_manager()
     sparse_kv_ops = _make_sparse_kv_ops()
     manager.current_kv_save_stream = MagicMock()
@@ -523,9 +523,11 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
         manager.inject_current_kv_into_selection = MagicMock()
         manager.wait_for_current_kv_writeback(capturing=True)
 
-    assert current_stream.record_event.call_count == 2
-    manager.current_kv_save_stream.wait_event.assert_called_once_with(input_event)
+    current_stream.record_event.assert_called_once_with()
+    manager.current_kv_save_stream.wait_event.assert_not_called()
     manager.fused_plan_stream.wait_event.assert_called_once_with(input_event)
+    writeback_args = manager._offload_new_kv_on_current_stream.call_args.args
+    assert writeback_args[-3:] == (False, True, True)
     planner = (
         sparse_kv_ops
         .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows

--- a/tests/ut/kv_offload/test_sparse_kv_offload_index_copy.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_index_copy.py
@@ -1,0 +1,233 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+pytest.importorskip("torch_npu")
+pytest.importorskip("memfabric_hybrid")
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (  # noqa: E402
+    sparse_kv_offload_manager as manager_module,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (  # noqa: E402
+    MooncakeHostPool,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (  # noqa: E402
+    SparseKVOffloadManager,
+)
+
+
+def _set_mooncake_allocator(manager):
+    allocator = object.__new__(MooncakeHostPool)
+    allocator.topology = SimpleNamespace()
+    manager._host_kv_allocator = allocator
+
+
+def test_eager_current_kv_index_copy_filters_invalid_slots():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.token_size_bytes_k = 2 * torch.bfloat16.itemsize
+    manager.token_size_bytes_v = 1 * torch.bfloat16.itemsize
+    manager.max_d2h_index_copy_tokens = 4
+
+    host_k = torch.zeros((8, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((8, 1), dtype=torch.bfloat16)
+    current_k = torch.tensor(
+        [[1, 2], [3, 4], [5, 6]], dtype=torch.bfloat16
+    )
+    current_v = torch.tensor([[7], [8], [9]], dtype=torch.bfloat16)
+
+    manager._offload_new_kv_via_index_copy(
+        slot_mapping=torch.tensor([3, -1, 5], dtype=torch.int64),
+        k_cache_cpu=host_k,
+        v_cache_cpu=host_v,
+        k=current_k,
+        v=current_v,
+        capturing=False,
+    )
+
+    assert torch.equal(host_k[3], current_k[0])
+    assert torch.equal(host_v[3], current_v[0])
+    assert torch.equal(host_k[5], current_k[2])
+    assert torch.equal(host_v[5], current_v[2])
+    assert torch.count_nonzero(host_k[0]).item() == 0
+    assert torch.count_nonzero(host_v[0]).item() == 0
+
+
+def test_graph_mooncake_writeback_waits_for_save_stream():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.tp_rank = 0
+    manager.use_fused_overlap = True
+    manager.layer_name_to_offload_id = {"layer.0": 0}
+    manager.current_kv_by_layer = {}
+    manager._offload_new_kv_on_current_stream = MagicMock()
+    _set_mooncake_allocator(manager)
+    manager.current_kv_save_stream = MagicMock()
+    current_stream = MagicMock()
+    current_kv_ready = object()
+    current_stream.record_event.return_value = current_kv_ready
+
+    slot_mapping = torch.tensor([2], dtype=torch.int64)
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.ones((1, 2), dtype=torch.bfloat16)
+    current_v = torch.ones((1, 1), dtype=torch.bfloat16)
+
+    with (
+        patch.object(manager_module.torch_npu.npu, "current_stream", return_value=current_stream),
+        patch.object(
+            manager_module.torch_npu.npu,
+            "stream",
+            side_effect=lambda _: nullcontext(),
+        ),
+    ):
+        manager.offload_new_kv(
+            "layer.0",
+            slot_mapping,
+            host_k,
+            host_v,
+            None,
+            None,
+            current_k,
+            current_v,
+            capturing=True,
+        )
+        manager.wait_for_current_kv_writeback(capturing=True)
+
+    manager._offload_new_kv_on_current_stream.assert_called_once_with(
+        slot_mapping,
+        host_k,
+        host_v,
+        None,
+        None,
+        current_k,
+        current_v,
+        False,
+        True,
+        True,
+    )
+    assert manager.current_kv_by_layer[0] == (current_k, current_v)
+    current_stream.record_event.assert_not_called()
+    manager.current_kv_save_stream.wait_event.assert_not_called()
+    current_stream.wait_stream.assert_called_once_with(manager.current_kv_save_stream)
+
+
+def test_graph_mooncake_index_copy_runs_on_save_stream():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.token_size_bytes_k = 2 * torch.bfloat16.itemsize
+    manager.token_size_bytes_v = torch.bfloat16.itemsize
+    manager.max_d2h_index_copy_tokens = 4
+    manager.d2h_slot_mapping_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_src_idx_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_dst_idx_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_index_count_cpu = torch.zeros(1, dtype=torch.int32)
+    manager.d2h_src_idx_npu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_dst_idx_npu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_index_count_npu = torch.zeros(1, dtype=torch.int32)
+    manager.current_kv_save_stream = MagicMock()
+    current_stream = MagicMock()
+    descriptors_ready = object()
+    current_stream.record_event.return_value = descriptors_ready
+
+    def enqueue_descriptors(
+        slot_mapping,
+        num_actual_tokens,
+        max_num_tokens,
+        num_host_slots,
+        src_idx,
+        dst_idx,
+        count,
+    ):
+        assert slot_mapping[0].item() == 2
+        assert num_actual_tokens == 1
+        assert max_num_tokens == 4
+        assert num_host_slots == 4
+        src_idx.zero_()
+        dst_idx.fill_(2)
+        count.fill_(1)
+
+    sparse_kv_ops = SimpleNamespace(
+        sparse_kv_enqueue_current_kv_index_copy_descriptors=MagicMock(
+            side_effect=enqueue_descriptors,
+        ),
+    )
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.tensor([[1, 2]], dtype=torch.bfloat16)
+    current_v = torch.tensor([[3]], dtype=torch.bfloat16)
+
+    with (
+        patch.object(manager_module, "_sparse_kv_ops", return_value=sparse_kv_ops),
+        patch.object(manager_module.torch_npu.npu, "current_stream", return_value=current_stream),
+        patch.object(
+            manager_module.torch_npu.npu,
+            "stream",
+            side_effect=lambda _: nullcontext(),
+        ),
+    ):
+        manager._offload_new_kv_via_index_copy(
+            slot_mapping=torch.tensor([2], dtype=torch.int64),
+            k_cache_cpu=host_k,
+            v_cache_cpu=host_v,
+            k=current_k,
+            v=current_v,
+            capturing=True,
+            prepare_descriptors=True,
+        )
+
+    assert torch.equal(host_k[2], current_k[0])
+    assert torch.equal(host_v[2], current_v[0])
+    current_stream.record_event.assert_called_once_with()
+    manager.current_kv_save_stream.wait_event.assert_called_once_with(
+        descriptors_ready
+    )
+    sparse_kv_ops.sparse_kv_enqueue_current_kv_index_copy_descriptors.assert_called_once()
+
+
+def test_graph_mooncake_prepares_descriptors_on_first_layer_only():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.tp_rank = 0
+    manager.use_fused_overlap = True
+    manager.layer_name_to_offload_id = {
+        "layer.0": 0,
+        "layer.1": 1,
+    }
+    manager.current_kv_by_layer = {}
+    manager._offload_new_kv_on_current_stream = MagicMock()
+    _set_mooncake_allocator(manager)
+
+    slot_mapping = torch.tensor([2], dtype=torch.int64)
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.ones((1, 2), dtype=torch.bfloat16)
+    current_v = torch.ones((1, 1), dtype=torch.bfloat16)
+
+    for layer_name in ("layer.0", "layer.1"):
+        manager.offload_new_kv(
+            layer_name,
+            slot_mapping,
+            host_k,
+            host_v,
+            None,
+            None,
+            current_k,
+            current_v,
+            capturing=True,
+        )
+
+    assert manager._offload_new_kv_on_current_stream.call_count == 2
+    first_call, second_call = (
+        manager._offload_new_kv_on_current_stream.call_args_list
+    )
+    assert first_call.args[-3:] == (
+        False,
+        True,
+        True,
+    )
+    assert second_call.args[-3:] == (
+        False,
+        True,
+        False,
+    )

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -679,6 +679,7 @@ class TestSparseKVOffloadConfig(TestBase):
                 "dram_size_per_dp_GB": "64",
                 "keep_device_kv_cache": "false",
                 "use_fused_overlap": "true",
+                "host_backend": "mooncake",
             },
         )
 
@@ -687,6 +688,72 @@ class TestSparseKVOffloadConfig(TestBase):
         self.assertEqual(config.dram_size_per_dp_GB, 64)
         self.assertFalse(config.keep_device_kv_cache)
         self.assertTrue(config.use_fused_overlap)
+        self.assertEqual(config.host_backend, "mooncake")
+
+    def test_sparse_kv_host_backend_defaults_to_memfabric(self):
+        config = SparseKVOffloadConfig.from_additional_config(
+            SimpleNamespace(),
+            {"enabled": "false"},
+        )
+        self.assertEqual(config.host_backend, "memfabric")
+
+    def test_invalid_sparse_kv_host_backend_is_rejected(self):
+        with self.assertRaises(ValueError):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {"enabled": "false", "host_backend": "unknown"},
+            )
+
+    def test_mooncake_host_backend_requires_fused_overlap(self):
+        with self.assertRaisesRegex(ValueError, "requires use_fused_overlap"):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {"enabled": "true", "host_backend": "mooncake"},
+            )
+
+    def test_mooncake_host_backend_rejects_colocate_staging(self):
+        with self.assertRaisesRegex(ValueError, "keep_device_kv_cache"):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {
+                    "enabled": "true",
+                    "host_backend": "mooncake",
+                    "use_fused_overlap": "true",
+                    "keep_device_kv_cache": "true",
+                },
+            )
+
+    def test_mooncake_host_backend_valid_config_passes_validation(self):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(hf_text_config=SimpleNamespace(index_topk=128)),
+            parallel_config=SimpleNamespace(
+                prefill_context_parallel_size=1,
+                decode_context_parallel_size=1,
+                pipeline_parallel_size=1,
+            ),
+            kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+            use_v2_model_runner=False,
+        )
+
+        config = SparseKVOffloadConfig.from_additional_config(
+            vllm_config,
+            {
+                "enabled": "true",
+                "host_backend": "mooncake",
+                "use_fused_overlap": "true",
+                "keep_device_kv_cache": "false",
+            },
+        )
+
+        self.assertEqual(config.host_backend, "mooncake")
+
+    def test_mooncake_validation_skipped_when_disabled(self):
+        config = SparseKVOffloadConfig.from_additional_config(
+            SimpleNamespace(),
+            {"enabled": "false", "host_backend": "mooncake"},
+        )
+
+        self.assertEqual(config.host_backend, "mooncake")
 
     def test_unknown_key_is_rejected_even_when_disabled(self):
         with self.assertRaises(ValueError):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1300,6 +1300,7 @@ class SparseKVOffloadConfig:
     keep_device_kv_cache: bool = False
     topk: int = dataclasses.field(default=0, init=False)
     use_fused_overlap: bool = False
+    host_backend: Literal["memfabric", "mooncake"] = "memfabric"
 
     @model_validator(mode="after")
     def _validate_values(self):
@@ -1307,6 +1308,15 @@ class SparseKVOffloadConfig:
             raise ValueError("sparse_kv_offload_config.topk_buffer_size must be positive")
         if self.dram_size_per_dp_GB <= 0:
             raise ValueError("sparse_kv_offload_config.dram_size_per_dp_GB must be positive")
+        if self.enabled and self.host_backend == "mooncake":
+            if not self.use_fused_overlap:
+                raise ValueError("sparse_kv_offload_config.host_backend='mooncake' requires use_fused_overlap=true")
+            if self.keep_device_kv_cache:
+                raise ValueError(
+                    "sparse_kv_offload_config.host_backend='mooncake' is "
+                    "only supported for PD-disaggregated decode; "
+                    "keep_device_kv_cache must be false"
+                )
         return self
 
     @classmethod

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -529,7 +529,9 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             or self._fused_overlap_selection_capacity[3] < cache_blocks_per_row
             or self.selection_kv_block_table.device != device
             or self.selection_kv_block_status.device != device
-            or self.selection_membership_map.device.type != "cpu"
+            or not get_sparse_kv_offload_manager().is_fused_membership_storage(
+                self.selection_membership_map
+            )
             or self.fused_overlap_last_req_ids.device != device
         )
         if needs_realloc:

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import psutil
 import regex as re
 from vllm.logger import logger
+from vllm_ascend import envs
 
 from vllm_ascend.device.hardware_profile import (
     CPUBindingMode,
@@ -644,6 +645,13 @@ class CpuAlloc:
             anchor_cpu = cpu_pool[0]
             return self.cpu_node.get(anchor_cpu)
 
+        if envs.VLLM_ASCEND_SKIP_MIGRATEPAGES:
+            logger.info(
+                "[migrate] skipped because "
+                "VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding "
+                "continues."
+            )
+            return
         if not shutil.which("migratepages"):
             logger.info("The 'migratepages' command is not available, skipping memory binding.")
             return

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 import psutil
 import regex as re
 from vllm.logger import logger
-from vllm_ascend import envs
 
+from vllm_ascend import envs
 from vllm_ascend.device.hardware_profile import (
     CPUBindingMode,
     DeviceAddressingMode,
@@ -646,11 +646,7 @@ class CpuAlloc:
             return self.cpu_node.get(anchor_cpu)
 
         if envs.VLLM_ASCEND_SKIP_MIGRATEPAGES:
-            logger.info(
-                "[migrate] skipped because "
-                "VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding "
-                "continues."
-            )
+            logger.info("[migrate] skipped because VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding continues.")
             return
         if not shutil.which("migratepages"):
             logger.info("The 'migratepages' command is not available, skipping memory binding.")

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mooncake shared Host-memory pool for sparse KV offload."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+@dataclass(frozen=True)
+class HostPoolTopology:
+    """Tensor-parallel ownership of one shared Host-memory pool."""
+
+    tp_rank: int
+    tp_size: int
+    owner_rank: int = 0
+    device_id: int = 0
+    dp_rank: int = 0
+    tp_group: Any = None
+
+    def __post_init__(self) -> None:
+        if self.tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {self.tp_size}")
+        if not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError(
+                f"tp_rank out of range: rank={self.tp_rank}, "
+                f"size={self.tp_size}"
+            )
+        if not 0 <= self.owner_rank < self.tp_size:
+            raise ValueError(
+                f"owner_rank out of range: owner={self.owner_rank}, "
+                f"size={self.tp_size}"
+            )
+
+
+@dataclass
+class HostMemoryRegion:
+    """One shared allocation and its local NPU-addressable tensor view."""
+
+    tensor: torch.Tensor
+    handle: Any = None
+    register_location: str | None = None
+    release_callback: Callable[[Any], None] | None = None
+    _released: bool = field(default=False, init=False)
+
+    def release(self) -> None:
+        if self._released:
+            return
+        if self.release_callback is not None:
+            self.release_callback(self.handle)
+        self.handle = None
+        self._released = True
+
+
+def _select_shared_segment_mode() -> tuple[bool, bool]:
+    """Select a Mooncake mode that exposes an NPU-addressable Host VA."""
+    try:
+        from mooncake.shared_segment import shared_segment_supported
+    except ImportError as exc:
+        raise RuntimeError(
+            "Mooncake shared_segment support is required for sparse KV "
+            "offload with the Mooncake Host backend"
+        ) from exc
+
+    if shared_segment_supported(mmap=False):
+        return False, False
+    if shared_segment_supported(mmap=True, host_register=True):
+        return True, True
+    raise RuntimeError(
+        "Mooncake shared_segment cannot expose an NPU-addressable address"
+    )
+
+
+def allocate_mooncake_host_region(
+    *,
+    size_bytes: int,
+    alignment: int,
+    topology: HostPoolTopology,
+    name: str = "sparse_kv_offload_host_pool",
+) -> HostMemoryRegion:
+    """Create or map one shared segment for a Decode DP group's Host KV."""
+    try:
+        from mooncake.shared_segment import create_shared_segment
+    except ImportError as exc:
+        raise RuntimeError(
+            "Mooncake shared_segment support is required for sparse KV "
+            "offload with the Mooncake Host backend"
+        ) from exc
+
+    if size_bytes <= 0:
+        raise ValueError(f"size_bytes must be positive, got {size_bytes}")
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    allocation_size_bytes = int(size_bytes) + int(alignment) - 1
+    if topology.tp_size > 1 and topology.tp_group is None:
+        raise RuntimeError(
+            "create_shared_segment requires tp_group when tp_size > 1: "
+            f"tp={topology.tp_rank}/{topology.tp_size}"
+        )
+
+    mmap, host_register = _select_shared_segment_mode()
+    segment_name = f"{name}_dp{topology.dp_rank}"
+    logger.info(
+        "Creating sparse KV Mooncake Host pool name=%s tp=%s/%s owner=%s "
+        "device=%s mmap=%s host_register=%s size_bytes=%s allocated=%s",
+        segment_name,
+        topology.tp_rank,
+        topology.tp_size,
+        topology.owner_rank,
+        topology.device_id,
+        mmap,
+        host_register,
+        size_bytes,
+        allocation_size_bytes,
+    )
+    segment = create_shared_segment(
+        segment_name,
+        blocks={
+            "pool": {
+                "count": 1,
+                "shape": (allocation_size_bytes,),
+                "dtype": torch.int8,
+            }
+        },
+        world_size=topology.tp_size,
+        rank_id=topology.tp_rank,
+        owner_rank=topology.owner_rank,
+        device_id=topology.device_id,
+        tp_group=topology.tp_group,
+        mmap=mmap,
+        host_register=host_register,
+    )
+    if host_register and os.getenv(
+        "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+    ) is None:
+        os.environ["VLLM_ASCEND_SKIP_MIGRATEPAGES"] = "1"
+
+    raw = segment.tensors("pool")[0].reshape(-1)
+    base_offset = _align_up(raw.data_ptr(), alignment) - raw.data_ptr()
+    aligned = raw.narrow(0, base_offset, int(size_bytes))
+    device = getattr(aligned, "device", None)
+    if device is None or getattr(device, "type", None) == "cpu":
+        raise RuntimeError(
+            "Mooncake shared segment did not expose an NPU tensor: "
+            f"device={device}, mmap={mmap}, host_register={host_register}"
+        )
+    return HostMemoryRegion(
+        tensor=aligned,
+        handle=segment,
+        register_location=f"npu:{topology.device_id}",
+    )
+
+
+class MooncakeHostPool:
+    """Aligned bump allocator over one Mooncake shared segment."""
+
+    def __init__(
+        self,
+        region: HostMemoryRegion,
+        topology: HostPoolTopology,
+    ) -> None:
+        if region.tensor.dtype != torch.int8:
+            raise TypeError(
+                "Mooncake Host pool must use an int8 byte tensor, got "
+                f"{region.tensor.dtype}"
+            )
+        if not region.tensor.is_contiguous():
+            raise ValueError("Mooncake Host pool allocation must be contiguous")
+        self.region = region
+        self.topology = topology
+        self._offset = 0
+        self._registered_engine: Any = None
+        self._closed = False
+
+    @classmethod
+    def allocate(
+        cls,
+        *,
+        size_bytes: int,
+        alignment: int,
+        topology: HostPoolTopology,
+    ) -> MooncakeHostPool:
+        region = allocate_mooncake_host_region(
+            size_bytes=size_bytes,
+            alignment=alignment,
+            topology=topology,
+        )
+        try:
+            return cls(region, topology)
+        except Exception:
+            region.release()
+            raise
+
+    @property
+    def data_ptr(self) -> int:
+        return int(self.region.tensor.data_ptr())
+
+    @property
+    def nbytes(self) -> int:
+        return self.region.tensor.numel()
+
+    @property
+    def is_owner(self) -> bool:
+        return self.topology.tp_rank == self.topology.owner_rank
+
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor]:
+        if self._closed:
+            raise RuntimeError("cannot allocate from a closed Mooncake Host pool")
+        tensors: list[torch.Tensor] = []
+        for size in sizes:
+            if size < 0:
+                raise ValueError(f"allocation size must be non-negative, got {size}")
+            start = _align_up(self.data_ptr + self._offset, alignment) - self.data_ptr
+            end = start + int(size)
+            if end > self.nbytes:
+                raise MemoryError(
+                    "Mooncake Host pool is exhausted: "
+                    f"requested={size}, offset={start}, capacity={self.nbytes}"
+                )
+            tensors.append(self.region.tensor.narrow(0, start, int(size)))
+            self._offset = end
+        return tensors
+
+    def register(self, engine: Any) -> None:
+        if self._closed:
+            raise RuntimeError("cannot register a closed Mooncake Host pool")
+        if not self.is_owner:
+            raise RuntimeError(
+                "only the owner rank may register the Mooncake Host pool: "
+                f"rank={self.topology.tp_rank}, owner={self.topology.owner_rank}"
+            )
+        if self._registered_engine is engine:
+            return
+        if self._registered_engine is not None:
+            raise RuntimeError("Mooncake Host pool is already registered")
+        location = self.region.register_location
+        if location is None:
+            result = engine.register_memory(self.data_ptr, self.nbytes)
+        else:
+            try:
+                result = engine.register_memory(
+                    self.data_ptr,
+                    self.nbytes,
+                    location=location,
+                )
+            except TypeError:
+                result = engine.register_memory(
+                    self.data_ptr,
+                    self.nbytes,
+                    location,
+                )
+        if result not in (0, None):
+            raise RuntimeError(
+                "Mooncake register_memory failed for sparse KV Host pool: "
+                f"result={result}, ptr=0x{self.data_ptr:x}, size={self.nbytes}"
+            )
+        self._registered_engine = engine
+
+    def unregister(self) -> None:
+        if self._registered_engine is None:
+            return
+        unregister_memory = getattr(
+            self._registered_engine,
+            "unregister_memory",
+            None,
+        )
+        if unregister_memory is None:
+            raise RuntimeError(
+                "Mooncake engine must unregister the Host pool before release"
+            )
+        try:
+            result = unregister_memory(self.data_ptr)
+        except TypeError:
+            result = unregister_memory(self.data_ptr, self.nbytes)
+        if result not in (0, None):
+            raise RuntimeError(
+                "Mooncake unregister_memory failed for sparse KV Host pool: "
+                f"result={result}, ptr=0x{self.data_ptr:x}"
+            )
+        self._registered_engine = None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.unregister()
+        self.region.release()
+        self._closed = True

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -35,15 +35,9 @@ class HostPoolTopology:
         if self.tp_size <= 0:
             raise ValueError(f"tp_size must be positive, got {self.tp_size}")
         if not 0 <= self.tp_rank < self.tp_size:
-            raise ValueError(
-                f"tp_rank out of range: rank={self.tp_rank}, "
-                f"size={self.tp_size}"
-            )
+            raise ValueError(f"tp_rank out of range: rank={self.tp_rank}, size={self.tp_size}")
         if not 0 <= self.owner_rank < self.tp_size:
-            raise ValueError(
-                f"owner_rank out of range: owner={self.owner_rank}, "
-                f"size={self.tp_size}"
-            )
+            raise ValueError(f"owner_rank out of range: owner={self.owner_rank}, size={self.tp_size}")
 
 
 @dataclass
@@ -71,17 +65,14 @@ def _select_shared_segment_mode() -> tuple[bool, bool]:
         from mooncake.shared_segment import shared_segment_supported
     except ImportError as exc:
         raise RuntimeError(
-            "Mooncake shared_segment support is required for sparse KV "
-            "offload with the Mooncake Host backend"
+            "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
     if shared_segment_supported(mmap=False):
         return False, False
     if shared_segment_supported(mmap=True, host_register=True):
         return True, True
-    raise RuntimeError(
-        "Mooncake shared_segment cannot expose an NPU-addressable address"
-    )
+    raise RuntimeError("Mooncake shared_segment cannot expose an NPU-addressable address")
 
 
 def allocate_mooncake_host_region(
@@ -96,8 +87,7 @@ def allocate_mooncake_host_region(
         from mooncake.shared_segment import create_shared_segment
     except ImportError as exc:
         raise RuntimeError(
-            "Mooncake shared_segment support is required for sparse KV "
-            "offload with the Mooncake Host backend"
+            "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
     if size_bytes <= 0:
@@ -107,8 +97,7 @@ def allocate_mooncake_host_region(
     allocation_size_bytes = int(size_bytes) + int(alignment) - 1
     if topology.tp_size > 1 and topology.tp_group is None:
         raise RuntimeError(
-            "create_shared_segment requires tp_group when tp_size > 1: "
-            f"tp={topology.tp_rank}/{topology.tp_size}"
+            f"create_shared_segment requires tp_group when tp_size > 1: tp={topology.tp_rank}/{topology.tp_size}"
         )
 
     mmap, host_register = _select_shared_segment_mode()
@@ -143,9 +132,7 @@ def allocate_mooncake_host_region(
         mmap=mmap,
         host_register=host_register,
     )
-    if host_register and os.getenv(
-        "VLLM_ASCEND_SKIP_MIGRATEPAGES"
-    ) is None:
+    if host_register and os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES") is None:
         os.environ["VLLM_ASCEND_SKIP_MIGRATEPAGES"] = "1"
 
     raw = segment.tensors("pool")[0].reshape(-1)
@@ -173,10 +160,7 @@ class MooncakeHostPool:
         topology: HostPoolTopology,
     ) -> None:
         if region.tensor.dtype != torch.int8:
-            raise TypeError(
-                "Mooncake Host pool must use an int8 byte tensor, got "
-                f"{region.tensor.dtype}"
-            )
+            raise TypeError(f"Mooncake Host pool must use an int8 byte tensor, got {region.tensor.dtype}")
         if not region.tensor.is_contiguous():
             raise ValueError("Mooncake Host pool allocation must be contiguous")
         self.region = region
@@ -231,8 +215,7 @@ class MooncakeHostPool:
             end = start + int(size)
             if end > self.nbytes:
                 raise MemoryError(
-                    "Mooncake Host pool is exhausted: "
-                    f"requested={size}, offset={start}, capacity={self.nbytes}"
+                    f"Mooncake Host pool is exhausted: requested={size}, offset={start}, capacity={self.nbytes}"
                 )
             tensors.append(self.region.tensor.narrow(0, start, int(size)))
             self._offset = end
@@ -282,17 +265,14 @@ class MooncakeHostPool:
             None,
         )
         if unregister_memory is None:
-            raise RuntimeError(
-                "Mooncake engine must unregister the Host pool before release"
-            )
+            raise RuntimeError("Mooncake engine must unregister the Host pool before release")
         try:
             result = unregister_memory(self.data_ptr)
         except TypeError:
             result = unregister_memory(self.data_ptr, self.nbytes)
         if result not in (0, None):
             raise RuntimeError(
-                "Mooncake unregister_memory failed for sparse KV Host pool: "
-                f"result={result}, ptr=0x{self.data_ptr:x}"
+                f"Mooncake unregister_memory failed for sparse KV Host pool: result={result}, ptr=0x{self.data_ptr:x}"
             )
         self._registered_engine = None
 

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -46,7 +46,6 @@ class HostMemoryRegion:
 
     tensor: torch.Tensor
     handle: Any = None
-    register_location: str | None = None
     release_callback: Callable[[Any], None] | None = None
     _released: bool = field(default=False, init=False)
 
@@ -68,8 +67,6 @@ def _select_shared_segment_mode() -> tuple[bool, bool]:
             "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
-    if shared_segment_supported(mmap=False):
-        return False, False
     if shared_segment_supported(mmap=True, host_register=True):
         return True, True
     raise RuntimeError("Mooncake shared_segment cannot expose an NPU-addressable address")
@@ -147,7 +144,6 @@ def allocate_mooncake_host_region(
     return HostMemoryRegion(
         tensor=aligned,
         handle=segment,
-        register_location=f"npu:{topology.device_id}",
     )
 
 
@@ -166,7 +162,6 @@ class MooncakeHostPool:
         self.region = region
         self.topology = topology
         self._offset = 0
-        self._registered_engine: Any = None
         self._closed = False
 
     @classmethod
@@ -196,10 +191,6 @@ class MooncakeHostPool:
     def nbytes(self) -> int:
         return self.region.tensor.numel()
 
-    @property
-    def is_owner(self) -> bool:
-        return self.topology.tp_rank == self.topology.owner_rank
-
     def allocate_tensors(
         self,
         sizes: list[int],
@@ -221,64 +212,8 @@ class MooncakeHostPool:
             self._offset = end
         return tensors
 
-    def register(self, engine: Any) -> None:
-        if self._closed:
-            raise RuntimeError("cannot register a closed Mooncake Host pool")
-        if not self.is_owner:
-            raise RuntimeError(
-                "only the owner rank may register the Mooncake Host pool: "
-                f"rank={self.topology.tp_rank}, owner={self.topology.owner_rank}"
-            )
-        if self._registered_engine is engine:
-            return
-        if self._registered_engine is not None:
-            raise RuntimeError("Mooncake Host pool is already registered")
-        location = self.region.register_location
-        if location is None:
-            result = engine.register_memory(self.data_ptr, self.nbytes)
-        else:
-            try:
-                result = engine.register_memory(
-                    self.data_ptr,
-                    self.nbytes,
-                    location=location,
-                )
-            except TypeError:
-                result = engine.register_memory(
-                    self.data_ptr,
-                    self.nbytes,
-                    location,
-                )
-        if result not in (0, None):
-            raise RuntimeError(
-                "Mooncake register_memory failed for sparse KV Host pool: "
-                f"result={result}, ptr=0x{self.data_ptr:x}, size={self.nbytes}"
-            )
-        self._registered_engine = engine
-
-    def unregister(self) -> None:
-        if self._registered_engine is None:
-            return
-        unregister_memory = getattr(
-            self._registered_engine,
-            "unregister_memory",
-            None,
-        )
-        if unregister_memory is None:
-            raise RuntimeError("Mooncake engine must unregister the Host pool before release")
-        try:
-            result = unregister_memory(self.data_ptr)
-        except TypeError:
-            result = unregister_memory(self.data_ptr, self.nbytes)
-        if result not in (0, None):
-            raise RuntimeError(
-                f"Mooncake unregister_memory failed for sparse KV Host pool: result={result}, ptr=0x{self.data_ptr:x}"
-            )
-        self._registered_engine = None
-
     def close(self) -> None:
         if self._closed:
             return
-        self.unregister()
         self.region.release()
         self._closed = True

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -45,6 +45,17 @@ OFFLOAD_V_CACHE_CPU_INDEX = 3
 OFFLOAD_TOPK_BUFFER_K_INDEX = 4
 OFFLOAD_TOPK_BUFFER_V_INDEX = 5
 
+
+class HostKVAllocator(typing.Protocol):
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor]: ...
+
+    def close(self) -> None: ...
+
+
 FSA_EXTERNAL_PLAN_READY_MARKER = 0x5A45
 FSA_PAIRED_SELECTION_COPY_MARKER = 0x5A56
 FSA_SELECTION_MEMBERSHIP_MAP_INT16_COUNT = 16376
@@ -320,8 +331,17 @@ def allocate_kv_cache_tensors_for_sparse_kv_offload(
     tp_rank: int,
     keep_device_kv_cache: bool,
     npu_kv_cache_allocate_func: typing.Callable,
+    host_kv_cache_allocate_func: typing.Callable[
+        [list[int], int], list[torch.Tensor | None]
+    ]
+    | None = None,
 ):
-    if tp_rank == 0:
+    if host_kv_cache_allocate_func is not None:
+        [k_tensor_cpu, v_tensor_cpu] = host_kv_cache_allocate_func(
+            [k_tensor_size, v_tensor_size],
+            alignment,
+        )
+    elif tp_rank == 0:
         [k_tensor_cpu, v_tensor_cpu] = empty_aligned_int8_cpu_tensors(
             [k_tensor_size, v_tensor_size],
             alignment,
@@ -383,7 +403,7 @@ def reshape_kv_cache_tensors_for_sparse_kv_offload(
     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape) if raw_k_tensor is not None else None
     v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape) if raw_v_tensor is not None else None
 
-    if tp_rank == 0:
+    if raw_k_tensor_cpu is not None and raw_v_tensor_cpu is not None:
         k_cache_cpu = raw_k_tensor_cpu.view(k_cache_dtype).view(k_shape)
         v_cache_cpu = raw_v_tensor_cpu.view(v_cache_dtype).view(v_shape)
     else:
@@ -535,23 +555,70 @@ class SparseKVOffloadManager:
                 f"limit={sparse_kv_offload_config.dram_size_per_dp_GB} GiB, "
                 f"num_blocks={kv_cache_config.num_blocks}"
             )
-        actual_pool_size_bytes = min(planned_pool_size_bytes, dram_limit_bytes)
+        self.host_pool_size_bytes = min(
+            planned_pool_size_bytes,
+            dram_limit_bytes,
+        )
+        self._host_kv_allocator: HostKVAllocator | None = None
+        self._host_allocation_prepared = False
         logger.info(
             "SparseKVOffloadManager starts CPU KV pool initialization: "
             "planned=%.2f GiB, configured_limit=%s GiB, num_blocks=%s.",
-            actual_pool_size_bytes / (1 << 30),
+            self.host_pool_size_bytes / (1 << 30),
             sparse_kv_offload_config.dram_size_per_dp_GB,
             kv_cache_config.num_blocks,
         )
+
+    def prepare_host_kv_allocation(
+        self,
+        *,
+        device_id: int,
+        dp_rank: int,
+    ) -> None:
+        """Prepare Host KV allocation before per-layer cache allocation."""
+        if self._host_allocation_prepared:
+            return
+
+        # dp_rank is part of the backend-neutral contract. The existing
+        # MemFabric allocator does not need it.
+        del dp_rank
         config = offload.OffloadConfig()
-        config.device_id = torch_npu.npu.current_device()
-        config.reserve_size = actual_pool_size_bytes
-        config.alloc_size = actual_pool_size_bytes if self.tp_rank == 0 else 0
+        config.device_id = device_id
+        config.reserve_size = self.host_pool_size_bytes
+        config.alloc_size = (
+            self.host_pool_size_bytes if self.tp_rank == 0 else 0
+        )
         config.world_size = self.tp_size
         config.rank_id = self.tp_rank
         config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
+        assert offload.initialize(config) == 0, (
+            "Sparse KV offload offload.initialize failed."
+        )
         self.tp_group.barrier()
+        self._host_allocation_prepared = True
+
+    def allocate_host_kv_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor | None]:
+        """Allocate one layer's Host K/V through the prepared allocator."""
+        if not self._host_allocation_prepared:
+            raise RuntimeError(
+                "prepare_host_kv_allocation must run before Host KV allocation"
+            )
+        if self._host_kv_allocator is not None:
+            return self._host_kv_allocator.allocate_tensors(sizes, alignment)
+        if self.tp_rank == 0:
+            return empty_aligned_int8_cpu_tensors(sizes, alignment)
+        return [None for _ in sizes]
+
+    def close(self) -> None:
+        """Release backend-owned Host KV resources."""
+        allocator = self._host_kv_allocator
+        if allocator is not None:
+            allocator.close()
+            self._host_kv_allocator = None
 
     def _warmup_external_lru_planner_threads(self) -> int:
         if not (self.use_fused_overlap and self.tp_rank == 0):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -797,6 +797,10 @@ class SparseKVOffloadManager:
     ):
         self._register_offload_layers(kv_caches)
 
+        # HostKVAllocator-backed pools give every TP rank local Host KV views,
+        # while the legacy MemFabric path only allocates on tp_rank == 0.
+        uses_host_allocator = self._host_kv_allocator is not None
+
         # register topk_buffer and cpu kv_cache
         self.topk_buffers_k: list[torch.Tensor] = []
         self.topk_buffers_v: list[torch.Tensor] = []
@@ -812,7 +816,7 @@ class SparseKVOffloadManager:
                 )
             self.topk_buffers_k.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_K_INDEX])
             self.topk_buffers_v.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_V_INDEX])
-            if self.tp_rank == 0:
+            if uses_host_allocator or self.tp_rank == 0:
                 self.k_caches_cpu.append(cache_or_caches[OFFLOAD_K_CACHE_CPU_INDEX])
                 self.v_caches_cpu.append(cache_or_caches[OFFLOAD_V_CACHE_CPU_INDEX])
 
@@ -881,53 +885,74 @@ class SparseKVOffloadManager:
         self.gvas_k_bases: list[int] = []
         self.gvas_v_bases: list[int] = []
         self.cpu_block_lens: list[tuple[int, int]] = []
-        gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
-        gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
-        cpu_block_lens_tensor = torch.zeros([self.num_layers, 2], dtype=torch.int64, device="npu")
-        shape_k_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
-        shape_v_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
-        if self.tp_rank == 0:
+        if uses_host_allocator:
+            # HostKVAllocator gave every rank local Host KV views: use them
+            # directly instead of broadcasting the tp0 pointers.
             for layer_id in range(self.num_layers):
                 k_cpu = self.k_caches_cpu[layer_id]
                 v_cpu = self.v_caches_cpu[layer_id]
-                gvas_k_tensor[layer_id] = k_cpu.data_ptr()
-                gvas_v_tensor[layer_id] = v_cpu.data_ptr()
-                cpu_block_lens_tensor[layer_id, 0] = (
-                    k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks
+                self.gvas_k_bases.append(k_cpu.data_ptr())
+                self.gvas_v_bases.append(v_cpu.data_ptr())
+                self.cpu_block_lens.append(
+                    (
+                        k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks,
+                        v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks,
+                    )
                 )
-                cpu_block_lens_tensor[layer_id, 1] = (
-                    v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks
-                )
-            shape_k_tensor.copy_(torch.tensor(self.k_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
-            shape_v_tensor.copy_(torch.tensor(self.v_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
-        self.tp_group.broadcast(gvas_k_tensor, src=0)
-        self.tp_group.broadcast(gvas_v_tensor, src=0)
-        self.tp_group.broadcast(cpu_block_lens_tensor, src=0)
-        self.tp_group.broadcast(shape_k_tensor, src=0)
-        self.tp_group.broadcast(shape_v_tensor, src=0)
-        for layer_id in range(self.num_layers):
-            self.gvas_k_bases.append(gvas_k_tensor[layer_id].item())
-            self.gvas_v_bases.append(gvas_v_tensor[layer_id].item())
-            self.cpu_block_lens.append(
-                (
-                    cpu_block_lens_tensor[layer_id, 0].item(),
-                    cpu_block_lens_tensor[layer_id, 1].item(),
-                )
-            )
-
-        if self.use_fused_overlap and self.tp_rank != 0:
-            cpu_k_shape = [int(x) for x in shape_k_tensor.tolist()]
-            cpu_v_shape = [int(x) for x in shape_v_tensor.tolist()]
-            self.k_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_k_shape) for ptr in self.gvas_k_bases]
-            self.v_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_v_shape) for ptr in self.gvas_v_bases]
             logger.info(
-                "[fused_overlap_offload][init] restored shared CPU KV views on "
-                "tp_rank=%s layer_count=%s k_shape=%s v_shape=%s",
+                "Registered local Host KV views: tp=%s/%s layers=%s",
                 self.tp_rank,
+                self.tp_size,
                 self.num_layers,
-                cpu_k_shape,
-                cpu_v_shape,
             )
+        else:
+            gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+            gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+            cpu_block_lens_tensor = torch.zeros([self.num_layers, 2], dtype=torch.int64, device="npu")
+            shape_k_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
+            shape_v_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
+            if self.tp_rank == 0:
+                for layer_id in range(self.num_layers):
+                    k_cpu = self.k_caches_cpu[layer_id]
+                    v_cpu = self.v_caches_cpu[layer_id]
+                    gvas_k_tensor[layer_id] = k_cpu.data_ptr()
+                    gvas_v_tensor[layer_id] = v_cpu.data_ptr()
+                    cpu_block_lens_tensor[layer_id, 0] = (
+                        k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks
+                    )
+                    cpu_block_lens_tensor[layer_id, 1] = (
+                        v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks
+                    )
+                shape_k_tensor.copy_(torch.tensor(self.k_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
+                shape_v_tensor.copy_(torch.tensor(self.v_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
+            self.tp_group.broadcast(gvas_k_tensor, src=0)
+            self.tp_group.broadcast(gvas_v_tensor, src=0)
+            self.tp_group.broadcast(cpu_block_lens_tensor, src=0)
+            self.tp_group.broadcast(shape_k_tensor, src=0)
+            self.tp_group.broadcast(shape_v_tensor, src=0)
+            for layer_id in range(self.num_layers):
+                self.gvas_k_bases.append(gvas_k_tensor[layer_id].item())
+                self.gvas_v_bases.append(gvas_v_tensor[layer_id].item())
+                self.cpu_block_lens.append(
+                    (
+                        cpu_block_lens_tensor[layer_id, 0].item(),
+                        cpu_block_lens_tensor[layer_id, 1].item(),
+                    )
+                )
+
+            if self.use_fused_overlap and self.tp_rank != 0:
+                cpu_k_shape = [int(x) for x in shape_k_tensor.tolist()]
+                cpu_v_shape = [int(x) for x in shape_v_tensor.tolist()]
+                self.k_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_k_shape) for ptr in self.gvas_k_bases]
+                self.v_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_v_shape) for ptr in self.gvas_v_bases]
+                logger.info(
+                    "[fused_overlap_offload][init] restored shared CPU KV views on "
+                    "tp_rank=%s layer_count=%s k_shape=%s v_shape=%s",
+                    self.tp_rank,
+                    self.num_layers,
+                    cpu_k_shape,
+                    cpu_v_shape,
+                )
 
         gvas_buffer_offset = 0
         gvas_buffer_size_bytes = self.max_num_topk_rows * self.topk * 2 * 8  # 2: k+v, 8: int64

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -31,6 +31,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostPoolTopology,
+    MooncakeHostPool,
+)
 from vllm_ascend.utils import AscendDeviceType, enable_custom_op, get_ascend_device_type
 
 # Main BF16 cache:
@@ -51,7 +55,7 @@ class HostKVAllocator(typing.Protocol):
         self,
         sizes: list[int],
         alignment: int,
-    ) -> list[torch.Tensor]: ...
+    ) -> list[torch.Tensor | None]: ...
 
     def close(self) -> None: ...
 
@@ -206,6 +210,33 @@ def empty_aligned_int8_cpu_tensors(
         allocate_tensors.append(raw_tensor[base_offset : base_offset + size])
         base_offset += chunk_num * alignment
     return allocate_tensors
+
+
+class MemFabricHostKVAllocator:
+    """HostKVAllocator implementation over the legacy MemFabric backend.
+
+    The MemFabric pool is prepared once by `offload.initialize` in
+    prepare_host_kv_allocation and only tp_rank 0 allocates per-layer
+    tensors; other ranks receive None and rely on the tp0 pointer
+    broadcast in register_kv_caches.
+    """
+
+    def __init__(self, tp_rank: int) -> None:
+        self._tp_rank = tp_rank
+
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor | None]:
+        if self._tp_rank == 0:
+            return empty_aligned_int8_cpu_tensors(sizes, alignment)
+        return [None for _ in sizes]
+
+    def close(self) -> None:
+        # MemFabric pool is process-scoped and owned by the offload
+        # runtime; there is nothing per-allocator to release.
+        return None
 
 
 @dataclass(frozen=True)
@@ -508,6 +539,7 @@ class SparseKVOffloadManager:
         self.topk_buffer_size = sparse_kv_offload_config.topk_buffer_size
         self.topk = sparse_kv_offload_config.topk
         self.use_fused_overlap = sparse_kv_offload_config.use_fused_overlap
+        self.host_backend = sparse_kv_offload_config.host_backend
 
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
@@ -576,19 +608,45 @@ class SparseKVOffloadManager:
         if self._host_allocation_prepared:
             return
 
-        # dp_rank is part of the backend-neutral contract. The existing
-        # MemFabric allocator does not need it.
-        del dp_rank
-        config = offload.OffloadConfig()
-        config.device_id = device_id
-        config.reserve_size = self.host_pool_size_bytes
-        config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
-        config.world_size = self.tp_size
-        config.rank_id = self.tp_rank
-        config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
-        self.tp_group.barrier()
-        self._host_allocation_prepared = True
+        if self.host_backend == "mooncake":
+            topology = HostPoolTopology(
+                tp_rank=self.tp_rank,
+                tp_size=self.tp_size,
+                owner_rank=0,
+                device_id=device_id,
+                dp_rank=dp_rank,
+                tp_group=self.tp_group,
+            )
+            self._host_kv_allocator = MooncakeHostPool.allocate(
+                size_bytes=self.host_pool_size_bytes,
+                alignment=_CPU_CACHE_ALIGNMENT,
+                topology=topology,
+            )
+            self._host_allocation_prepared = True
+            logger.info(
+                "Sparse KV offload selected Mooncake Host backend: pool=%.2f GiB, tp=%s/%s, dp=%s, owner=%s.",
+                self.host_pool_size_bytes / (1 << 30),
+                self.tp_rank,
+                self.tp_size,
+                dp_rank,
+                topology.owner_rank,
+            )
+        elif self.host_backend == "memfabric":
+            # MemFabric: process-wide pool prepared here; dp_rank is part of
+            # the backend-neutral contract but unused by this backend.
+            config = offload.OffloadConfig()
+            config.device_id = device_id
+            config.reserve_size = self.host_pool_size_bytes
+            config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
+            config.world_size = self.tp_size
+            config.rank_id = self.tp_rank
+            config.scene = offload.Scene.SHARED
+            assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
+            self.tp_group.barrier()
+            self._host_kv_allocator = MemFabricHostKVAllocator(self.tp_rank)
+            self._host_allocation_prepared = True
+        else:
+            raise ValueError(f"Unsupported sparse KV offload Host backend: {self.host_backend!r}")
 
     def allocate_host_kv_tensors(
         self,
@@ -596,13 +654,10 @@ class SparseKVOffloadManager:
         alignment: int,
     ) -> list[torch.Tensor | None]:
         """Allocate one layer's Host K/V through the prepared allocator."""
-        if not self._host_allocation_prepared:
+        allocator = self._host_kv_allocator
+        if allocator is None:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
-        if self._host_kv_allocator is not None:
-            return self._host_kv_allocator.allocate_tensors(sizes, alignment)
-        if self.tp_rank == 0:
-            return empty_aligned_int8_cpu_tensors(sizes, alignment)
-        return [None for _ in sizes]
+        return allocator.allocate_tensors(sizes, alignment)
 
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
@@ -788,9 +843,8 @@ class SparseKVOffloadManager:
     ):
         self._register_offload_layers(kv_caches)
 
-        # HostKVAllocator-backed pools give every TP rank local Host KV views,
-        # while the legacy MemFabric path only allocates on tp_rank == 0.
-        uses_host_allocator = self._host_kv_allocator is not None
+        # Mooncake hands every TP rank local Host KV views; MemFabric uses tp0 allocation + pointer broadcast.
+        uses_local_views = self.host_backend == "mooncake"
 
         # register topk_buffer and cpu kv_cache
         self.topk_buffers_k: list[torch.Tensor] = []
@@ -807,7 +861,7 @@ class SparseKVOffloadManager:
                 )
             self.topk_buffers_k.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_K_INDEX])
             self.topk_buffers_v.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_V_INDEX])
-            if uses_host_allocator or self.tp_rank == 0:
+            if uses_local_views or self.tp_rank == 0:
                 self.k_caches_cpu.append(cache_or_caches[OFFLOAD_K_CACHE_CPU_INDEX])
                 self.v_caches_cpu.append(cache_or_caches[OFFLOAD_V_CACHE_CPU_INDEX])
 
@@ -876,7 +930,7 @@ class SparseKVOffloadManager:
         self.gvas_k_bases: list[int] = []
         self.gvas_v_bases: list[int] = []
         self.cpu_block_lens: list[tuple[int, int]] = []
-        if uses_host_allocator:
+        if uses_local_views:
             # HostKVAllocator gave every rank local Host KV views: use them
             # directly instead of broadcasting the tp0 pointers.
             for layer_id in range(self.num_layers):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -331,10 +331,7 @@ def allocate_kv_cache_tensors_for_sparse_kv_offload(
     tp_rank: int,
     keep_device_kv_cache: bool,
     npu_kv_cache_allocate_func: typing.Callable,
-    host_kv_cache_allocate_func: typing.Callable[
-        [list[int], int], list[torch.Tensor | None]
-    ]
-    | None = None,
+    host_kv_cache_allocate_func: typing.Callable[[list[int], int], list[torch.Tensor | None]] | None = None,
 ):
     if host_kv_cache_allocate_func is not None:
         [k_tensor_cpu, v_tensor_cpu] = host_kv_cache_allocate_func(
@@ -585,15 +582,11 @@ class SparseKVOffloadManager:
         config = offload.OffloadConfig()
         config.device_id = device_id
         config.reserve_size = self.host_pool_size_bytes
-        config.alloc_size = (
-            self.host_pool_size_bytes if self.tp_rank == 0 else 0
-        )
+        config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
         config.world_size = self.tp_size
         config.rank_id = self.tp_rank
         config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, (
-            "Sparse KV offload offload.initialize failed."
-        )
+        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
         self.tp_group.barrier()
         self._host_allocation_prepared = True
 
@@ -604,9 +597,7 @@ class SparseKVOffloadManager:
     ) -> list[torch.Tensor | None]:
         """Allocate one layer's Host K/V through the prepared allocator."""
         if not self._host_allocation_prepared:
-            raise RuntimeError(
-                "prepare_host_kv_allocation must run before Host KV allocation"
-            )
+            raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         if self._host_kv_allocator is not None:
             return self._host_kv_allocator.allocate_tensors(sizes, alignment)
         if self.tp_rank == 0:

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -32,8 +32,10 @@ from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
     HostPoolTopology,
     MooncakeHostPool,
+    allocate_mooncake_host_region,
 )
 from vllm_ascend.utils import AscendDeviceType, enable_custom_op, get_ascend_device_type
 
@@ -553,6 +555,11 @@ class SparseKVOffloadManager:
         )
         self.fused_overlap_membership_map: torch.Tensor | None = None
         self.fused_overlap_membership_map_rows = 0
+        self.fused_overlap_membership_region: HostMemoryRegion | None = None
+        self.fused_overlap_planner_membership_map: torch.Tensor | None = None
+        self.fused_overlap_membership_plan_device_staging: (
+            torch.Tensor | None
+        ) = None
         self.fused_overlap_plan_owner_layer_id: int | None = None
         self.fused_overlap_plan_topk: int | None = None
         self.fused_overlap_plan_num_tokens = 0
@@ -659,8 +666,22 @@ class SparseKVOffloadManager:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         return allocator.allocate_tensors(sizes, alignment)
 
+    def _requires_fused_membership_staging(self) -> bool:
+        """Whether the active Host allocator needs a CPU planner bridge."""
+        return isinstance(
+            getattr(self, "_host_kv_allocator", None),
+            MooncakeHostPool,
+        )
+
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
+        region = getattr(self, "fused_overlap_membership_region", None)
+        if region is not None:
+            region.release()
+            self.fused_overlap_membership_region = None
+            self.fused_overlap_membership_map = None
+            self.fused_overlap_planner_membership_map = None
+            self.fused_overlap_membership_plan_device_staging = None
         allocator = self._host_kv_allocator
         if allocator is not None:
             allocator.close()
@@ -785,35 +806,120 @@ class SparseKVOffloadManager:
             return self.fused_overlap_membership_map
 
         shape = [row_capacity, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT]
-        owner_ptr = torch.zeros(1, dtype=torch.int64, device="npu")
-        membership_map = None
-        if self.tp_rank == 0:
-            membership_map = offload.empty(
-                [row_capacity * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT],
-                dtype=torch.int16,
-                pin_memory=True,
-            ).view(shape)
-            membership_map.fill_(-1)
-            control = membership_map[
-                :,
-                FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT : FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
-                + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
-            ]
-            control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
-            control[:, 2] = self.topk
-            control[:, 3] = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
-            control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
-            owner_ptr[0] = membership_map.data_ptr()
-        self.tp_group.broadcast(owner_ptr, src=0)
-        shared_ptr = int(owner_ptr.item())
-        if self.tp_rank != 0:
-            membership_map = self._restore_int16_tensor(shared_ptr, shape)
-        if membership_map is None:
-            raise RuntimeError("mapped membership storage was not initialized")
-        self.tp_group.barrier()
+        if self._requires_fused_membership_staging():
+            allocator = self._host_kv_allocator
+            assert isinstance(allocator, MooncakeHostPool)
+            region = allocate_mooncake_host_region(
+                size_bytes=(
+                    row_capacity
+                    * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
+                    * torch.int16.itemsize
+                ),
+                alignment=_CPU_CACHE_ALIGNMENT,
+                topology=allocator.topology,
+                name="sparse_kv_offload_fused_membership",
+            )
+            membership_map = region.tensor.view(torch.int16).view(shape)
+            planner_map = None
+            if self.tp_rank == 0:
+                plan_width = (
+                    self.topk
+                    + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+                )
+                plan_shape = [row_capacity, plan_width]
+                planner_map = torch.empty(
+                    plan_shape,
+                    dtype=torch.int16,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.fused_overlap_membership_plan_device_staging = (
+                    torch.empty(
+                        plan_shape,
+                        dtype=torch.int16,
+                        device=membership_map.device,
+                    )
+                )
+                self._init_fused_overlap_plan_staging(planner_map)
+                self._init_fused_overlap_membership_control(membership_map)
+                torch_npu.npu.current_stream().synchronize()
+            self.tp_group.barrier()
+            self.fused_overlap_membership_region = region
+            self.fused_overlap_planner_membership_map = planner_map
+        else:
+            owner_ptr = torch.zeros(1, dtype=torch.int64, device="npu")
+            membership_map = None
+            if self.tp_rank == 0:
+                membership_map = offload.empty(
+                    [
+                        row_capacity
+                        * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
+                    ],
+                    dtype=torch.int16,
+                    pin_memory=True,
+                ).view(shape)
+                self._init_fused_overlap_membership_control(membership_map)
+                owner_ptr[0] = membership_map.data_ptr()
+            self.tp_group.broadcast(owner_ptr, src=0)
+            shared_ptr = int(owner_ptr.item())
+            if self.tp_rank != 0:
+                membership_map = self._restore_int16_tensor(shared_ptr, shape)
+            if membership_map is None:
+                raise RuntimeError(
+                    "mapped membership storage was not initialized"
+                )
+            self.tp_group.barrier()
+            self.fused_overlap_planner_membership_map = membership_map
+
         self.fused_overlap_membership_map = membership_map
         self.fused_overlap_membership_map_rows = row_capacity
         return membership_map
+
+    def _init_fused_overlap_membership_control(
+        self,
+        membership_map: torch.Tensor,
+    ) -> None:
+        membership_map.fill_(-1)
+        control = membership_map[
+            :,
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT:
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
+            + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+        ]
+        control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
+        control[:, 2] = self.topk
+        control[:, 3] = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
+
+    def _init_fused_overlap_plan_staging(
+        self,
+        plan_staging: torch.Tensor,
+    ) -> None:
+        plan_staging.fill_(-1)
+        control = plan_staging[
+            :,
+            self.topk:
+            self.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+        ]
+        control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
+        control[:, 2] = self.topk
+        control[:, 3] = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
+
+    def is_fused_membership_storage(self, tensor: torch.Tensor) -> bool:
+        if tensor.dtype != torch.int16:
+            return False
+        if self._requires_fused_membership_staging():
+            return (
+                self.fused_overlap_membership_map is not None
+                and tensor.data_ptr()
+                == self.fused_overlap_membership_map.data_ptr()
+            )
+        return tensor.device.type == "cpu"
 
     def get_fused_overlap_cpu_kv_inputs(
         self,
@@ -1493,12 +1599,74 @@ class SparseKVOffloadManager:
             selection_membership_map,
         )
         layer_id = self._get_offload_layer_id(layer_name)
-        plan_start = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        plan_start = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        plan_width = FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS - plan_start
         plan_storage = selection_membership_map[
             :num_tokens,
             plan_start:FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS,
         ]
-        encoded_plan_stride = selection_membership_map.stride(0)
+        planner_membership_map = self.fused_overlap_planner_membership_map
+        planner_plan_start = plan_start
+        if self.tp_rank == 0:
+            if planner_membership_map is None:
+                planner_membership_map = selection_membership_map
+            elif self._requires_fused_membership_staging():
+                planner_plan_start = 0
+            if (
+                planner_membership_map.dim() != 2
+                or planner_membership_map.shape[0] < num_tokens
+                or planner_membership_map.shape[1]
+                < planner_plan_start + plan_width
+                or planner_membership_map.dtype != torch.int16
+                or planner_membership_map.device.type != "cpu"
+            ):
+                raise ValueError(
+                    "external FSA planner requires CPU int16 storage: "
+                    f"shape={tuple(planner_membership_map.shape)}, "
+                    f"dtype={planner_membership_map.dtype}, "
+                    f"device={planner_membership_map.device}"
+                )
+            planner_storage = planner_membership_map[
+                :num_tokens,
+                planner_plan_start:planner_plan_start + plan_width,
+            ]
+            if (
+                self._requires_fused_membership_staging()
+                and not planner_storage.is_contiguous()
+            ):
+                raise RuntimeError(
+                    "Mooncake external FSA planner staging must be compact "
+                    "and contiguous"
+                )
+            encoded_plan_stride = planner_membership_map.stride(0)
+        else:
+            # Only TP0 owns and runs the CPU planner. Other TP ranks consume
+            # the published plan after the metadata broadcast.
+            planner_storage = plan_storage
+            encoded_plan_stride = selection_membership_map.stride(0)
+
+        def publish_plan(non_blocking: bool) -> None:
+            if planner_storage.data_ptr() == plan_storage.data_ptr():
+                return
+            device_staging = (
+                self.fused_overlap_membership_plan_device_staging
+            )
+            if device_staging is None:
+                raise RuntimeError(
+                    "external FSA plan requires an NPU staging buffer when "
+                    "planner and operator membership storage are separate"
+                )
+            device_plan_storage = device_staging[:num_tokens, :plan_width]
+            device_plan_storage.copy_(
+                planner_storage,
+                non_blocking=non_blocking,
+            )
+            plan_storage.copy_(
+                device_plan_storage,
+                non_blocking=non_blocking,
+            )
 
         owner_layer_id = self.fused_overlap_plan_owner_layer_id
         owner_map = self.fused_overlap_plan_membership_map
@@ -1546,7 +1714,7 @@ class SparseKVOffloadManager:
                 self.lru_epochs_ptr,
                 self.lru_physical_row_workspace_ptr,
                 self.max_num_topk_rows,
-                plan_storage.data_ptr(),
+                planner_storage.data_ptr(),
                 encoded_plan_stride,
                 num_tokens,
                 self.topk,
@@ -1573,7 +1741,11 @@ class SparseKVOffloadManager:
                         ],
                         non_blocking=True,
                     )
+                    publish_plan(non_blocking=True)
                 self.tp_group.broadcast(self.fused_plan_metadata_npu, src=0)
+            torch_npu.npu.current_stream().wait_stream(
+                self.fused_plan_stream
+            )
             self.fused_overlap_plan_owner_layer_id = layer_id
             self.fused_overlap_plan_topk = self.topk
             self.fused_overlap_plan_num_tokens = num_tokens
@@ -1594,6 +1766,7 @@ class SparseKVOffloadManager:
                         self.max_num_topk_rows * 2 : self.max_num_topk_rows * 2 + num_tokens
                     ]
                 )
+                publish_plan(non_blocking=False)
             except Exception as exc:
                 planner_error = exc
                 self.fused_plan_status_npu.fill_(1)
@@ -1657,10 +1830,12 @@ class SparseKVOffloadManager:
             or selection_membership_map.shape[0] < num_tokens
             or selection_membership_map.shape[1] < FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS
             or selection_membership_map.dtype != torch.int16
-            or selection_membership_map.device.type != "cpu"
+            or not self.is_fused_membership_storage(
+                selection_membership_map
+            )
         ):
             raise ValueError(
-                "external FSA plan requires mapped CPU int16 membership storage: "
+                "external FSA plan requires registered int16 membership storage: "
                 f"min_shape=({num_tokens}, {FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS}), "
                 f"actual_shape={tuple(selection_membership_map.shape)}, "
                 f"dtype={selection_membership_map.dtype}, "

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -97,6 +97,8 @@ _SPARSE_KV_OFFLOAD_OP_NAMES = (
     "sparse_kv_compute_lru_resident_addrs",
     "sparse_kv_restore_bfloat16_tensor",
     "sparse_kv_restore_int16_tensor",
+    "sparse_kv_compute_current_kv_index_copy_descriptors",
+    "sparse_kv_enqueue_current_kv_index_copy_descriptors",
 )
 
 
@@ -553,6 +555,7 @@ class SparseKVOffloadManager:
             self.max_num_tokens,
             self.max_num_reqs * decode_width,
         )
+        self.max_d2h_index_copy_tokens = self.max_num_topk_rows
         self.fused_overlap_membership_map: torch.Tensor | None = None
         self.fused_overlap_membership_map_rows = 0
         self.fused_overlap_membership_region: HostMemoryRegion | None = None
@@ -666,12 +669,15 @@ class SparseKVOffloadManager:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         return allocator.allocate_tensors(sizes, alignment)
 
-    def _requires_fused_membership_staging(self) -> bool:
-        """Whether the active Host allocator needs a CPU planner bridge."""
+    def _uses_mooncake_host_pool(self) -> bool:
         return isinstance(
             getattr(self, "_host_kv_allocator", None),
             MooncakeHostPool,
         )
+
+    def _requires_fused_membership_staging(self) -> bool:
+        """Whether the active Host allocator needs a CPU planner bridge."""
+        return self._uses_mooncake_host_pool()
 
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
@@ -1008,6 +1014,46 @@ class SparseKVOffloadManager:
             self.fused_plan_status_npu = self.fused_plan_metadata_npu[:1]
             self.fused_plan_current_linear_slots_npu = self.fused_plan_metadata_npu[1:]
             self.current_kv_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+            if self._uses_mooncake_host_pool() and self.tp_rank == 0:
+                self.d2h_slot_mapping_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_src_idx_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_dst_idx_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_index_count_cpu = torch.zeros(
+                    1,
+                    dtype=torch.int32,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_src_idx_npu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                self.d2h_dst_idx_npu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                self.d2h_index_count_npu = torch.zeros(
+                    1,
+                    dtype=torch.int32,
+                    device=device,
+                )
         self.d2h_size_npu = torch.empty(1, dtype=torch.int32, device=device)
         self.d2h_token_indices_npu = torch.arange(self.max_num_tokens, dtype=torch.int64, device=device)
 
@@ -1330,10 +1376,22 @@ class SparseKVOffloadManager:
         has_prefill: bool = False,
         capturing: bool = False,
     ) -> None:
+        prepare_index_copy_descriptors = True
         if not has_prefill and k is not None and v is not None and self.use_fused_overlap:
             layer_id = self._get_offload_layer_id(layer_name)
             self.current_kv_by_layer[layer_id] = (k, v)
-        use_side_stream = self.tp_rank == 0 and self.use_fused_overlap and capturing and not has_prefill
+            # All decode layers share one slot mapping within a forward step.
+            prepare_index_copy_descriptors = layer_id == 0
+        use_mooncake_index_copy = (
+            self.use_fused_overlap and self._uses_mooncake_host_pool()
+        )
+        use_side_stream = (
+            self.tp_rank == 0
+            and self.use_fused_overlap
+            and capturing
+            and not has_prefill
+            and not use_mooncake_index_copy
+        )
         if not use_side_stream:
             self._offload_new_kv_on_current_stream(
                 slot_mapping,
@@ -1344,6 +1402,8 @@ class SparseKVOffloadManager:
                 k,
                 v,
                 has_prefill,
+                capturing,
+                prepare_index_copy_descriptors,
             )
             return
 
@@ -1359,6 +1419,8 @@ class SparseKVOffloadManager:
                 k,
                 v,
                 has_prefill,
+                capturing,
+                prepare_index_copy_descriptors,
             )
 
     def _offload_new_kv_on_current_stream(
@@ -1372,6 +1434,7 @@ class SparseKVOffloadManager:
         v: torch.Tensor | None,  # decode: k/v -> cache_cpu[slot]
         has_prefill: bool = False,
         capturing: bool = False,
+        prepare_index_copy_descriptors: bool = True,
     ) -> None:
         # the has_prefill path (NPU paged cache -> CPU pool D2H) only exists
         # for single-node PD-colocate debug.
@@ -1397,6 +1460,17 @@ class SparseKVOffloadManager:
             if k is None or v is None:
                 raise ValueError("decode offload requires current-token K/V")
             device = k.device
+            if self.use_fused_overlap and self._uses_mooncake_host_pool():
+                self._offload_new_kv_via_index_copy(
+                    slot_mapping=slot_mapping,
+                    k_cache_cpu=k_cache_cpu,
+                    v_cache_cpu=v_cache_cpu,
+                    k=k,
+                    v=v,
+                    capturing=capturing,
+                    prepare_descriptors=prepare_index_copy_descriptors,
+                )
+                return
 
         slots = slot_mapping.reshape(-1).to(device=device, dtype=torch.int64)
         token_count = slots.numel()
@@ -1454,6 +1528,124 @@ class SparseKVOffloadManager:
         )
         if result not in (None, 0):
             raise RuntimeError(f"memfabric D2H sparse_copy failed with result={result}")
+
+    def _prepare_current_kv_index_copy_descriptors(
+        self,
+        *,
+        slots: torch.Tensor,
+        token_count: int,
+        num_slots: int,
+    ) -> None:
+        self.d2h_slot_mapping_cpu[:token_count].copy_(
+            slots,
+            non_blocking=True,
+        )
+        _sparse_kv_ops().sparse_kv_enqueue_current_kv_index_copy_descriptors(
+            self.d2h_slot_mapping_cpu,
+            token_count,
+            self.max_d2h_index_copy_tokens,
+            num_slots,
+            self.d2h_src_idx_cpu,
+            self.d2h_dst_idx_cpu,
+            self.d2h_index_count_cpu,
+        )
+        self.d2h_src_idx_npu.copy_(
+            self.d2h_src_idx_cpu,
+            non_blocking=True,
+        )
+        self.d2h_dst_idx_npu.copy_(
+            self.d2h_dst_idx_cpu,
+            non_blocking=True,
+        )
+        self.d2h_index_count_npu.copy_(
+            self.d2h_index_count_cpu,
+            non_blocking=True,
+        )
+
+    def _offload_new_kv_via_index_copy(
+        self,
+        *,
+        slot_mapping: torch.Tensor,
+        k_cache_cpu: torch.Tensor,
+        v_cache_cpu: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        capturing: bool,
+        prepare_descriptors: bool = True,
+    ) -> None:
+        """Write current-token K/V into the Mooncake Shared Segment."""
+        token_dim_k = self.token_size_bytes_k // k.element_size()
+        token_dim_v = self.token_size_bytes_v // v.element_size()
+        k_rows = k.reshape(-1, token_dim_k)
+        v_rows = v.reshape(-1, token_dim_v)
+        if not k_rows.is_contiguous():
+            k_rows = k_rows.contiguous()
+        if not v_rows.is_contiguous():
+            v_rows = v_rows.contiguous()
+        flat_host_k = k_cache_cpu.reshape(-1, token_dim_k)
+        flat_host_v = v_cache_cpu.reshape(-1, token_dim_v)
+        slots = slot_mapping.reshape(-1).to(
+            device=k.device,
+            dtype=torch.int64,
+        )
+        token_count = slots.numel()
+        if token_count == 0:
+            return
+        if token_count > self.max_d2h_index_copy_tokens:
+            raise ValueError(
+                "Sparse KV offload rows exceed index_copy capacity, "
+                f"got {token_count}, "
+                f"capacity={self.max_d2h_index_copy_tokens}"
+            )
+        if k_rows.shape[0] != token_count or v_rows.shape[0] != token_count:
+            raise ValueError("decode K/V row counts must match slot_mapping")
+        if flat_host_k.device != k.device or flat_host_v.device != v.device:
+            raise RuntimeError(
+                "Mooncake Host views and current K/V must share one NPU device"
+            )
+        num_slots = flat_host_k.shape[0]
+        if num_slots != flat_host_v.shape[0] or num_slots <= 0:
+            raise ValueError(
+                "Mooncake Host K/V pools have incompatible token capacities"
+            )
+
+        if capturing:
+            if prepare_descriptors:
+                self._prepare_current_kv_index_copy_descriptors(
+                    slots=slots,
+                    token_count=token_count,
+                    num_slots=num_slots,
+                )
+            current_kv_ready = torch_npu.npu.current_stream().record_event()
+            with torch_npu.npu.stream(self.current_kv_save_stream):
+                self.current_kv_save_stream.wait_event(current_kv_ready)
+                flat_host_k.index_copy_(
+                    0,
+                    self.d2h_dst_idx_npu,
+                    k_rows.index_select(0, self.d2h_src_idx_npu),
+                )
+                flat_host_v.index_copy_(
+                    0,
+                    self.d2h_dst_idx_npu,
+                    v_rows.index_select(0, self.d2h_src_idx_npu),
+                )
+            return
+
+        valid = (slots >= 0) & (slots < num_slots)
+        valid_indices = torch.nonzero(valid, as_tuple=False).reshape(-1)
+        if valid_indices.numel() == 0:
+            return
+        destinations = slots.index_select(0, valid_indices)
+        flat_host_k.index_copy_(
+            0,
+            destinations,
+            k_rows.index_select(0, valid_indices),
+        )
+        flat_host_v.index_copy_(
+            0,
+            destinations,
+            v_rows.index_select(0, valid_indices),
+        )
 
     def onload_topk_kv(
         self,
@@ -1867,7 +2059,11 @@ class SparseKVOffloadManager:
         torch_npu.npu_scatter_nd_update_(flat_rope, indices, current_rope)
 
     def wait_for_current_kv_writeback(self, capturing: bool = False) -> None:
-        if self.use_fused_overlap and capturing and self.tp_rank == 0:
+        if (
+            self.use_fused_overlap
+            and capturing
+            and self.tp_rank == 0
+        ):
             torch_npu.npu.current_stream().wait_stream(self.current_kv_save_stream)
 
     def _onload_topk_kv_cpu(self, args):

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -76,6 +76,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # (safe for Ascend 910B/A3). Set to a positive value to override when
     # auto-detection is unavailable or for debugging UB overflow issues.
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
+    # Skip process-wide NUMA page migration when a Mooncake shared segment
+    # falls back to mmap + HostRegister. CPU thread binding remains enabled.
+    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -78,9 +78,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
     # Skip process-wide NUMA page migration when a Mooncake shared segment
     # falls back to mmap + HostRegister. CPU thread binding remains enabled.
-    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(
-        int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))
-    ),
+    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4203,7 +4203,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.sparse_kv_offload_config,
             )
             self.sparse_kv_offload_manager.prepare_host_kv_allocation(
-                device_id=torch_npu.npu.current_device(),
+                device_id=torch.npu.current_device(),
                 dp_rank=int(self.dp_rank),
             )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4202,6 +4202,7 @@ class NPUModelRunner(GPUModelRunner):
                 kv_cache_config,
                 self.sparse_kv_offload_config,
             )
+            assert self.sparse_kv_offload_manager is not None
             self.sparse_kv_offload_manager.prepare_host_kv_allocation(
                 device_id=torch.npu.current_device(),
                 dp_rank=int(self.dp_rank),
@@ -4786,6 +4787,7 @@ class NPUModelRunner(GPUModelRunner):
                         k_tensor_size = int(kv_cache_tensor_size // k_tensor_split_factor)
                         v_tensor_size = int(kv_cache_tensor_size // v_tensor_split_factor)
                     if self.sparse_kv_offload_enabled:
+                        assert self.sparse_kv_offload_manager is not None
                         assert self.use_sparse, "Sparse KV offload only support sparse attention."
                         assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
                         assert v_tensor_size is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4202,6 +4202,10 @@ class NPUModelRunner(GPUModelRunner):
                 kv_cache_config,
                 self.sparse_kv_offload_config,
             )
+            self.sparse_kv_offload_manager.prepare_host_kv_allocation(
+                device_id=torch_npu.npu.current_device(),
+                dp_rank=int(self.dp_rank),
+            )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
         # TODO: refactor the logic of attention
         if (
@@ -4243,6 +4247,16 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def shutdown(self) -> None:
+        parent_shutdown = getattr(super(), "shutdown", None)
+        try:
+            if callable(parent_shutdown):
+                parent_shutdown()
+        finally:
+            manager = getattr(self, "sparse_kv_offload_manager", None)
+            if manager is not None:
+                manager.close()
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()
@@ -4785,6 +4799,7 @@ class NPUModelRunner(GPUModelRunner):
                                     self.tp_rank,
                                     self.sparse_kv_offload_config.keep_device_kv_cache,
                                     self._allocate_int8_cache_tensor,
+                                    self.sparse_kv_offload_manager.allocate_host_kv_tensors,
                                 )
                             )
                         else:
@@ -4798,6 +4813,7 @@ class NPUModelRunner(GPUModelRunner):
                                             self.tp_rank,
                                             self.sparse_kv_offload_config.keep_device_kv_cache,
                                             self._allocate_int8_cache_tensor,
+                                            self.sparse_kv_offload_manager.allocate_host_kv_tensors,
                                         )
                                     )
                         continue


### PR DESCRIPTION
### What this PR does / why we need it?

> [!IMPORTANT]
> This PR depends on https://github.com/vllm-project/vllm-ascend/pull/15883, which introduces the Mooncake Host pool and the backend-neutral Host KV allocator wiring. Please review this PR on top of #15883.

This PR completes the Mooncake execution path for sparse KV offload with fused sparse attention overlap. It addresses two places where the existing MemFabric path cannot be used directly with Mooncake Shared Segments:

1. **Fused-overlap membership plan staging**
   - Allocate the fused selection membership map from a dedicated Mooncake `HostMemoryRegion` and retain the region for the lifetime of the manager.
   - Keep a compact pinned-CPU planner buffer containing only the encoded Top-K plan and control fields.
   - Publish the CPU-generated plan through an NPU staging tensor into the NPU-addressable Mooncake membership map.
   - Preserve the existing direct-write path for MemFabric, where the CPU planner and fused operator can use the same membership storage.
   - Validate planner storage shape, dtype, device, stride, and contiguity before passing raw pointers to the external planner.

2. **Graph-safe current-token KV writeback**
   - Write newly generated decode K/V directly into NPU-addressable Mooncake Host views with `index_select` + `index_copy_`.
   - Add CPU descriptor builders that filter invalid `slot_mapping` entries and pad source/destination indices to a graph-stable shape.
   - Enqueue descriptor generation as an ACL Host callback so descriptors are refreshed on every graph replay.
   - Bind captured callback payloads to the ACL model-RI lifetime, avoiding both replay-time use-after-free and permanent payload leaks.
   - Generate descriptors once per decode step on the first layer and reuse them across layers because all decode layers share the same slot mapping.
   - Run the actual Mooncake K/V writeback on `current_kv_save_stream` and add explicit stream dependencies before the data is consumed.

These changes are needed because the external LRU planner requires writable CPU `int16` storage, while a Mooncake Shared Segment is exposed as an NPU-addressable tensor. Similarly, graph replay cannot use dynamically sized `nonzero` output to build `index_copy_` indices in Python. The CPU planner bridge and captured Host callback keep both paths graph-safe without changing the MemFabric behavior.

### Does this PR introduce _any_ user-facing change?

Yes. When sparse KV offload is configured with `host_backend="mooncake"` and `use_fused_overlap=true` (the configuration introduced by #15883), fused-overlap membership planning and current-token KV writeback now work with Mooncake Shared Segments in both eager and graph execution.

This PR does not add another public configuration option and does not change the behavior of the default `memfabric` backend.

### How was this patch tested?

Added or extended coverage for:

- Mooncake membership allocation, ownership, release, compact planner staging, and two-hop plan publication.
- Eager and captured external-plan execution, TP-rank behavior, stream ordering, and planner argument/stride validation.
- Eager current-KV index-copy filtering, captured writeback stream ordering, and first-layer-only descriptor generation.
- C++ descriptor construction and padding, plus descriptor refresh across ACL graph replays in the single-card NPU nightly suite.

The following targeted unit tests passed locally:

```bash
python -m pytest -q --confcutdir=tests/ut/distributed/kv_transfer/sparse_kv_offload \
  tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
# 35 passed

python -m pytest -q --confcutdir=tests/ut/kv_offload \
  tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
# 12 passed

python -m pytest -q --confcutdir=tests/ut/kv_offload \
  tests/ut/kv_offload/test_sparse_kv_offload_index_copy.py
# 4 passed
```

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
