### PR TITLE
[BugFix][Ops] Fix OOB reads before cu_num_draft_tokens buffer in rejection sampling kernels

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -357,6 +357,290 @@ def test_rejection_greedy_sample_triton_kernel(synthetic_mode):
     torch.npu.reset_peak_memory_stats()
 
 
+# Boundary scenarios for the cu_num_draft_tokens[offset - 1] read in
+# rejection_greedy_sample_triton. The old tl.where formulation evaluated the
+# load unconditionally, so lane offset == 0 read one element before the
+# buffer whenever it was active. Cover every lane-0 activation mode:
+# - "all_greedy_none": is_greedy=None makes lane 0 always active (previously
+#   an out-of-bounds read on every launch).
+# - "all_greedy": is_greedy all True, same lane-0 activation via the tensor
+#   path.
+# - "mixed_first_greedy": request 0 greedy (lane 0 active, OOB in old code).
+# - "mixed_first_random": request 0 sampling (lane 0 masked by is_greedy_mask).
+# The batch mixes all-match (bonus), first-token reject, mid reject, and
+# zero-draft-token requests.
+@pytest.mark.parametrize(
+    "is_greedy_pattern",
+    ["all_greedy_none", "all_greedy", "mixed_first_greedy", "mixed_first_random"],
+)
+@torch.inference_mode()
+def test_rejection_greedy_sample_triton_boundary(is_greedy_pattern):
+    device = "npu"
+    batch_size = 8
+    max_spec_len = 3
+    # Varying draft lengths, including a zero-draft-token request (index 4).
+    draft_tokens_per_req = [3, 1, 2, 3, 0, 2, 1, 3]
+    cu_num_draft_tokens = torch.tensor([3, 4, 6, 9, 9, 11, 12, 15], dtype=torch.int32, device=device)
+    draft_token_ids = torch.tensor(
+        [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19], dtype=torch.int64, device=device
+    )
+    # Requests: 0 all-match, 1 match, 2 first-token reject, 3 mid reject,
+    # 4 no tokens, 5 all-match, 6 match, 7 first-token reject.
+    target_argmax = torch.tensor(
+        [5, 6, 7, 8, 0, 10, 11, 12, 0, 14, 15, 16, 0, 18, 19], dtype=torch.int64, device=device
+    )
+    bonus_token_ids = torch.arange(21, 29, dtype=torch.int64, device=device).unsqueeze(1)
+
+    if is_greedy_pattern == "all_greedy_none":
+        is_greedy = None
+        greedy_rows = torch.ones(batch_size, dtype=torch.bool)
+    elif is_greedy_pattern == "all_greedy":
+        is_greedy = torch.ones(batch_size, dtype=torch.bool, device=device)
+        greedy_rows = is_greedy.cpu()
+    elif is_greedy_pattern == "mixed_first_greedy":
+        is_greedy = torch.tensor([True, False, True, False, True, False, True, False], device=device)
+        greedy_rows = is_greedy.cpu()
+    else:  # mixed_first_random
+        is_greedy = torch.tensor([False, True, False, True, False, True, False, True], device=device)
+        greedy_rows = is_greedy.cpu()
+
+    output_token_ids = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    output_ref = output_token_ids.clone()
+    output_triton = output_token_ids.clone()
+
+    rejection_greedy_sample_pytorch(
+        output_ref,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        draft_tokens_per_req,
+        max_spec_len,
+        is_greedy,
+    )
+    rejection_greedy_sample_triton[(grid,)](
+        output_triton,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        is_greedy,
+        batch_size,
+        max_spec_len,
+        None,  # uniform_probs (standard greedy path)
+        None,  # synthetic_conditional_rates
+        SYNTHETIC_MODE=False,
+        BLOCK_SIZE=block_size,
+    )
+    torch.npu.synchronize()
+    assert torch.equal(output_ref, output_triton), f"is_greedy_pattern={is_greedy_pattern}"
+
+    # Non-greedy rows are owned by the random-sampling kernel and must stay
+    # untouched (sentinel preserved).
+    if is_greedy is not None:
+        non_greedy_rows = ~greedy_rows
+        assert non_greedy_rows.any()
+        assert (output_triton[non_greedy_rows.to(device)] == -1).all()
+
+    # Spot-check greedy rows: an all-match request emits the bonus token; a
+    # first-token rejection emits target_argmax and leaves the tail untouched.
+    if greedy_rows[0]:
+        assert output_triton[0].tolist() == [5, 6, 7, 21]
+    if greedy_rows[7]:
+        assert output_triton[7].tolist() == [0, -1, -1, -1]
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+# Randomized mixed batch large enough to force BLOCK_SIZE > 1, so the
+# offset == 0 lane shares a program block with other lanes. Covers the
+# multi-lane layout where only lane 0 of the first block needs masking.
+@pytest.mark.parametrize("first_req_greedy", [True, False])
+@torch.inference_mode()
+def test_rejection_greedy_sample_triton_boundary_multilane(first_req_greedy):
+    device = "npu"
+    torch.manual_seed(1234)
+    batch_size = 256  # > vector core count on all Ascend hardware
+    max_spec_len = 4
+    vocab_size = 32
+
+    lens = torch.randint(0, max_spec_len + 1, (batch_size,), dtype=torch.int32)
+    lens[0] = max_spec_len  # force an all-match request for the bonus path
+    cu_num_draft_tokens = torch.cumsum(lens, dim=0, dtype=torch.int32).to(device)
+    draft_tokens_per_req = lens.tolist()
+    num_tokens = int(lens.sum())
+
+    draft_token_ids = torch.randint(0, vocab_size, (num_tokens,), dtype=torch.int64, device=device)
+    target_argmax = torch.randint(0, vocab_size, (num_tokens,), dtype=torch.int64, device=device)
+    # Make request 0 all-match so its bonus path is exercised.
+    end0 = int(cu_num_draft_tokens[0])
+    target_argmax[:end0] = draft_token_ids[:end0]
+    bonus_token_ids = torch.randint(0, vocab_size, (batch_size, 1), dtype=torch.int64, device=device)
+    is_greedy = (torch.rand(batch_size) < 0.5).to(device)
+    is_greedy[0] = first_req_greedy
+
+    output_token_ids = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+    assert block_size > 1
+
+    output_ref = output_token_ids.clone()
+    output_triton = output_token_ids.clone()
+
+    rejection_greedy_sample_pytorch(
+        output_ref,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        draft_tokens_per_req,
+        max_spec_len,
+        is_greedy,
+    )
+    rejection_greedy_sample_triton[(grid,)](
+        output_triton,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        is_greedy,
+        batch_size,
+        max_spec_len,
+        None,
+        None,
+        SYNTHETIC_MODE=False,
+        BLOCK_SIZE=block_size,
+    )
+    torch.npu.synchronize()
+    assert torch.equal(output_ref, output_triton), f"first_req_greedy={first_req_greedy}"
+    # All-match request 0 appends the bonus token when it is greedy.
+    if first_req_greedy:
+        assert output_triton[0, max_spec_len].item() == bonus_token_ids[0, 0].item()
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+# Boundary scenarios for the cu_num_draft_tokens[offsets - 1] read in
+# rejection_random_sample_kernel. The mask there is not_greedy_mask, so lane 0
+# was active (and the old tl.where formulation read one element before the
+# buffer) whenever request 0 was a sampling request. Cover:
+# - "all_random": every request sampling (lane 0 always active).
+# - "mixed_first_random": request 0 sampling, greedy rows interleaved.
+# - "mixed_first_greedy": request 0 greedy (lane 0 masked by not_greedy_mask).
+# Also exercises a -1 draft placeholder (always rejected -> recovered token),
+# a forced all-accept request (bonus), and a zero-draft-token request.
+@pytest.mark.parametrize("is_greedy_pattern", ["all_random", "mixed_first_random", "mixed_first_greedy"])
+@torch.inference_mode()
+def test_rejection_random_sample_boundary(is_greedy_pattern):
+    device = "npu"
+    torch.manual_seed(5678)
+    batch_size = 8
+    max_spec_len = 3
+    vocab_size = 5
+    cu_num_draft_tokens = torch.tensor([3, 4, 6, 9, 9, 11, 12, 15], dtype=torch.int32, device=device)
+    num_tokens = 15
+
+    draft_token_ids = torch.randint(0, vocab_size, (num_tokens,), dtype=torch.int64, device=device)
+    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=device) + 0.01
+    target_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=device)
+    uniform_probs = torch.rand(num_tokens, dtype=torch.float32, device=device)
+    recovered_token_ids = torch.randint(0, vocab_size, (num_tokens,), dtype=torch.int64, device=device)
+    bonus_token_ids = torch.randint(0, vocab_size, (batch_size, 1), dtype=torch.int64, device=device)
+
+    # Force deterministic paths on top of the random data:
+    # - Request 0 (tokens 0..2): all-accept -> bonus token at position 3.
+    for t in range(3):
+        d = draft_token_ids[t]
+        draft_probs[t, :] = 0.01
+        draft_probs[t, d] = 0.5
+        target_probs[t, :] = 0.0
+        target_probs[t, d] = 0.5
+        uniform_probs[t] = 0.1  # 0.5 / 0.5 = 1.0 >= 0.1 -> accept
+    # - Token 6 (request 3, position 0): -1 placeholder -> always rejected,
+    #   emits the recovered token.
+    draft_token_ids[6] = -1
+
+    if is_greedy_pattern == "all_random":
+        is_greedy = torch.zeros(batch_size, dtype=torch.bool, device=device)
+    elif is_greedy_pattern == "mixed_first_random":
+        is_greedy = torch.tensor([False, True, False, True, False, True, False, True], device=device)
+    else:  # mixed_first_greedy
+        is_greedy = torch.tensor([True, False, True, False, True, False, True, False], device=device)
+
+    output_token_ids = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    output_ref = output_token_ids.clone()
+    output_triton = output_token_ids.clone()
+
+    rejection_random_sample_pytorch(
+        output_ref,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        bonus_token_ids,
+        recovered_token_ids,
+        uniform_probs,
+        is_greedy,
+        max_spec_len,
+        vocab_size,
+    )
+    rejection_random_sample_kernel[(grid,)](
+        output_triton,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        None,  # target_indices
+        bonus_token_ids,
+        recovered_token_ids,
+        uniform_probs,
+        is_greedy,
+        max_spec_len,
+        vocab_size,
+        vocab_size,  # global_vocab_size
+        batch_size,
+        None,  # ori_target_probs
+        None,  # synthetic_conditional_rates
+        NO_ORI_TARGET_PROBS=True,
+        NO_DRAFT_PROBS=False,
+        ENABLE_REDUCE_SAMPLING=False,
+        SYNTHETIC_MODE=False,
+        ENTROPY_VERIFY=False,
+        BLOCK_SIZE=block_size,
+    )
+    torch.npu.synchronize()
+    assert torch.equal(output_ref, output_triton), f"is_greedy_pattern={is_greedy_pattern}"
+
+    # Greedy rows are owned by the greedy kernel and must stay untouched.
+    greedy_rows = is_greedy.cpu()
+    if greedy_rows.any():
+        assert (output_triton[greedy_rows.to(device)] == -1).all()
+
+    # Spot checks, only meaningful when the row is a sampling request.
+    if not greedy_rows[0]:
+        # Request 0: all three draft tokens accepted + bonus at position 3.
+        assert output_triton[0].tolist() == [
+            draft_token_ids[0].item(),
+            draft_token_ids[1].item(),
+            draft_token_ids[2].item(),
+            bonus_token_ids[0, 0].item(),
+        ]
+    if not greedy_rows[3]:
+        # Request 3 starts with a -1 placeholder: rejected, emits recovered.
+        assert output_triton[3, 0].item() == recovered_token_ids[6].item()
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
 DEVICE = "npu"
 BATCH_SIZE = 7
 MAX_SPEC_LEN = 3

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -438,11 +438,12 @@ def test_rejection_greedy_sample_triton_boundary(is_greedy_pattern):
     assert torch.equal(output_ref, output_triton), f"is_greedy_pattern={is_greedy_pattern}"
 
     # Non-greedy rows are owned by the random-sampling kernel and must stay
