### PR TITLE
[CI] Align coverage workflow with PR-test vLLM version

### DIFF
--- a/.github/workflows/schedule_test_coverage.yaml
+++ b/.github/workflows/schedule_test_coverage.yaml
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         vllm_version:
-          - ${{ needs.select-full-tests.outputs.release_tag }}
+          - ${{ needs.select-full-tests.outputs.main_commit }}
     uses: ./.github/workflows/_selected_tests.yaml
     with:
       vllm: ${{ matrix.vllm_version }}


### PR DESCRIPTION
Use the verified vLLM main commit from pr_test.yaml, and allow the coverage workflow to run on pull requests.

### What this PR does / why we need it?
The version of the scheduled task vllm is changed to be the same as that of the PR.
### Does this PR introduce _any_ user-facing change?
no
### How was this patch tested?
The version of the VLLM used by the coverage rate scheduled task is the same as that used by the PR.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