-    # untouched (sentinel preserved).
+    # untouched (sentinel preserved). The all-greedy pattern has no such rows,
+    # so the check is skipped.
     if is_greedy is not None:
         non_greedy_rows = ~greedy_rows
-        assert non_greedy_rows.any()
-        assert (output_triton[non_greedy_rows.to(device)] == -1).all()
+        if non_greedy_rows.any():
+            assert (output_triton[non_greedy_rows.to(device)] == -1).all()
 
     # Spot-check greedy rows: an all-match request emits the bonus token; a
     # first-token rejection emits target_argmax and leaves the tail untouched.

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -108,8 +108,13 @@ def rejection_greedy_sample_triton(
         is_greedy = tl.load(is_greedy_ptr + offset, mask=mask, other=0)
         is_greedy_mask = mask & (is_greedy != 0)
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + offset - 1, is_greedy_mask))
-    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, is_greedy_mask)
+    # Mask the load itself: tl.where does not prevent reading before the
+    # buffer start (both arms are always evaluated), so lane offset == 0 must
+    # be masked out at the load. other=0 keeps num_draft_tokens deterministic
+    # (0) for masked lanes, which the per-position loop below relies on to
+    # skip them.
+    start_idx = tl.load(cu_num_draft_tokens_ptr + offset - 1, mask=is_greedy_mask & (offset > 0), other=0)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, is_greedy_mask, other=0)
     num_draft_tokens = end_idx - start_idx
 
     for pos in tl.range(0, BLOCK_SIZE):
@@ -203,8 +208,11 @@ def rejection_random_sample_kernel(
     mask = offsets < vec_len
     is_greedy = tl.load(is_greedy_ptr + offsets, mask, other=1)
     not_greedy_mask = is_greedy == 0
-    start_idxs = tl.where(offsets == 0, 0, tl.load(cu_num_draft_tokens_ptr + offsets - 1, not_greedy_mask))
-    end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, not_greedy_mask)
+    # Mask the load itself: tl.where does not prevent reading before the
+    # buffer start (both arms are always evaluated), so lane offsets == 0 must
+    # be masked out at the load.
+    start_idxs = tl.load(cu_num_draft_tokens_ptr + offsets - 1, mask=not_greedy_mask & (offsets > 0), other=0)
+    end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, not_greedy_mask, other=0)
     n_num_draft_tokens = end_idxs - start_idxs
 
     for req_i in range(BLOCK_SIZE):
@@ -368,8 +376,12 @@ def expand_kernel(
     offset = req_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     len_mask = offset < vec_len
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_tokens_ptr + offset - 1, len_mask))
-    end_idx = tl.load(cu_num_tokens_ptr + offset, len_mask)
+    # Mask the load itself: tl.where does not prevent reading before the
+    # buffer start (both arms are always evaluated), so lane offset == 0 must
+    # be masked out at the load. other=0 keeps num_tokens deterministic (0)
+    # for out-of-range lanes, which the store mask below relies on.
+    start_idx = tl.load(cu_num_tokens_ptr + offset - 1, mask=len_mask & (offset > 0), other=0)
+    end_idx = tl.load(cu_num_tokens_ptr + offset, len_mask, other=0)
     num_tokens = end_idx - start_idx
 
     src_val = tl.load(input_ptr + offset, len_mask)
@@ -402,8 +414,14 @@ def sample_recovered_tokens_kernel(
     req_idx = tl.program_id(0)
     pos = tl.program_id(1)
 
-    # Compute token index
-    start_idx = tl.where(req_idx == 0, 0, tl.load(cu_num_draft_tokens_ptr + req_idx - 1))
+    # Compute token index. Clamp the previous-request index instead of
+    # relying on tl.where: tl.where does not prevent reading before the
+    # buffer start (both arms are always evaluated), and a 0-d masked load is
+    # not reliably supported on triton-ascend. The clamped load address always
+    # stays inside the buffer; tl.where merely discards the value for
+    # req_idx == 0.
+    prev_req_idx = tl.maximum(req_idx - 1, 0)
+    start_idx = tl.where(req_idx == 0, 0, tl.load(cu_num_draft_tokens_ptr + prev_req_idx))
     end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
     num_draft_tokens = end_idx - start_idx
 


### PR DESCRIPTION
https://github.com/vllm-project/vllm-ascend/pull/16215

## What this PR does / why we need it?

Fixes sporadic device error **507035** (MTE illegal GM address access, fault symbol `load_gm_to_ubuf_1d_int32_t+0x6c`) in `rejection_greedy_sample_triton`, and eliminates three more instances of the same latent pattern.

**Root cause:** `tl.where` is a select instruction, not control flow — *both arms are always evaluated*. The pattern

```python
start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + offset - 1, is_greedy_mask))
```

therefore reads one int32 **before the buffer start** whenever lane `offset == 0` is active in the load mask (e.g. all-greedy batches where `is_greedy=None`). Whether this faults depends on the allocator layout: in production it crashed only when `cu_num_draft_tokens` happened to sit at an allocation boundary (`ptr - 4` falling into an unmapped page), which explains the sporadic, TP-dependent failures. The fault was reproduced in isolation: with `cu` placed at a boundary address (`0x400040000000`, faulting address `0x40003ffffffc`), the old kernel reports 507035 at synchronize while the fixed kernel passes 3/3 runs; with padded placement the old kernel also passes — confirming the crash is layout-dependent, not data-dependent.

**Changes:**

1. **Mask the prev-entry load itself** in the three tensor-path kernels (lane 0's load is now predicated off at the hardware level, so no memory transaction is issued):
   - `rejection_greedy_sample_triton`: `mask=is_greedy_mask & (offset > 0), other=0`
   - `rejection_random_sample_kernel`: `mask=not_greedy_mask & (offsets > 0), other=0`
   - `expand_kernel`: `mask=len_mask & (offset > 0), other=0` (lane 0 was *unconditionally* active here — same exposure level as the crashed greedy kernel)
2. **`sample_recovered_tokens_kernel`** (scalar `req_idx` path): clamp the index with `tl.maximum(req_idx - 1, 0)` so the load address always stays inside the buffer; `tl.where` then merely discards the (in-bounds, unused) value for `req_idx == 0`. A 0-d masked load is not a verified construct on triton-ascend, so the clamp is the safer equivalent.
3. **`other=0` on the `end_idx` loads**: without it, masked lanes receive an *undefined* value (Triton only guarantees the memory is not accessed). The per-request token loops (`for i in range(num_tokens1)`) rely on `num_draft_tokens == 0` to skip inactive lanes, so an undefined `end_idx` could turn into an out-of-bounds loop with both OOB reads *and writes*. `other=0` makes this invariant deterministic instead of dependent on backend implementation details.

Note: this matches the masking idiom already used by `rejection_random_sample_block_verify_kernel` in the same file (`prev_mask = not_greedy_mask & (offsets > 0)`).

## Does this PR introduce _any_ user-facing change?

No API or behavior change. For all in-bounds inputs the kernels produce bit-identical results — the only eliminated behaviors are an out-of-bounds read and reliance on undefined masked-load values. Users benefit from the disappearance of sporadic 507035 device errors / hangs in speculative decoding workloads (observed on an 8-machine PD deployment under D-model graph mode; after the fix, 3 consecutive rounds of 64-concurrent requests completed 192/192 with no device errors).

## How was this patch tested?

**Unit/e2e tests added** (`tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py`, 9 new parameterized cases, device=npu, compared against the PyTorch reference implementations):

- `test_rejection_greedy_sample_triton_boundary` — 4 patterns: `is_greedy=None` all-greedy (the always-OOB lane-0 path), all-greedy tensor, mixed batch with first request greedy vs sampling; batch includes all-match (bonus), first-token reject, mid reject, and zero-draft-token requests; also asserts non-greedy rows stay untouched (sentinel preserved)
- `test_rejection_greedy_sample_triton_boundary_multilane` — batch=256 randomized mixed batch forcing `BLOCK_SIZE > 1`, so lane 0 shares a program block with other lanes; first request greedy/sampling both covered
- `test_rejection_random_sample_boundary` — 3 patterns: all-random (lane-0 always active in this kernel), mixed with first request sampling vs greedy; includes forced all-accept (bonus), a `-1` draft placeholder (always rejected → recovered token), and a zero-draft-token request

**Existing tests** for `expand_kernel` and `sample_recovered_tokens_kernel` in the same file already exercise the req0/lane0 path on every launch and serve as regression coverage for fixes `expand_kernel` and `sample_recovered_tokens_kernel`.

**Fault-level reproduction** (isolated single-op experiment, documented in the linked investigation): boundary-address allocation of `cu` reproduces 507035 with the old kernel and passes with the fixed kernel, for both the all-accept and rejection branches.

```bash
# Commands used
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py -k "boundary"
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
ruff check && ruff format --check
```

> Note: the boundary tests verify semantic equivalence and lane-0 masking behavior; they cannot deterministically force the allocator to place tensors at mapping boundaries, so the 507035 reproduction itself relies on the dedicated single-op repro rather than pytest.

```
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_expand_kernel [14:59:22]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_sample_recovered_tokens_kernel [14:59:23]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-1-False] [14:59:23]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-1-True] [14:59:24]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-2-False] [14:59:24]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-2-True] [14:59:24]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-3-False] [14:59:25]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1-1024-3-True] [14:59:25]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-1-False] [14:59:26]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-1-True] [14:59:26]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-2-False] [14:59:26]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-2-True] [14:59:27]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-3-False] [14:59:27]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[256-1024-3-True] [14:59:27]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-1-False] [14:59:28]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-1-True] [14:59:28]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-2-False] [14:59:29]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-2-True] [14:59:29]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-3-False] [14:59:29]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[512-1024-3-True] [14:59:30]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-1-False] [14:59:30]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-1-True] [14:59:31]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-2-False] [14:59:31]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-2-True] [14:59:31]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-3-False] [14:59:32]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample[1024-1024-3-True] [14:59:32]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_spec_len_1_triton_kernel[False] [14:59:32]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_spec_len_1_triton_kernel[True] [14:59:33]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_kernel[False] [14:59:33]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_kernel[True] [14:59:34]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary[all_greedy_none] [14:59:34]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary[all_greedy] [14:59:34]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary[mixed_first_greedy] [14:59:35]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary[mixed_first_random] [14:59:35]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary_multilane[True] [14:59:36]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_greedy_sample_triton_boundary_multilane[False] [14:59:36]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample_boundary[all_random] [14:59:36]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample_boundary[mixed_first_random] [14:59:37]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_random_sample_boundary[mixed_first_greedy] [14:59:37]
PASSED
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py::test_rejection_sampler_block_verify_triton_kernel[5-3-7-is_greedy0-uniform_probs0-recovered_token_ids0-bonus_token_ids0-target_probs0-None-draft_token_ids0-cu_num_draft_tokens0] [14:59:38]
PASSED[INFO] Model cache cleared
```

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
