### PR TITLE
[MoE][Feature] Add explicit force-load-balance probe

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -71,7 +71,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). The legacy `VLLM_ASCEND_ENABLE_MLAPO` environment variable is no longer supported. |
 | `mlapo_keep_prefill_weights`        | bool | `False` | When True, keep MLAPO prefill weights on NPU instead of freeing them on kv_consumer (decode-only D) nodes. D nodes have normal local-prefill paths (recompute / fallback / preempt) that crash when the weights are freed (issue #11882). Enable this to trade NPU memory for stability. |
 | `weight_nz_mode`                    | int  | `1`     | Weight NZ mode. `0` disables NZ, `1` enables NZ only for quantized weights, and `2` also enables NZ for BF16/FP16 weights when supported. The legacy `VLLM_ASCEND_ENABLE_NZ` environment variable is no longer supported. |
-| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. `0` disables the fused path and `1` enables it when the model and parallel configuration support it. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
+| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. With `1`, MegaMoe is selected from instantiated layer capabilities: A2/A3 support BF16/W8A8/W4A8, and A5 supports W4A8 MXFP with `group_size=32`. Unsupported layouts keep the non-MegaMoe path. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. The legacy `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable is no longer supported. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature requires sequence parallelism to be enabled.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
@@ -81,6 +81,49 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. **Note**: This is an experimental feature. **Limitations**: (1) Not supported on PD-disaggregated scenario. (2) Must be disabled when sampling logprobs are requested. When reduce sample is enabled, logprobs are silently computed over partitioned logits instead of the full vocabulary, producing incorrect logprob values and top-k rankings. (3) Cannot be enabled together with lmhead TP.|
 
 The details of each configuration option are as follows:
+
+**enable_fused_mc2 (CANN MegaMoe / dispatch_ffn_combine)**
+
+When `enable_fused_mc2=1`, MoE communication may be replaced by the fused
+`dispatch_ffn_combine` or `mega_moe` operator. On A5 the MegaMoe path is
+selected from the instantiated MoE layer capabilities instead of checkpoint
+metadata; unsupported layer layouts keep the decomposed MC2/AllToAll path.
+On A5, only pure prefill batches select MegaMoe. This branch is not gated by
+the decode MC2 token capacity; decode and mixed batches retain the existing
+MC2/AllGather/AllToAll selection.
+
+| Item | A2 / A3 | A5 (Ascend 950PR / 950DT) |
+| ---- | ------- | ------------------------- |
+| Quantization | W8A8 / W4A8 (INT) and BF16 | W4A8 MXFP only, `group_size=32` |
+| Activation | SwiGLU | SwiGLU and SiTU (`activation_params={beta, linear_beta}`) |
+| Max routed experts | 1024 | 2048 (must be divisible by EP size) |
+| Max EP world size | 64 | 1024 |
+| Max top-k | 16 | 32 |
+| Hidden size | [1024, 8192], multiple of 512 | [1024, 8192], multiple of 512 |
+
+Notes for A5:
+
+- The validated CANN 9.2 package exposes the communication-context builder at
+  `cann_ops_transformer.ops.mc2.common.comm_context`. Its native loader reuses
+  cached bindings and can build missing bindings on first use. Warm up the
+  intended prefill shapes before collecting performance profiles.
+- Requires a `cann_ops_transformer` build with SiTUGLU support and the
+  `mega_moe` custom operator package. If the package is installed under
+  `${ASCEND_HOME_PATH}/opp/vendors`, make sure `ASCEND_CUSTOM_OPP_PATH` also
+  contains that vendor directory. vLLM Ascend prepends its own bundled vendors
+  path at startup, which otherwise shadows the installed package and makes the
+  call fall back to the built-in older operator.
+- The symmetric buffer receive capacity uses the operator's automatic mode
+  (`max_recv_token_num=0`); `mega_moe_max_tokens` is not used on A5.
+- The MegaMoe path is mutually exclusive with
+  `multistream_overlap_shared_expert`; the latter is force-disabled when
+  `enable_fused_mc2=1`.
+
+```bash
+vllm serve <model> \
+    --tensor-parallel-size 8 --enable-expert-parallel \
+    --additional-config '{"enable_fused_mc2": 1}'
+```
 
 **xlite_graph_config**
 

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -116,8 +116,13 @@ Notes for A5:
   contains that vendor directory. vLLM Ascend prepends its own bundled vendors
   path at startup, which otherwise shadows the installed package and makes the
   call fall back to the built-in older operator.
-- The symmetric buffer receive capacity uses the operator's automatic mode
-  (`max_recv_token_num=0`); `mega_moe_max_tokens` is not used on A5.
+- The receive capacity is `max_recv_token_num = 3 * max_num_batched_tokens`:
+  a 16384-token prefill chunk reserves 49152 received token rows per rank.
+  The configured chunk size is shared by prefill, decode and idle dummy
+  batches; it must match across all EP ranks. `mega_moe_max_tokens` is not
+  used on A5. This fixed capacity replaces the operator's worst-case automatic
+  allocation; it is not a guarantee against arbitrary expert-load imbalance.
+  The actual per-rank received token count must fit within this capacity.
 - The MegaMoe path is mutually exclusive with
   `multistream_overlap_shared_expert`; the latter is force-disabled when
   `enable_fused_mc2=2`.

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -71,7 +71,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). The legacy `VLLM_ASCEND_ENABLE_MLAPO` environment variable is no longer supported. |
 | `mlapo_keep_prefill_weights`        | bool | `False` | When True, keep MLAPO prefill weights on NPU instead of freeing them on kv_consumer (decode-only D) nodes. D nodes have normal local-prefill paths (recompute / fallback / preempt) that crash when the weights are freed (issue #11882). Enable this to trade NPU memory for stability. |
 | `weight_nz_mode`                    | int  | `1`     | Weight NZ mode. `0` disables NZ, `1` enables NZ only for quantized weights, and `2` also enables NZ for BF16/FP16 weights when supported. The legacy `VLLM_ASCEND_ENABLE_NZ` environment variable is no longer supported. |
-| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. With `1`, MegaMoe is selected from instantiated layer capabilities: A2/A3 support BF16/W8A8/W4A8, and A5 supports W4A8 MXFP with `group_size=32`. Unsupported layouts keep the non-MegaMoe path. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
+| `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. With `2`, CANN MegaMoe is selected from instantiated layer capabilities: A2/A3 support BF16/W8A8/W4A8, and A5 supports W4A8 MXFP with `group_size=32`. Unsupported layouts keep the non-MegaMoe path. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. The legacy `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable is no longer supported. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature requires sequence parallelism to be enabled.|
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
@@ -84,8 +84,10 @@ The details of each configuration option are as follows:
 
 **enable_fused_mc2 (CANN MegaMoe / dispatch_ffn_combine)**
 
-When `enable_fused_mc2=1`, MoE communication may be replaced by the fused
-`dispatch_ffn_combine` or `mega_moe` operator. On A5 the MegaMoe path is
+`enable_fused_mc2=0` disables the fused path. `1` retains the legacy fused
+path where supported and does not enable CANN MegaMoe. `2` explicitly enables
+CANN MegaMoe; configuration initialization normalizes it to `1` while keeping
+the MegaMoe runtime gate enabled. On A5 the MegaMoe path is
 selected from the instantiated MoE layer capabilities instead of checkpoint
 metadata; unsupported layer layouts keep the decomposed MC2/AllToAll path.
 On A5, only pure prefill batches select MegaMoe. This branch is not gated by
@@ -117,12 +119,12 @@ Notes for A5:
   (`max_recv_token_num=0`); `mega_moe_max_tokens` is not used on A5.
 - The MegaMoe path is mutually exclusive with
   `multistream_overlap_shared_expert`; the latter is force-disabled when
-  `enable_fused_mc2=1`.
+  `enable_fused_mc2=2`.
 
 ```bash
 vllm serve <model> \
     --tensor-parallel-size 8 --enable-expert-parallel \
-    --additional-config '{"enable_fused_mc2": 1}'
+    --additional-config '{"enable_fused_mc2": 2}'
 ```
 
 **xlite_graph_config**

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -116,13 +116,14 @@ Notes for A5:
   contains that vendor directory. vLLM Ascend prepends its own bundled vendors
   path at startup, which otherwise shadows the installed package and makes the
   call fall back to the built-in older operator.
-- The receive capacity is `max_recv_token_num = 3 * max_num_batched_tokens`:
-  a 16384-token prefill chunk reserves 49152 received token rows per rank.
-  The configured chunk size is shared by prefill, decode and idle dummy
-  batches; it must match across all EP ranks. `mega_moe_max_tokens` is not
-  used on A5. This fixed capacity replaces the operator's worst-case automatic
-  allocation; it is not a guarantee against arbitrary expert-load imbalance.
-  The actual per-rank received token count must fit within this capacity.
+- The receive capacity is fixed at `max_recv_token_num=65536` received token
+  rows per rank, independently of chunk size. Prefill, decode and idle dummy
+  batches use the same capacity. `mega_moe_max_tokens` is not used on A5.
+  This replaces the operator's worst-case automatic allocation; the actual
+  per-rank received token count must fit within 65536 rows. For Kimi K3 with
+  DP4/TP8/EP32, top-k 16 and a 16384-token chunk per DP group, the average
+  received load is 32768 rows per rank, so this capacity provides 2x the
+  average load, not a guarantee against arbitrary expert-load imbalance.
 - The MegaMoe path is mutually exclusive with
   `multistream_overlap_shared_expert`; the latter is force-disabled when
   `enable_fused_mc2=2`.

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -90,9 +90,10 @@ CANN MegaMoe; configuration initialization normalizes it to `1` while keeping
 the MegaMoe runtime gate enabled. On A5 the MegaMoe path is
 selected from the instantiated MoE layer capabilities instead of checkpoint
 metadata; unsupported layer layouts keep the decomposed MC2/AllToAll path.
-On A5, only pure prefill batches select MegaMoe. This branch is not gated by
-the decode MC2 token capacity; decode and mixed batches retain the existing
-MC2/AllGather/AllToAll selection.
+On A5, supported models select MegaMoe for prefill, decode, mixed and idle
+dummy batches. Selection is independent of local attention metadata and the
+decode MC2 token capacity, so all DP ranks sharing an EP group use the same
+communication path. Configure the same switch and model on every EP rank.
 
 | Item | A2 / A3 | A5 (Ascend 950PR / 950DT) |
 | ---- | ------- | ------------------------- |

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -109,6 +109,52 @@ def _implementation():
     return impl
 
 
+@pytest.mark.parametrize("chunk_size, expected", [(4096, 12288), (8192, 24576), (16384, 49152)])
+@pytest.mark.parametrize("decode_only", [False, True])
+def test_a5_receive_capacity_is_three_chunks_on_all_dp_ranks(monkeypatch, chunk_size, expected, decode_only):
+    monkeypatch.setattr(
+        comm,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(scheduler_config=SimpleNamespace(max_num_batched_tokens=chunk_size)),
+    )
+    monkeypatch.setattr(comm, "get_mc2_group", lambda: SimpleNamespace(device_group=object()))
+    for ep_rank in (0, 8, 16, 24):
+        impl = _implementation()
+        impl.token_dispatcher.a5_need_extra_args = True
+        impl.token_dispatcher.ep_world_size = 32
+        impl.token_dispatcher.ep_rank_id = ep_rank
+        impl.token_dispatcher.max_num_tokens_per_rank = chunk_size // 8
+        impl.moe_config = SimpleNamespace(
+            experts_per_token=16,
+            num_experts=896,
+            hidden_dim=3584,
+            intermediate_size_per_partition=3072,
+        )
+        impl.get_symm_buffer_for_mega_moe = MagicMock()
+        result = impl._init_mega_moe_symm_buffer(is_decode_only_node=decode_only)
+        assert result is impl.get_symm_buffer_for_mega_moe.return_value
+        assert impl.get_symm_buffer_for_mega_moe.call_args.kwargs["max_recv_token_num"] == expected
+
+
+@pytest.mark.parametrize("decode_only, expected", [(False, 65536), (True, 1048576)])
+def test_non_a5_receive_capacity_policy_is_preserved(monkeypatch, decode_only, expected):
+    monkeypatch.setattr(comm, "get_mc2_group", lambda: SimpleNamespace(device_group=object()))
+    monkeypatch.setattr(comm, "get_ascend_config", lambda: SimpleNamespace(mega_moe_max_tokens=65536))
+    impl = _implementation()
+    impl.token_dispatcher.a5_need_extra_args = False
+    impl.token_dispatcher.ep_world_size = 32
+    impl.token_dispatcher.max_num_tokens_per_rank = 2048
+    impl.moe_config = SimpleNamespace(
+        experts_per_token=16,
+        num_experts=896,
+        hidden_dim=3584,
+        intermediate_size_per_partition=3072,
+    )
+    impl.get_symm_buffer_for_mega_moe = MagicMock()
+    impl._init_mega_moe_symm_buffer(is_decode_only_node=decode_only)
+    assert impl.get_symm_buffer_for_mega_moe.call_args.kwargs["max_recv_token_num"] == expected
+
+
 def test_fused_mc2_routes_supported_situ_to_mega_moe():
     impl = _implementation()
     request = _request()

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -5,7 +5,9 @@ import pytest
 import torch
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
+from vllm_ascend import ascend_config as config_module
 from vllm_ascend import ascend_forward_context as afc
+from vllm_ascend import utils
 from vllm_ascend.ops.fused_moe import moe_comm_method as comm
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_experts_input
 from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
@@ -16,17 +18,22 @@ from vllm_ascend.quantization.quant_type import QuantType
 
 
 @pytest.mark.parametrize(
-    ("tokens", "pure_prefill", "supported", "expected"),
+    ("tokens", "pure_prefill", "supported", "switch", "enabled", "expected"),
     [
-        (1, True, True, afc.MoECommType.FUSED_MC2),
-        (8192, True, True, afc.MoECommType.FUSED_MC2),
-        (1, False, True, afc.MoECommType.MC2),
-        (8, False, True, afc.MoECommType.MC2),
-        (8192, False, True, afc.MoECommType.ALLTOALL),
-        (1, True, False, afc.MoECommType.MC2),
+        (1, True, True, 1, True, afc.MoECommType.FUSED_MC2),
+        (8192, True, True, 1, True, afc.MoECommType.FUSED_MC2),
+        (1, False, True, 1, True, afc.MoECommType.MC2),
+        (8, False, True, 1, True, afc.MoECommType.MC2),
+        (8192, False, True, 1, True, afc.MoECommType.ALLTOALL),
+        (1, True, False, 1, True, afc.MoECommType.MC2),
+        (8192, True, True, 0, False, afc.MoECommType.ALLTOALL),
+        (8192, True, True, 1, False, afc.MoECommType.ALLTOALL),
+        (8192, True, True, 0, True, afc.MoECommType.ALLTOALL),
     ],
 )
-def test_a5_pure_prefill_only_without_capacity_gate(monkeypatch, tokens, pure_prefill, supported, expected):
+def test_a5_pure_prefill_only_without_capacity_gate(
+    monkeypatch, tokens, pure_prefill, supported, switch, enabled, expected
+):
     config = SimpleNamespace(
         model_config=SimpleNamespace(hf_text_config=SimpleNamespace(top_k_experts=1)),
         parallel_config=SimpleNamespace(enable_expert_parallel=True, world_size_across_dp=8),
@@ -36,7 +43,8 @@ def test_a5_pure_prefill_only_without_capacity_gate(monkeypatch, tokens, pure_pr
     monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: 8)
     monkeypatch.setattr(afc, "get_ascend_device_type", lambda: afc.AscendDeviceType.A5)
     monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=8))
-    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=1))
+    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=switch))
+    monkeypatch.setattr(afc, "is_mega_moe_supported", lambda: enabled)
     assert (
         afc.select_moe_comm_method(tokens, config, is_pure_prefill=pure_prefill, cann_mega_moe_supported=supported)
         == expected
@@ -96,3 +104,53 @@ def test_fused_mc2_routes_supported_situ_to_mega_moe():
     assert args[3][0].is_contiguous()
     assert kwargs["l1_weights_sf"][0].is_contiguous()
     assert result.routed_out is impl.mega_moe.return_value[0]
+
+
+@pytest.mark.parametrize("value, normalized, enabled", [(0, 0, False), (1, 1, False), (2, 1, True)])
+def test_fused_mc2_input_controls_mega_moe(monkeypatch, value, normalized, enabled):
+    monkeypatch.setattr(config_module, "_MEGA_MOE_SUPPORTED", None)
+    monkeypatch.setattr(config_module.importlib.util, "find_spec", lambda _: object())
+    config = SimpleNamespace(weight_nz_mode=1, enable_mc2_hierarchy_comm=False, enable_fused_mc2=value)
+    config_module.AscendConfig._validate_user_input_ranges(config)
+    assert config.enable_fused_mc2 == normalized
+    assert config_module.is_mega_moe_supported() is enabled
+
+
+@pytest.mark.parametrize("switch, enabled, loads", [(0, False, False), (1, False, False), (1, True, True)])
+def test_fused_mc2_load_respects_mega_moe_switch(monkeypatch, switch, enabled, loads):
+    def initialize_base(self, config):
+        self.moe_config = config
+        self.token_dispatcher = SimpleNamespace(a5_need_extra_args=True)
+
+    monkeypatch.setattr(comm.MoECommMethod, "__init__", initialize_base)
+    monkeypatch.setattr(comm, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=switch))
+    monkeypatch.setattr(comm, "is_mega_moe_supported", lambda: enabled)
+    monkeypatch.setattr(comm.torch, "zeros", lambda *args, **kwargs: None)
+    loader = MagicMock(return_value=(MagicMock(), MagicMock()))
+    monkeypatch.setattr(comm.moe_utils, "load_cann_mega_moe_ops", loader)
+    config = SimpleNamespace(num_local_experts=2, swiglu_limit=None, swiglu_alpha=None, swiglu_beta=None)
+    capability = CannMegaMoeLayerCapability(True, "", QuantType.W4A8MXFP)
+    instance = comm.FusedMC2CommImpl(config, cann_mega_moe_capability=capability)
+    assert loader.called is loads
+    assert (instance.mega_moe is not None) is loads
+
+
+@pytest.mark.parametrize("switch, enabled, skip", [(0, False, True), (1, False, True), (1, True, False)])
+def test_disabled_capability_does_not_force_dp_allreduce(monkeypatch, switch, enabled, skip):
+    config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        compilation_config=SimpleNamespace(cudagraph_mode=SimpleNamespace(separate_routine=lambda: False)),
+    )
+    ascend = SimpleNamespace(
+        enable_fused_mc2=switch,
+        get_mc2_comm_alg=lambda: "",
+        scheduler_config=SimpleNamespace(recompute_scheduler_enable=True),
+    )
+    monkeypatch.setattr(utils, "get_ascend_config", lambda: ascend)
+    monkeypatch.setattr(utils, "is_mega_moe_supported", lambda: enabled)
+    monkeypatch.setattr(utils, "is_moe_model", lambda _: True)
+    monkeypatch.setattr(utils, "get_potential_max_tokens", lambda: 8)
+    monkeypatch.setattr(afc, "use_cann_megamoe", lambda _: False)
+    monkeypatch.setattr(afc, "select_moe_comm_method", lambda *args, **kwargs: afc.MoECommType.MC2)
+    assert utils.should_skip_allreduce_across_dp_group(config, cann_mega_moe_supported=True) is skip

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend import ascend_forward_context as afc
+from vllm_ascend.ops.fused_moe import moe_comm_method as comm
+from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_experts_input
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
+    CannMegaMoeActivation,
+    CannMegaMoeLayerCapability,
+)
+from vllm_ascend.quantization.quant_type import QuantType
+
+
+@pytest.mark.parametrize(
+    ("tokens", "pure_prefill", "supported", "expected"),
+    [
+        (1, True, True, afc.MoECommType.FUSED_MC2),
+        (8192, True, True, afc.MoECommType.FUSED_MC2),
+        (1, False, True, afc.MoECommType.MC2),
+        (8, False, True, afc.MoECommType.MC2),
+        (8192, False, True, afc.MoECommType.ALLTOALL),
+        (1, True, False, afc.MoECommType.MC2),
+    ],
+)
+def test_a5_pure_prefill_only_without_capacity_gate(monkeypatch, tokens, pure_prefill, supported, expected):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=SimpleNamespace(top_k_experts=1)),
+        parallel_config=SimpleNamespace(enable_expert_parallel=True, world_size_across_dp=8),
+        lora_config=None,
+    )
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: True)
+    monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: 8)
+    monkeypatch.setattr(afc, "get_ascend_device_type", lambda: afc.AscendDeviceType.A5)
+    monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=8))
+    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=1))
+    assert (
+        afc.select_moe_comm_method(tokens, config, is_pure_prefill=pure_prefill, cann_mega_moe_supported=supported)
+        == expected
+    )
+
+
+def _request():
+    return build_fused_experts_input(
+        hidden_states=torch.ones(2, 4),
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.tensor([[0], [1]]),
+        w1=torch.ones(2, 4, 8).transpose(-2, -1),
+        w2=torch.ones(2, 4, 8).transpose(-2, -1),
+        w1_scale=torch.ones(2, 4, 2, 2).transpose(-3, -2),
+        w2_scale=torch.ones(2, 4, 2, 2).transpose(-3, -2),
+        quant_type=QuantType.W4A8MXFP,
+        mxfp_act_quant_type=torch.float8_e4m3fn,
+        mxfp_weight_quant_type=torch.float4_e2m1fn_x2,
+        mxfp_scale_dtype=torch.float8_e8m0fnu,
+        mxfp_per_token_scale_dtype=torch.float8_e8m0fnu,
+        dynamic_eplb=False,
+        activation=MoEActivation.SITU,
+    )
+
+
+def _implementation():
+    impl = comm.FusedMC2CommImpl.__new__(comm.FusedMC2CommImpl)
+    impl.token_dispatcher = MagicMock(spec=comm.TokenDispatcherWithMC2)
+    impl.token_dispatcher.max_num_tokens_per_rank = 512
+    impl.token_dispatcher.global_bs = 0
+    impl.moe_config = SimpleNamespace(activation_situ_beta=4.0, activation_situ_linear_beta=25.0)
+    impl.cann_mega_moe_capability = CannMegaMoeLayerCapability(
+        True, "", QuantType.W4A8MXFP, CannMegaMoeActivation("situglu", alpha=25.0, beta=4.0)
+    )
+    impl.mega_moe = MagicMock(return_value=(torch.ones(2, 4), torch.ones(2, dtype=torch.int32)))
+    impl.mega_moe_symm_buffer = SimpleNamespace(dispatch_quant_mode=4, dispatch_quant_out_dtype=torch.float8_e4m3fn)
+    impl.swiglu_limit = 0.0
+    return impl
+
+
+def test_fused_mc2_routes_supported_situ_to_mega_moe():
+    impl = _implementation()
+    request = _request()
+    with (
+        patch.object(comm, "get_ascend_config", return_value=SimpleNamespace(enable_fused_mc2=1)),
+        patch.object(comm, "is_mega_moe_supported", return_value=True),
+        patch.object(comm, "_EXTRA_CTX", SimpleNamespace(is_decode_only_node=False)),
+    ):
+        result = impl.fused_experts(request)
+    impl.mega_moe.assert_called_once()
+    args, kwargs = impl.mega_moe.call_args
+    assert torch.equal(args[1], request.topk_ids.to(torch.int32))
+    assert kwargs["activation"] == "situglu"
+    assert kwargs["activation_params"] == {"beta": 4.0, "linear_beta": 25.0}
+    assert args[3][0].data_ptr() == request.weights.w1.data_ptr()
+    assert kwargs["l1_weights_sf"][0].data_ptr() == request.weights.w1_scale.data_ptr()
+    assert args[3][0].is_contiguous()
+    assert kwargs["l1_weights_sf"][0].is_contiguous()
+    assert result.routed_out is impl.mega_moe.return_value[0]

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -109,14 +109,9 @@ def _implementation():
     return impl
 
 
-@pytest.mark.parametrize("chunk_size, expected", [(4096, 12288), (8192, 24576), (16384, 49152)])
+@pytest.mark.parametrize("chunk_size", [4096, 8192, 16384])
 @pytest.mark.parametrize("decode_only", [False, True])
-def test_a5_receive_capacity_is_three_chunks_on_all_dp_ranks(monkeypatch, chunk_size, expected, decode_only):
-    monkeypatch.setattr(
-        comm,
-        "get_current_vllm_config",
-        lambda: SimpleNamespace(scheduler_config=SimpleNamespace(max_num_batched_tokens=chunk_size)),
-    )
+def test_a5_receive_capacity_is_fixed_on_all_dp_ranks(monkeypatch, chunk_size, decode_only):
     monkeypatch.setattr(comm, "get_mc2_group", lambda: SimpleNamespace(device_group=object()))
     for ep_rank in (0, 8, 16, 24):
         impl = _implementation()
@@ -133,7 +128,7 @@ def test_a5_receive_capacity_is_three_chunks_on_all_dp_ranks(monkeypatch, chunk_
         impl.get_symm_buffer_for_mega_moe = MagicMock()
         result = impl._init_mega_moe_symm_buffer(is_decode_only_node=decode_only)
         assert result is impl.get_symm_buffer_for_mega_moe.return_value
-        assert impl.get_symm_buffer_for_mega_moe.call_args.kwargs["max_recv_token_num"] == expected
+        assert impl.get_symm_buffer_for_mega_moe.call_args.kwargs["max_recv_token_num"] == 65536
 
 
 @pytest.mark.parametrize("decode_only, expected", [(False, 65536), (True, 1048576)])

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -18,22 +19,19 @@ from vllm_ascend.quantization.quant_type import QuantType
 
 
 @pytest.mark.parametrize(
-    ("tokens", "pure_prefill", "supported", "switch", "enabled", "expected"),
+    ("tokens", "supported", "switch", "enabled", "expected"),
     [
-        (1, True, True, 1, True, afc.MoECommType.FUSED_MC2),
-        (8192, True, True, 1, True, afc.MoECommType.FUSED_MC2),
-        (1, False, True, 1, True, afc.MoECommType.MC2),
-        (8, False, True, 1, True, afc.MoECommType.MC2),
-        (8192, False, True, 1, True, afc.MoECommType.ALLTOALL),
-        (1, True, False, 1, True, afc.MoECommType.MC2),
-        (8192, True, True, 0, False, afc.MoECommType.ALLTOALL),
-        (8192, True, True, 1, False, afc.MoECommType.ALLTOALL),
-        (8192, True, True, 0, True, afc.MoECommType.ALLTOALL),
+        (1, True, 1, True, afc.MoECommType.FUSED_MC2),
+        (8, True, 1, True, afc.MoECommType.FUSED_MC2),
+        (8192, True, 1, True, afc.MoECommType.FUSED_MC2),
+        (1, False, 1, True, afc.MoECommType.MC2),
+        (8192, False, 1, True, afc.MoECommType.ALLTOALL),
+        (8192, True, 0, False, afc.MoECommType.ALLTOALL),
+        (8192, True, 1, False, afc.MoECommType.ALLTOALL),
+        (8192, True, 0, True, afc.MoECommType.ALLTOALL),
     ],
 )
-def test_a5_pure_prefill_only_without_capacity_gate(
-    monkeypatch, tokens, pure_prefill, supported, switch, enabled, expected
-):
+def test_a5_capability_selection_without_capacity_gate(monkeypatch, tokens, supported, switch, enabled, expected):
     config = SimpleNamespace(
         model_config=SimpleNamespace(hf_text_config=SimpleNamespace(top_k_experts=1)),
         parallel_config=SimpleNamespace(enable_expert_parallel=True, world_size_across_dp=8),
@@ -45,10 +43,36 @@ def test_a5_pure_prefill_only_without_capacity_gate(
     monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=8))
     monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=switch))
     monkeypatch.setattr(afc, "is_mega_moe_supported", lambda: enabled)
-    assert (
-        afc.select_moe_comm_method(tokens, config, is_pure_prefill=pure_prefill, cann_mega_moe_supported=supported)
-        == expected
+    assert afc.select_moe_comm_method(tokens, config, cann_mega_moe_supported=supported) == expected
+
+
+@pytest.mark.parametrize("counts", [(2, 0), None, (0, 1), (1, 1), (0, 0)])
+def test_a5_dp_ranks_keep_same_comm_method_with_different_metadata(monkeypatch, counts):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=SimpleNamespace(top_k_experts=8)),
+        parallel_config=SimpleNamespace(enable_expert_parallel=True, world_size_across_dp=32),
+        lora_config=None,
     )
+    context = SimpleNamespace(dp_metadata=None)
+    capability = CannMegaMoeLayerCapability(True, "", QuantType.W4A8MXFP)
+    monkeypatch.setattr(afc, "set_current_vllm_config", lambda _: nullcontext())
+    monkeypatch.setattr(afc, "set_forward_context", lambda **kwargs: nullcontext())
+    monkeypatch.setattr(afc, "get_forward_context", lambda: context)
+    monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 8)
+    monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=4))
+    monkeypatch.setattr(afc, "has_layer_idx", lambda _: False)
+    monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
+    monkeypatch.setattr(afc, "get_model_cann_mega_moe_capability", lambda _: capability)
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: True)
+    monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: 128)
+    monkeypatch.setattr(afc, "get_ascend_device_type", lambda: afc.AscendDeviceType.A5)
+    monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=32))
+    monkeypatch.setattr(afc, "get_ascend_config", lambda: SimpleNamespace(enable_fused_mc2=1))
+    monkeypatch.setattr(afc, "is_mega_moe_supported", lambda: True)
+    monkeypatch.setattr(comm, "get_moe_comm_method", lambda kind: kind)
+    metadata = None if counts is None else {"layer": SimpleNamespace(num_prefills=counts[0], num_decodes=counts[1])}
+    with afc.set_ascend_forward_context(metadata, config, num_tokens=16128):
+        assert context.moe_comm_type == afc.MoECommType.FUSED_MC2
 
 
 def _request():

--- a/tests/ut/ops/test_a5_megamoe_prefill_selection.py
+++ b/tests/ut/ops/test_a5_megamoe_prefill_selection.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -219,3 +220,27 @@ def test_disabled_capability_does_not_force_dp_allreduce(monkeypatch, switch, en
     monkeypatch.setattr(afc, "use_cann_megamoe", lambda _: False)
     monkeypatch.setattr(afc, "select_moe_comm_method", lambda *args, **kwargs: afc.MoECommType.MC2)
     assert utils.should_skip_allreduce_across_dp_group(config, cann_mega_moe_supported=True) is skip
+
+
+@pytest.mark.parametrize("mask", [[True, True], [True, False], [False, False]])
+@pytest.mark.parametrize("dtype", [torch.bool, torch.int8])
+def test_a5_mxfp_padding_does_not_route_or_propagate_stale_output(mask, dtype):
+    impl = _implementation()
+    request = _request()
+    valid = torch.tensor(mask)
+    request = replace(request, routing=replace(request.routing, mc2_mask=valid.to(dtype)))
+    original_ids = request.topk_ids.clone()
+    impl.mega_moe.return_value[0][~valid] = float("nan")
+    with (
+        patch.object(comm, "get_ascend_config", return_value=SimpleNamespace(enable_fused_mc2=1)),
+        patch.object(comm, "is_mega_moe_supported", return_value=True),
+        patch.object(comm, "_EXTRA_CTX", SimpleNamespace(is_decode_only_node=False)),
+    ):
+        result = impl.fused_experts(request)
+    routed_ids = impl.mega_moe.call_args.args[1]
+    assert torch.equal(routed_ids[valid], original_ids[valid].int())
+    assert (routed_ids[~valid] == -1).all()
+    assert torch.equal(request.topk_ids, original_ids)
+    assert (result.routed_out[~valid] == 0).all()
+    assert (result.routed_out[valid] == 1).all()
+    assert impl.mega_moe.call_args.kwargs["x_active_mask"] is None

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -82,7 +82,7 @@ def test_use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval
     assert use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval) is expected
 
 
-def test_force_load_balance_probe_is_explicit_and_keeps_megamoe_unchanged(monkeypatch):
+def test_force_load_balance_probe_is_explicit_and_supports_megamoe(monkeypatch):
     monkeypatch.setattr(routed_experts_module, "ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE", True)
 
     assert should_force_moe_load_balance(
@@ -92,7 +92,7 @@ def test_force_load_balance_probe_is_explicit_and_keeps_megamoe_unchanged(monkey
         capturing=False,
         cudagraph_runtime_mode=CUDAGraphMode.NONE,
     )
-    assert not should_force_moe_load_balance(
+    assert should_force_moe_load_balance(
         quant_type=QuantType.W4A8MXFP,
         in_profile_run=False,
         use_mega_moe=True,

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from torch import nn
 from torch.nn import functional as F
-from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.activation import SituAndMul
 
 from vllm_ascend.ascend_forward_context import MoECommType
@@ -19,6 +19,7 @@ from vllm_ascend.ops.fused_moe.routed_experts import (
     AscendRoutedExperts,
     AscendUnquantizedFusedMoEMethod,
     make_eplb_placement_config,
+    should_force_moe_load_balance,
     use_multistage_eplb_load,
 )
 from vllm_ascend.ops.fused_moe.router import fused_topk_router as fused_topk_router_module
@@ -79,6 +80,58 @@ def _build_unquantized_method(*, dynamic_eplb: bool = False):
 )
 def test_use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval, expected):
     assert use_multistage_eplb_load(dynamic_eplb, policy_type, collection_interval) is expected
+
+
+def test_force_load_balance_probe_is_explicit_and_keeps_megamoe_unchanged(monkeypatch):
+    monkeypatch.setattr(routed_experts_module, "ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE", True)
+
+    assert should_force_moe_load_balance(
+        quant_type=QuantType.W4A8MXFP,
+        in_profile_run=False,
+        use_mega_moe=False,
+        capturing=False,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    assert not should_force_moe_load_balance(
+        quant_type=QuantType.W4A8MXFP,
+        in_profile_run=False,
+        use_mega_moe=True,
+        capturing=False,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    assert not should_force_moe_load_balance(
+        quant_type=QuantType.W8A8MXFP,
+        in_profile_run=False,
+        use_mega_moe=False,
+        capturing=False,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+    assert should_force_moe_load_balance(
+        quant_type=QuantType.W4A8MXFP,
+        in_profile_run=True,
+        use_mega_moe=True,
+        capturing=False,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+
+@pytest.mark.parametrize(
+    "cudagraph_runtime_mode",
+    [CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE],
+)
+def test_force_load_balance_probe_skips_graph_mode(monkeypatch, cudagraph_runtime_mode):
+    monkeypatch.setattr(routed_experts_module, "ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE", True)
+    warning_once = MagicMock()
+    monkeypatch.setattr(routed_experts_module.logger, "warning_once", warning_once)
+
+    assert not should_force_moe_load_balance(
+        quant_type=QuantType.W4A8MXFP,
+        in_profile_run=False,
+        use_mega_moe=False,
+        capturing=False,
+        cudagraph_runtime_mode=cudagraph_runtime_mode,
+    )
+    warning_once.assert_called_once()
 
 
 def test_make_eplb_placement_config_does_not_copy_source():

--- a/tests/ut/ops/test_mega_moe_adapter.py
+++ b/tests/ut/ops/test_mega_moe_adapter.py
@@ -1,0 +1,228 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
+    CannMegaMoeApiCapability,
+    CannMegaMoeLayerCapability,
+    evaluate_cann_mega_moe_layer,
+    get_model_cann_mega_moe_capability,
+    probe_cann_mega_moe_api,
+    resolve_cann_mega_moe_activation,
+)
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import AscendDeviceType
+
+
+@pytest.fixture
+def a5_api_capability():
+    return CannMegaMoeApiCapability(
+        available=True,
+        supports_situ=True,
+        supports_comm_context_preload=True,
+    )
+
+
+def _moe_config(**overrides):
+    values = {
+        "in_dtype": torch.bfloat16,
+        "hidden_dim": 3584,
+        "intermediate_size_per_partition": 3072,
+        "experts_per_token": 16,
+        "ep_size": 32,
+        "num_experts": 896,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _quant_method(quant_type=QuantType.W4A8MXFP, group_size=32):
+    return SimpleNamespace(quant_type=quant_type, group_size=group_size)
+
+
+def _compatible_mega_moe(*args, **kwargs):
+    return args, kwargs
+
+
+def _situ_mega_moe(
+    x,
+    topk_ids,
+    topk_weights,
+    l1_weights,
+    l2_weights,
+    sym_buffer,
+    *,
+    l1_weights_sf=None,
+    l2_weights_sf=None,
+    l1_bias=None,
+    l2_bias=None,
+    x_active_mask=None,
+    activation="swiglu",
+    activation_clamp=None,
+    activation_params=None,
+    weight1_type=None,
+    weight2_type=None,
+):
+    return x, topk_ids
+
+
+def test_api_probe_separates_base_backend_from_a5_extensions():
+    ops_module = SimpleNamespace(
+        mega_moe=_compatible_mega_moe,
+        get_symm_buffer_for_mega_moe=object(),
+    )
+
+    probe_cann_mega_moe_api.cache_clear()
+    with patch(
+        "vllm_ascend.ops.fused_moe.mega_moe_adapter.import_module",
+        side_effect=[ops_module, ImportError("comm context is unavailable")],
+    ):
+        capability = probe_cann_mega_moe_api()
+    probe_cann_mega_moe_api.cache_clear()
+
+    assert capability.available
+    assert not capability.supports_situ
+    assert not capability.supports_comm_context_preload
+
+
+def test_api_probe_recognizes_explicit_a5_situ_contract():
+    ops_module = SimpleNamespace(
+        mega_moe=_situ_mega_moe,
+        get_symm_buffer_for_mega_moe=object(),
+    )
+    comm_context_module = SimpleNamespace(
+        comm_context_op_builder=SimpleNamespace(load=lambda: None),
+    )
+
+    probe_cann_mega_moe_api.cache_clear()
+    with patch(
+        "vllm_ascend.ops.fused_moe.mega_moe_adapter.import_module",
+        side_effect=[ops_module, comm_context_module],
+    ):
+        capability = probe_cann_mega_moe_api()
+    probe_cann_mega_moe_api.cache_clear()
+
+    assert capability.available
+    assert capability.supports_situ
+    assert capability.supports_comm_context_preload
+
+
+def test_a5_capability_uses_instantiated_layer_contract(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(),
+        _quant_method(),
+        MoEActivation.SITU,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.W4A8MXFP
+    assert capability.activation is not None
+    assert capability.activation.name == "situglu"
+    assert capability.activation.alpha == 25.0
+    assert capability.activation.beta == 4.0
+
+
+def test_a5_capability_unwraps_the_runtime_quant_scheme(a5_api_capability):
+    wrapped_quant_method = SimpleNamespace(quant_method=_quant_method())
+
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(),
+        wrapped_quant_method,
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.W4A8MXFP
+
+
+@pytest.mark.parametrize(
+    ("config_overrides", "quant_overrides", "reason"),
+    [
+        ({}, {"group_size": 64}, "group_size=32"),
+        ({"hidden_dim": 3600}, {}, "hidden size"),
+        ({"experts_per_token": 33}, {}, "top-k"),
+        ({"num_experts": 895}, {}, "divisible by EP size"),
+    ],
+)
+def test_a5_capability_rejects_unsupported_runtime_layout(
+    a5_api_capability,
+    config_overrides,
+    quant_overrides,
+    reason,
+):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(**config_overrides),
+        _quant_method(**quant_overrides),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A5,
+        api_capability=a5_api_capability,
+    )
+
+    assert not capability.supported
+    assert reason in capability.reason
+
+
+def test_a3_keeps_unquantized_megamoe_support(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(num_experts=128, ep_size=8),
+        _quant_method(QuantType.NONE, group_size=None),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A3,
+        api_capability=a5_api_capability,
+    )
+
+    assert capability.supported
+    assert capability.quant_type == QuantType.NONE
+
+
+def test_a3_rejects_mxfp4_instead_of_entering_incompatible_operator(a5_api_capability):
+    capability = evaluate_cann_mega_moe_layer(
+        _moe_config(num_experts=128, ep_size=8),
+        _quant_method(),
+        MoEActivation.SILU,
+        device_type=AscendDeviceType.A3,
+        api_capability=a5_api_capability,
+    )
+
+    assert not capability.supported
+    assert "W4A8MXFP" in capability.reason
+
+
+def test_situ_requires_linear_beta():
+    activation = resolve_cann_mega_moe_activation(MoEActivation.SITU, situ_beta=1.0)
+
+    assert activation is None
+
+
+def test_model_capability_requires_every_registered_moe_layer():
+    model = torch.nn.Module()
+    model.first_moe = torch.nn.Module()
+    model.second_moe = torch.nn.Module()
+    supported = CannMegaMoeLayerCapability(True, "", QuantType.W4A8MXFP)
+    unsupported = CannMegaMoeLayerCapability(False, "unsupported activation", QuantType.W4A8MXFP)
+    model.first_moe.cann_mega_moe_capability = supported
+    model.second_moe.cann_mega_moe_capability = unsupported
+
+    assert get_model_cann_mega_moe_capability(model) is unsupported
+
+
+def test_model_capability_ignores_checkpoint_metadata_without_registered_layers():
+    model = torch.nn.Module()
+    model.quantization_config = {
+        "quant_method": "compressed-tensors",
+        "format": "mxfp4-pack-quantized",
+    }
+
+    capability = get_model_cann_mega_moe_capability(model)
+
+    assert not capability.supported
+    assert "no registered" in capability.reason

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -13,14 +13,15 @@ from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.ops.fused_moe import moe_mlp as moe_mlp_module
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEWeights
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.dataclass.moe_quant import MoEMxfpParams, MoEQuantParams
 from vllm_ascend.ops.fused_moe.moe_mlp import (
     _swiglu_oai_dynamic_mx_quant,
     cumsum_group_list,
-    synthetic_balance_group_list,
     quant_apply_mlp,
+    synthetic_balance_group_list,
     unified_apply_mlp,
     unquant_apply_mlp,
 )

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -19,6 +19,7 @@ from vllm_ascend.ops.fused_moe.dataclass.moe_quant import MoEMxfpParams, MoEQuan
 from vllm_ascend.ops.fused_moe.moe_mlp import (
     _swiglu_oai_dynamic_mx_quant,
     cumsum_group_list,
+    synthetic_balance_group_list,
     quant_apply_mlp,
     unified_apply_mlp,
     unquant_apply_mlp,
@@ -61,6 +62,30 @@ class TestCumsumGroupList(unittest.TestCase):
                 with self.assertRaises(NotImplementedError) as excinfo:
                     cumsum_group_list(self.glist_dict[0], src_list_type, dst_list_type)
                 self.assertIn("This feature is under development.", str(excinfo.exception))
+
+
+class TestSyntheticBalanceGroupList(unittest.TestCase):
+    def test_balances_count_group_list_and_preserves_total(self):
+        group_list = torch.tensor([0, 7, 1, 2], dtype=torch.int64)
+        result = synthetic_balance_group_list(group_list, group_list_type=1)
+        self.assertTrue(torch.equal(result, torch.tensor([3, 3, 2, 2])))
+        self.assertEqual(result.sum(), group_list.sum())
+        self.assertEqual(result.dtype, group_list.dtype)
+
+    def test_balances_cumulative_group_list_and_preserves_total(self):
+        group_list = torch.tensor([0, 7, 8, 10], dtype=torch.int32)
+        result = synthetic_balance_group_list(group_list, group_list_type=0)
+        self.assertTrue(torch.equal(result, torch.tensor([3, 6, 8, 10], dtype=torch.int32)))
+        self.assertEqual(result[-1], group_list[-1])
+        self.assertEqual(result.dtype, group_list.dtype)
+
+    def test_rejects_sparse_group_list(self):
+        with self.assertRaisesRegex(ValueError, "supports only count"):
+            synthetic_balance_group_list(torch.tensor([[0, 2], [3, 1]]), group_list_type=2)
+
+    def test_rejects_empty_group_list(self):
+        with self.assertRaisesRegex(ValueError, "non-empty 1-D"):
+            synthetic_balance_group_list(torch.tensor([], dtype=torch.int64), group_list_type=1)
 
 
 class TestW4A8RuntimeFlags(unittest.TestCase):
@@ -236,7 +261,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         expected = torch.randn(2, 8)
         mlp_compute_input = MoEMlpComputeInput(
             hidden_states=hidden_states,
-            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list=torch.tensor([3, 1], dtype=torch.int64),
             group_list_type=1,
             dynamic_scale=None,
             topk_scales=None,
@@ -254,6 +279,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         )
 
         with (
+            patch.object(moe_mlp_module, "ENABLE_MOE_SYNTHETIC_BALANCE", False),
             patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp", return_value=expected) as mock_unquant,
             patch("vllm_ascend.ops.fused_moe.moe_mlp.quant_apply_mlp") as mock_quant,
         ):
@@ -263,7 +289,39 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         mock_unquant.assert_called_once()
         self.assertEqual(mock_unquant.call_args.kwargs["activation"], "silu")
         self.assertFalse(mock_unquant.call_args.kwargs["need_trans"])
+        self.assertTrue(torch.equal(mock_unquant.call_args.kwargs["group_list"], torch.tensor([3, 1])))
         mock_quant.assert_not_called()
+
+    def test_request_applies_synthetic_group_list_balance_when_enabled(self):
+        hidden_states = torch.randn(4, 8)
+        expected = torch.randn(4, 8)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=hidden_states,
+            group_list=torch.tensor([0, 4], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=torch.randn(2, 16, 8),
+                w2=torch.randn(2, 8, 8),
+                w1_bias=torch.randn(2, 16),
+                w2_bias=torch.randn(2, 8),
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.NONE),
+            fusion=False,
+            activation="silu",
+            need_trans=False,
+            dynamic_eplb=False,
+        )
+
+        with (
+            patch.object(moe_mlp_module, "ENABLE_MOE_SYNTHETIC_BALANCE", True),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.unquant_apply_mlp", return_value=expected) as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        self.assertTrue(torch.equal(mock_unquant.call_args.kwargs["group_list"], torch.tensor([2, 2])))
 
     def test_request_quant_path(self):
         for quant_type, mxfp_dtype in (

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -1035,6 +1035,25 @@ class TestTopLevelSwitchTypeValidation(TestBase):
         self.assertFalse(is_mega_moe_supported())
 
     @_clean_up
+    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch.object(AscendConfig, "_is_megamoe_supported_by_config", return_value=False)
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_a5_explicit_megamoe_defers_to_layer_capability(self, mock_fix, legacy_check, mock_device):
+        vc = VllmConfig()
+        vc.additional_config = {"enable_fused_mc2": 2}
+
+        def find_spec(name, *args, **kwargs):
+            if name == "cann_ops_transformer":
+                return object()
+            return real_find_spec(name, *args, **kwargs)
+
+        with patch("vllm_ascend.ascend_config.importlib.util.find_spec", side_effect=find_spec):
+            config = init_ascend_config(vc)
+        self.assertEqual(config.enable_fused_mc2, 1)
+        self.assertTrue(is_mega_moe_supported())
+        legacy_check.assert_not_called()
+
+    @_clean_up
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_converged_bypass_fields_are_validated(self, mock_fix):
         vc = VllmConfig()

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -478,7 +478,13 @@ def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER
 
 
-def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):
+@pytest.mark.parametrize(
+    ("num_prefills", "num_decodes", "expected_pure_prefill"),
+    [(1, 0, True), (1, 1, False), (0, 1, False), (0, 0, False)],
+)
+def test_set_ascend_forward_context_pins_current_vllm_config(
+    monkeypatch, num_prefills, num_decodes, expected_pure_prefill
+):
     vllm_config = _make_vllm_config()
     seen: dict[str, object] = {"config": None, "inside": False}
 
@@ -503,7 +509,8 @@ def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):
     monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 1)
     monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=1))
     monkeypatch.setattr(afc, "has_layer_idx", lambda _model: False)
-    monkeypatch.setattr(afc, "select_moe_comm_method", lambda *_args, **_kwargs: None)
+    selector = MagicMock(return_value=None)
+    monkeypatch.setattr(afc, "select_moe_comm_method", selector)
     monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
 
     moe_mod_name = "vllm_ascend.ops.fused_moe.moe_comm_method"
@@ -512,8 +519,10 @@ def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):
     else:
         monkeypatch.setitem(sys.modules, moe_mod_name, SimpleNamespace(get_moe_comm_method=lambda _t: None))
 
-    with afc.set_ascend_forward_context(None, vllm_config, num_tokens=4):
+    metadata = {"layer": SimpleNamespace(num_prefills=num_prefills, num_decodes=num_decodes)}
+    with afc.set_ascend_forward_context(metadata, vllm_config, num_tokens=4):
         assert seen["inside"] is True
         assert seen["config"] is vllm_config
 
     assert seen["inside"] is False
+    selector.assert_called_once_with(4, vllm_config, model_instance=None, is_pure_prefill=expected_pure_prefill)

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -478,13 +478,7 @@ def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER
 
 
-@pytest.mark.parametrize(
-    ("num_prefills", "num_decodes", "expected_pure_prefill"),
-    [(1, 0, True), (1, 1, False), (0, 1, False), (0, 0, False)],
-)
-def test_set_ascend_forward_context_pins_current_vllm_config(
-    monkeypatch, num_prefills, num_decodes, expected_pure_prefill
-):
+def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):
     vllm_config = _make_vllm_config()
     seen: dict[str, object] = {"config": None, "inside": False}
 
@@ -519,10 +513,9 @@ def test_set_ascend_forward_context_pins_current_vllm_config(
     else:
         monkeypatch.setitem(sys.modules, moe_mod_name, SimpleNamespace(get_moe_comm_method=lambda _t: None))
 
-    metadata = {"layer": SimpleNamespace(num_prefills=num_prefills, num_decodes=num_decodes)}
-    with afc.set_ascend_forward_context(metadata, vllm_config, num_tokens=4):
+    with afc.set_ascend_forward_context(None, vllm_config, num_tokens=4):
         assert seen["inside"] is True
         assert seen["config"] is vllm_config
 
     assert seen["inside"] is False
-    selector.assert_called_once_with(4, vllm_config, model_instance=None, is_pure_prefill=expected_pure_prefill)
+    selector.assert_called_once_with(4, vllm_config, model_instance=None)

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -158,6 +158,7 @@ class TestDeviceMetadataFullGraphEvents(unittest.TestCase):
 
         @contextmanager
         def forward_context(*args, **kwargs):
+            self.assertEqual(kwargs["num_actual_tokens"], expected_actual_tokens)
             events.append("context_enter")
             yield
             events.append("context_exit")
@@ -168,9 +169,13 @@ class TestDeviceMetadataFullGraphEvents(unittest.TestCase):
             patch("vllm_ascend.worker.model_runner_v1.set_ascend_forward_context", forward_context),
             patch("vllm_ascend.worker.model_runner_v1.update_cos_sin"),
         ):
-            runner._dummy_run(4, cudagraph_runtime_mode=CUDAGraphMode.FULL, is_graph_capturing=True)
-
-        self.assertEqual(events, ["context_enter", "forward", "context_exit", "release"])
+            for actual_tokens in (None, 0, 2):
+                with self.subTest(actual_tokens=actual_tokens):
+                    events.clear()
+                    expected_actual_tokens = 4 if actual_tokens is None else actual_tokens
+                    kwargs = {} if actual_tokens is None else {"num_actual_tokens": actual_tokens}
+                    runner._dummy_run(4, cudagraph_runtime_mode=CUDAGraphMode.FULL, is_graph_capturing=True, **kwargs)
+                    self.assertEqual(events, ["context_enter", "forward", "context_exit", "release"])
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -766,11 +766,17 @@ class TestNPUWorker(TestBase):
             mock_uniform_decode_query_len = mock_model_runner.uniform_decode_query_len
             worker.model_runner = mock_model_runner
 
-            # Test execute_dummy_batch
-            worker.execute_dummy_batch()
-
-            # Verify call
-            mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
+            for device_type in (AscendDeviceType.A5, AscendDeviceType.A3, AscendDeviceType._310P):
+                for use_v2 in (False, True):
+                    with self.subTest(device_type=device_type, use_v2=use_v2):
+                        worker.use_v2_model_runner = use_v2
+                        mock_model_runner._dummy_run.reset_mock()
+                        with patch("vllm_ascend.worker.worker.get_ascend_device_type", return_value=device_type):
+                            worker.execute_dummy_batch()
+                        kwargs = {"uniform_decode": True}
+                        if device_type == AscendDeviceType.A5 and not use_v2:
+                            kwargs["num_actual_tokens"] = 0
+                        mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, **kwargs)
 
     @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
     @patch("vllm_ascend.worker.worker.get_ascend_config")

--- a/typos.toml
+++ b/typos.toml
@@ -21,7 +21,7 @@ extend-ignore-identifiers-re = [".*Unc.*", ".*_thw",
     ".*ot.*", ".*[Tt]h[rR].*",
     # tools/ai_qos.py: align with driver qos_mata_config / original_sdma_mata (not "meta")
     ".*(?i)mata.*"]
-extend-ignore-words-re = ["CANN", "cann","ND","alog","nd","BA","datas","ful","udo","artifcat",]
+extend-ignore-words-re = ["CANN", "Cann", "cann","ND","alog","nd","BA","datas","ful","udo","artifcat",]
 extend-ignore-re = []
 
 [default.extend-identifiers]

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -509,7 +509,7 @@ class AscendConfig:
             )
 
         # enable_shared_expert_dp = val and ep and tp>1
-        from vllm_ascend.utils import enable_sp
+        from vllm_ascend.utils import AscendDeviceType, enable_sp, get_ascend_device_type
 
         self.enable_shared_expert_dp = (
             self.enable_shared_expert_dp
@@ -565,7 +565,14 @@ class AscendConfig:
                 "enable_fused_mc2 and multistream_overlap_shared_expert "
                 "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
             )
-        if self.enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED and not self._is_megamoe_supported_by_config(vc):
+        # A5 is validated from instantiated layer capabilities, including MXFP.
+        # The legacy checkpoint-metadata filter below is only for A2/A3.
+        if (
+            self.enable_fused_mc2 == 1
+            and _MEGA_MOE_SUPPORTED
+            and get_ascend_device_type() != AscendDeviceType.A5
+            and not self._is_megamoe_supported_by_config(vc)
+        ):
             self.enable_fused_mc2 = 0
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -12,6 +12,7 @@ from vllm.forward_context import BatchDescriptor, get_forward_context, set_forwa
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config, is_mega_moe_supported
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import get_model_cann_mega_moe_capability
 from vllm_ascend.utils import (
     AscendDeviceType,
     get_ascend_device_type,
@@ -141,9 +142,14 @@ def set_ascend_forward_context(
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 
         max_num_tokens = int(num_tokens_across_dp.max().item()) if num_tokens_across_dp is not None else num_tokens
+        is_pure_prefill = bool(attn_metadata) and all(
+            meta.num_prefills > 0 and meta.num_decodes == 0 for meta in attn_metadata.values()
+        )
         moe_comm_type = select_moe_comm_method(
             max_num_tokens,
             vllm_config,
+            model_instance=model_instance,
+            is_pure_prefill=is_pure_prefill,
         )
 
         forward_context.moe_comm_type = moe_comm_type
@@ -316,11 +322,20 @@ def _select_a5_moe_comm_method(
     num_tokens: int,
     vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
+    is_pure_prefill: bool = False,
 ) -> MoECommType:
+    hf_text_config = vllm_config.model_config.hf_text_config
+    if cann_mega_moe_supported is None:
+        cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
+    if is_pure_prefill and get_ascend_config().enable_fused_mc2 == 1 and cann_mega_moe_supported:
+        return MoECommType.FUSED_MC2
+
     num_experts_per_tok = getattr(
-        vllm_config.model_config.hf_text_config,
+        hf_text_config,
         "num_experts_per_tok",
-        getattr(vllm_config.model_config.hf_text_config, "top_k_experts", 1),
+        getattr(hf_text_config, "top_k_experts", 1),
     )
     world_size = vllm_config.parallel_config.world_size_across_dp
     if (num_tokens is None or num_tokens <= mc2_tokens_capacity) and world_size > 1:
@@ -330,7 +345,14 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
+def select_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    *,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
+    is_pure_prefill: bool = False,
+) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -349,7 +371,12 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
     Args:
         num_tokens (int): The number of tokens in the current batch.
         vllm_config (VllmConfig): Runtime configuration for the model.
-        is_draft_model (bool): Whether the model runs in MTP mode.
+        is_pure_prefill (bool): Select A5 MegaMoe only for pure prefill;
+            decode and mixed batches retain the original MC2 selection.
+        model_instance (torch.nn.Module | None): Loaded model used to aggregate
+            registered MegaMoe layer capabilities.
+        cann_mega_moe_supported (bool | None): Optional already-aggregated
+            capability result for initialization paths without a model handle.
 
     Raises:
         ValueError: If the soc version is unsupported.
@@ -380,7 +407,14 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
             vllm_config,
         )
     elif soc_version == AscendDeviceType.A5:
-        moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
+        moe_comm_type = _select_a5_moe_comm_method(
+            num_tokens,
+            vllm_config,
+            mc2_tokens_capacity,
+            model_instance,
+            cann_mega_moe_supported,
+            is_pure_prefill=is_pure_prefill,
+        )
     elif soc_version == AscendDeviceType._310P:
         moe_comm_type = MoECommType.ALLGATHER
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -142,14 +142,10 @@ def set_ascend_forward_context(
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 
         max_num_tokens = int(num_tokens_across_dp.max().item()) if num_tokens_across_dp is not None else num_tokens
-        is_pure_prefill = bool(attn_metadata) and all(
-            meta.num_prefills > 0 and meta.num_decodes == 0 for meta in attn_metadata.values()
-        )
         moe_comm_type = select_moe_comm_method(
             max_num_tokens,
             vllm_config,
             model_instance=model_instance,
-            is_pure_prefill=is_pure_prefill,
         )
 
         forward_context.moe_comm_type = moe_comm_type
@@ -324,17 +320,11 @@ def _select_a5_moe_comm_method(
     mc2_tokens_capacity: int,
     model_instance: torch.nn.Module | None = None,
     cann_mega_moe_supported: bool | None = None,
-    is_pure_prefill: bool = False,
 ) -> MoECommType:
     hf_text_config = vllm_config.model_config.hf_text_config
     if cann_mega_moe_supported is None:
         cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
-    if (
-        is_pure_prefill
-        and get_ascend_config().enable_fused_mc2 == 1
-        and is_mega_moe_supported()
-        and cann_mega_moe_supported
-    ):
+    if get_ascend_config().enable_fused_mc2 == 1 and is_mega_moe_supported() and cann_mega_moe_supported:
         return MoECommType.FUSED_MC2
 
     num_experts_per_tok = getattr(
@@ -356,7 +346,6 @@ def select_moe_comm_method(
     *,
     model_instance: torch.nn.Module | None = None,
     cann_mega_moe_supported: bool | None = None,
-    is_pure_prefill: bool = False,
 ) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
@@ -369,15 +358,15 @@ def select_moe_comm_method(
        group size is small enough; otherwise use MC2 within capacity or
        all-to-all.
     5. On 310P, always use all-gather.
-    6. On A5 with expert parallel, use MC2 when tokens fit the MC2 capacity
-       and the EP size is large enough; otherwise use all-gather when
-       EP size is smaller than num of topK experts or all-to-all.
+    6. On A5 with expert parallel, prefer CANN MegaMoe when explicitly
+       enabled and supported by the model. This must not depend on local
+       batch metadata: active and idle DP ranks share the same EP group.
+       Otherwise use MC2 within capacity, all-gather for small EP groups,
+       or all-to-all.
 
     Args:
         num_tokens (int): The number of tokens in the current batch.
         vllm_config (VllmConfig): Runtime configuration for the model.
-        is_pure_prefill (bool): Select A5 MegaMoe only for pure prefill;
-            decode and mixed batches retain the original MC2 selection.
         model_instance (torch.nn.Module | None): Loaded model used to aggregate
             registered MegaMoe layer capabilities.
         cann_mega_moe_supported (bool | None): Optional already-aggregated
@@ -418,7 +407,6 @@ def select_moe_comm_method(
             mc2_tokens_capacity,
             model_instance,
             cann_mega_moe_supported,
-            is_pure_prefill=is_pure_prefill,
         )
     elif soc_version == AscendDeviceType._310P:
         moe_comm_type = MoECommType.ALLGATHER

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -329,7 +329,12 @@ def _select_a5_moe_comm_method(
     hf_text_config = vllm_config.model_config.hf_text_config
     if cann_mega_moe_supported is None:
         cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
-    if is_pure_prefill and get_ascend_config().enable_fused_mc2 == 1 and cann_mega_moe_supported:
+    if (
+        is_pure_prefill
+        and get_ascend_config().enable_fused_mc2 == 1
+        and is_mega_moe_supported()
+        and cann_mega_moe_supported
+    ):
         return MoECommType.FUSED_MC2
 
     num_experts_per_tok = getattr(

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,8 +66,49 @@ env_variables: dict[str, Callable[[], Any]] = {
     # In this case, developers need to set this value to "0.9.0" to make sure
     # that the correct package is installed.
     "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
+    # Whether to enable FlashComm optimization when tensor parallel is enabled.
+    # This feature will get better performance when concurrency is large.
+    # DEPRECATED: use additional_config.enable_flashcomm1 instead.
+    "VLLM_ASCEND_ENABLE_FLASHCOMM1": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0"))),
+    # Whether to enable msMonitor tool to monitor the performance of vllm-ascend.
+    "MSMONITOR_USE_DAEMON": lambda: bool(int(os.getenv("MSMONITOR_USE_DAEMON", "0"))),
+    # Whether to enable MLAPO optimization for DeepSeek W8A8 series models.
+    # This option is enabled by default. MLAPO can improve performance, but
+    # it will consume more NPU memory. If reducing NPU memory usage is a higher priority
+    # for your DeepSeek W8A8 scene, then disable it.
+    "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
+    # Experimental A5 MLA decode optimization. Split each request's Block Table
+    # while broadcasting Query, then merge Local FIA outputs with AttentionUpdate.
+    # It is disabled by default until the end-to-end accuracy/performance gates pass.
+    "VLLM_ASCEND_MLA_FIA_SPLIT": lambda: bool(int(os.getenv("VLLM_ASCEND_MLA_FIA_SPLIT", "0"))),
+    # Whether to enable weight cast format to FRACTAL_NZ.
+    # 0: close nz;
+    # 1: only quant case enable nz;
+    # 2: enable nz as long as possible.
+    "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Whether to enable fused MC2 (`dispatch_ffn_combine/mega_moe`).
+    # 0, or not set: default ALLTOALL and MC2 will be used.
+    # 1: ALLTOALL and MC2 might be replaced by `dispatch_ffn_combine/mega_moe` operator.
+    # `dispatch_ffn_combine` can be used only for moe layer with W8A8, EP<=32, non-mtp, non-dynamic-eplb.
+    # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=64, non-dynamic-eplb.
+    "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
+    # Force an even group_list distribution across local experts. This is a
+    # diagnostic-only switch: it changes the expert boundaries without
+    # rerouting tokens and therefore must not be used for accuracy evaluation.
+    # 0, or not set: preserve the group_list produced by the token dispatcher.
+    # 1: replace count/cumulative group_list values with an even distribution.
+    "VLLM_ASCEND_ENABLE_MOE_SYNTHETIC_BALANCE": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_MOE_SYNTHETIC_BALANCE", "0"))
+    ),
+    # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
+    # Use --additional-config '{"enable_balance_scheduling": true}' instead.
+    "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
+    # use fused op transpose_kv_cache_by_block, default is True
+    "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))
+    ),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -66,34 +66,8 @@ env_variables: dict[str, Callable[[], Any]] = {
     # In this case, developers need to set this value to "0.9.0" to make sure
     # that the correct package is installed.
     "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
-    # Whether to enable FlashComm optimization when tensor parallel is enabled.
-    # This feature will get better performance when concurrency is large.
-    # DEPRECATED: use additional_config.enable_flashcomm1 instead.
-    "VLLM_ASCEND_ENABLE_FLASHCOMM1": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1", "0"))),
-    # Whether to enable msMonitor tool to monitor the performance of vllm-ascend.
-    "MSMONITOR_USE_DAEMON": lambda: bool(int(os.getenv("MSMONITOR_USE_DAEMON", "0"))),
-    # Whether to enable MLAPO optimization for DeepSeek W8A8 series models.
-    # This option is enabled by default. MLAPO can improve performance, but
-    # it will consume more NPU memory. If reducing NPU memory usage is a higher priority
-    # for your DeepSeek W8A8 scene, then disable it.
-    "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
-    # Experimental A5 MLA decode optimization. Split each request's Block Table
-    # while broadcasting Query, then merge Local FIA outputs with AttentionUpdate.
-    # It is disabled by default until the end-to-end accuracy/performance gates pass.
-    "VLLM_ASCEND_MLA_FIA_SPLIT": lambda: bool(int(os.getenv("VLLM_ASCEND_MLA_FIA_SPLIT", "0"))),
-    # Whether to enable weight cast format to FRACTAL_NZ.
-    # 0: close nz;
-    # 1: only quant case enable nz;
-    # 2: enable nz as long as possible.
-    "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
-    # Whether to enable fused MC2 (`dispatch_ffn_combine/mega_moe`).
-    # 0, or not set: default ALLTOALL and MC2 will be used.
-    # 1: ALLTOALL and MC2 might be replaced by `dispatch_ffn_combine/mega_moe` operator.
-    # `dispatch_ffn_combine` can be used only for moe layer with W8A8, EP<=32, non-mtp, non-dynamic-eplb.
-    # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=64, non-dynamic-eplb.
-    "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
     # Force an even group_list distribution across local experts. This is a
     # diagnostic-only switch: it changes the expert boundaries without
     # rerouting tokens and therefore must not be used for accuracy evaluation.
@@ -102,12 +76,10 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ENABLE_MOE_SYNTHETIC_BALANCE": lambda: bool(
         int(os.getenv("VLLM_ASCEND_ENABLE_MOE_SYNTHETIC_BALANCE", "0"))
     ),
-    # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
-    # Use --additional-config '{"enable_balance_scheduling": true}' instead.
-    "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
-    # use fused op transpose_kv_cache_by_block, default is True
-    "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
-        int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))
+    # Development-only W4A8 MXFP routing override for load probes. It is
+    # ignored by MegaMoe and graph-mode requests.
+    "VLLM_ASCEND_ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE", "0"))
     ),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -22,11 +22,14 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_reduce,
 )
+from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import evaluate_cann_mega_moe_layer
 from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.ops.fused_moe.shared_experts import (
@@ -86,7 +89,25 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._quant_method,
             )
 
-        setup_moe_comm_method(self.moe_config)
+        self.cann_mega_moe_capability = evaluate_cann_mega_moe_layer(
+            self.moe_config,
+            routed_experts.quant_method,
+            getattr(self.moe_config, "activation", getattr(routed_experts, "activation", "silu")),
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        if get_ascend_config().enable_fused_mc2 == 1:
+            logger.info_once(
+                "CANN MegaMoe layer capability: supported=%s, quant=%s, activation=%s, reason=%s.",
+                self.cann_mega_moe_capability.supported,
+                self.cann_mega_moe_capability.quant_type,
+                self.cann_mega_moe_capability.activation,
+                self.cann_mega_moe_capability.reason or "supported",
+            )
+        setup_moe_comm_method(
+            self.moe_config,
+            cann_mega_moe_capability=self.cann_mega_moe_capability,
+        )
         alltoall_comm = get_moe_comm_method(MoECommType.ALLTOALL)
         if alltoall_comm is not None:
             expert_ids_per_ep_rank = getattr(alltoall_comm.token_dispatcher, "expert_ids_per_ep_rank", None)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -26,10 +26,10 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
 
-from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_config import get_ascend_config, is_mega_moe_supported
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
-from vllm_ascend.ops.fused_moe.mega_moe_adapter import evaluate_cann_mega_moe_layer
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import CannMegaMoeLayerCapability, evaluate_cann_mega_moe_layer
 from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.ops.fused_moe.shared_experts import (
@@ -89,14 +89,15 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._quant_method,
             )
 
-        self.cann_mega_moe_capability = evaluate_cann_mega_moe_layer(
-            self.moe_config,
-            routed_experts.quant_method,
-            getattr(self.moe_config, "activation", getattr(routed_experts, "activation", "silu")),
-            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
-            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
-        )
-        if get_ascend_config().enable_fused_mc2 == 1:
+        self.cann_mega_moe_capability = CannMegaMoeLayerCapability(False, "CANN MegaMoe is disabled", self.quant_type)
+        if get_ascend_config().enable_fused_mc2 == 1 and is_mega_moe_supported():
+            self.cann_mega_moe_capability = evaluate_cann_mega_moe_layer(
+                self.moe_config,
+                routed_experts.quant_method,
+                getattr(self.moe_config, "activation", getattr(routed_experts, "activation", "silu")),
+                situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+                situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+            )
             logger.info_once(
                 "CANN MegaMoe layer capability: supported=%s, quant=%s, activation=%s, reason=%s.",
                 self.cann_mega_moe_capability.supported,

--- a/vllm_ascend/ops/fused_moe/mega_moe_adapter.py
+++ b/vllm_ascend/ops/fused_moe/mega_moe_adapter.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Capability-driven adapter for the external CANN MegaMoe operator.
+
+The adapter deliberately reasons about the instantiated MoE layer instead of
+checkpoint metadata or model names. This keeps communication selection
+independent of how a quantized checkpoint describes the same runtime layout.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from functools import cache
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe import FusedMoEConfig
+
+
+_LAYER_CAPABILITY_ATTR = "cann_mega_moe_capability"
+_MODEL_CAPABILITY_ATTR = "_ascend_cann_mega_moe_capability"
+
+_A3_QUANT_TYPES = frozenset({QuantType.NONE, QuantType.W8A8, QuantType.W4A8})
+_A5_QUANT_TYPES = frozenset({QuantType.W4A8MXFP})
+_SWIGLU_ACTIVATIONS = frozenset({"silu", "swiglu", "moeactivation.silu"})
+_SITU_ACTIVATIONS = frozenset({"situ", "situglu", "moeactivation.situ"})
+_COMMON_MEGA_MOE_KEYWORDS = frozenset(
+    {
+        "activation_clamp",
+        "l1_bias",
+        "l1_weights_sf",
+        "l2_bias",
+        "l2_weights_sf",
+        "weight1_type",
+        "weight2_type",
+        "x_active_mask",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeApiCapability:
+    available: bool
+    supports_situ: bool = False
+    supports_comm_context_preload: bool = False
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeActivation:
+    name: str
+    alpha: float | None = None
+    beta: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CannMegaMoeLayerCapability:
+    supported: bool
+    reason: str
+    quant_type: QuantType
+    activation: CannMegaMoeActivation | None = None
+
+
+@cache
+def probe_cann_mega_moe_api() -> CannMegaMoeApiCapability:
+    """Probe the Python API surface without compiling the comm extension."""
+    try:
+        ops_module = import_module("cann_ops_transformer.ops")
+        mega_moe = ops_module.mega_moe
+        _ = ops_module.get_symm_buffer_for_mega_moe
+        parameters = inspect.signature(mega_moe).parameters
+        accepts_arbitrary_keywords = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        )
+        if not accepts_arbitrary_keywords and not _COMMON_MEGA_MOE_KEYWORDS.issubset(parameters):
+            missing = sorted(_COMMON_MEGA_MOE_KEYWORDS.difference(parameters))
+            raise TypeError(f"mega_moe is missing keyword parameters: {missing}")
+    except Exception as exc:
+        return CannMegaMoeApiCapability(False, reason=f"incompatible cann_ops_transformer API: {exc}")
+
+    try:
+        comm_context_module = import_module("cann_ops_transformer.ops.mc2.common.comm_context")
+        comm_context_builder = comm_context_module.comm_context_op_builder
+        _ = comm_context_builder.load
+        supports_comm_context_preload = True
+    except Exception:
+        # The A2/A3 operator does not require this extension. Keep the base
+        # backend available and let the A5 capability check reject preloading.
+        supports_comm_context_preload = False
+
+    return CannMegaMoeApiCapability(
+        True,
+        supports_situ={"activation", "activation_params"}.issubset(parameters),
+        supports_comm_context_preload=supports_comm_context_preload,
+    )
+
+
+def resolve_cann_mega_moe_activation(
+    activation: Any,
+    *,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
+) -> CannMegaMoeActivation | None:
+    """Normalize both legacy activation objects and main's MoEActivation."""
+    activation_name = str(getattr(activation, "value", activation)).lower()
+    linear_beta = getattr(activation, "linear_beta", situ_linear_beta)
+    beta = getattr(activation, "beta", situ_beta)
+
+    if activation_name in _SITU_ACTIVATIONS or linear_beta is not None:
+        if linear_beta is None:
+            return None
+        return CannMegaMoeActivation(name="situglu", alpha=linear_beta, beta=beta)
+
+    if activation_name in _SWIGLU_ACTIVATIONS:
+        return CannMegaMoeActivation(name="swiglu")
+    return None
+
+
+def _unsupported(reason: str, quant_type: QuantType) -> CannMegaMoeLayerCapability:
+    return CannMegaMoeLayerCapability(False, reason, quant_type)
+
+
+def evaluate_cann_mega_moe_layer(
+    moe_config: FusedMoEConfig,
+    quant_method: object,
+    activation: Any,
+    *,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
+    device_type: AscendDeviceType | None = None,
+    api_capability: CannMegaMoeApiCapability | None = None,
+) -> CannMegaMoeLayerCapability:
+    """Evaluate an instantiated MoE layer against the operator contract."""
+    device_type = device_type or get_ascend_device_type()
+    api_capability = api_capability or probe_cann_mega_moe_api()
+    # ModelSlim wraps the concrete MoE scheme in AscendFusedMoEMethod, which
+    # delegates to an inner scheme that carries quant_type / group_size.
+    inner_scheme = getattr(quant_method, "quant_method", None)
+    if inner_scheme is not None and hasattr(inner_scheme, "quant_type"):
+        quant_method = inner_scheme
+    quant_type = getattr(quant_method, "quant_type", QuantType.NONE)
+
+    if not api_capability.available:
+        return _unsupported(api_capability.reason, quant_type)
+
+    if device_type == AscendDeviceType.A5:
+        if quant_type not in _A5_QUANT_TYPES:
+            return _unsupported(f"A5 MegaMoe does not support {quant_type.name}", quant_type)
+        if getattr(quant_method, "group_size", None) != 32:
+            return _unsupported("A5 MXFP MegaMoe requires group_size=32", quant_type)
+        if not api_capability.supports_comm_context_preload:
+            return _unsupported("A5 MegaMoe requires comm-context preloading", quant_type)
+    elif device_type in {AscendDeviceType.A2, AscendDeviceType.A3}:
+        if quant_type not in _A3_QUANT_TYPES:
+            return _unsupported(f"A2/A3 MegaMoe does not support {quant_type.name}", quant_type)
+    else:
+        return _unsupported(f"MegaMoe is not supported on {device_type}", quant_type)
+
+    resolved_activation = resolve_cann_mega_moe_activation(
+        activation,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
+    )
+    if resolved_activation is None:
+        return _unsupported(f"unsupported MegaMoe activation: {activation}", quant_type)
+    if resolved_activation.name == "situglu" and not api_capability.supports_situ:
+        return _unsupported("installed MegaMoe API does not expose SiTU parameters", quant_type)
+    if resolved_activation.name == "situglu" and device_type != AscendDeviceType.A5:
+        return _unsupported("SiTU MegaMoe is supported only on A5", quant_type)
+
+    in_dtype = getattr(moe_config, "in_dtype", None)
+    if in_dtype not in {torch.bfloat16, torch.float16}:
+        return _unsupported(f"unsupported MegaMoe input dtype: {in_dtype}", quant_type)
+
+    hidden = int(moe_config.hidden_dim)
+    if hidden < 1024 or hidden > 8192 or hidden % 512 != 0:
+        return _unsupported(f"unsupported MegaMoe hidden size: {hidden}", quant_type)
+
+    intermediate_hidden = 2 * int(moe_config.intermediate_size_per_partition)
+    if intermediate_hidden < 1024 or intermediate_hidden % 512 != 0:
+        return _unsupported(f"unsupported MegaMoe intermediate size: {intermediate_hidden}", quant_type)
+
+    num_topk = int(moe_config.experts_per_token)
+    max_topk = 32 if device_type == AscendDeviceType.A5 else 16
+    if num_topk < 1 or num_topk > max_topk:
+        return _unsupported(f"unsupported MegaMoe top-k: {num_topk}", quant_type)
+
+    ep_size = int(moe_config.ep_size)
+    max_ep_size = 1024 if device_type == AscendDeviceType.A5 else 64
+    if ep_size < 2 or ep_size > max_ep_size:
+        return _unsupported(f"unsupported MegaMoe EP size: {ep_size}", quant_type)
+
+    num_experts = int(moe_config.num_experts)
+    max_num_experts = 2048 if device_type == AscendDeviceType.A5 else 1024
+    if num_experts < ep_size or num_experts > max_num_experts or num_experts % ep_size != 0:
+        return _unsupported(
+            f"MegaMoe requires experts divisible by EP size, got experts={num_experts}, EP={ep_size}",
+            quant_type,
+        )
+
+    return CannMegaMoeLayerCapability(True, "", quant_type, resolved_activation)
+
+
+def get_model_cann_mega_moe_capability(model_instance: torch.nn.Module | None) -> CannMegaMoeLayerCapability:
+    """Aggregate immutable layer capabilities and cache the model result."""
+    if model_instance is None:
+        return _unsupported("model instance is unavailable", QuantType.NONE)
+
+    cached = getattr(model_instance, _MODEL_CAPABILITY_ATTR, None)
+    if isinstance(cached, CannMegaMoeLayerCapability):
+        return cached
+
+    layer_capabilities = [
+        capability
+        for module in model_instance.modules()
+        if isinstance((capability := getattr(module, _LAYER_CAPABILITY_ATTR, None)), CannMegaMoeLayerCapability)
+    ]
+    if not layer_capabilities:
+        # The model can be queried while its module tree is still being built.
+        # Do not cache this transient result.
+        return _unsupported("model has no registered MegaMoe-capable layers", QuantType.NONE)
+
+    first_unsupported = next((capability for capability in layer_capabilities if not capability.supported), None)
+    result = first_unsupported or layer_capabilities[0]
+    setattr(model_instance, _MODEL_CAPABILITY_ATTR, result)
+    return result

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -268,6 +268,8 @@ class FusedMC2CommImpl(MoECommMethod):
     Communication and Computation parallelism on Ascend devices.
     """
 
+    token_dispatcher: TokenDispatcherWithMC2
+
     def __init__(
         self,
         moe_config,

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
+from vllm.config import get_current_vllm_config
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
@@ -349,8 +350,15 @@ class FusedMC2CommImpl(MoECommMethod):
         )
 
         if self.token_dispatcher.a5_need_extra_args:
-            # A5 uses the operator automatic receive-buffer mode.
-            max_recv_token_num = 0
+            # Use the same configured chunk capacity on every EP rank,
+            # including decode and idle dummy batches.
+            chunk_prefill_size = get_current_vllm_config().scheduler_config.max_num_batched_tokens
+            max_recv_token_num = 3 * chunk_prefill_size
+            logger.info(
+                "A5 MegaMoe receive capacity: chunk_prefill_size=%d recv_factor=3 max_recv_token_num=%d",
+                chunk_prefill_size,
+                max_recv_token_num,
+            )
         elif is_decode_only_node:
             max_recv_token_num = absolute_safe_max_recv_token_num
         else:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -466,6 +466,15 @@ class FusedMC2CommImpl(MoECommMethod):
         activation = activation_config.name
         activation_clamp = None if activation == "situglu" else self.swiglu_limit if self.swiglu_limit > 0 else None
         x_active_mask = None
+        invalid_mxfp_tokens = None
+        if (
+            fused_experts_input.quant.quant_type == QuantType.W4A8MXFP
+            and fused_experts_input.routing.mc2_mask is not None
+        ):
+            # A5 MegaMoe does not consume x_active_mask. Exclude padding
+            # from expert routing; -1 matches no expert in SendMask.
+            invalid_mxfp_tokens = ~fused_experts_input.routing.mc2_mask.bool()
+            topk_ids = topk_ids.masked_fill(invalid_mxfp_tokens.unsqueeze(-1), -1)
         if (
             fused_experts_input.quant.quant_type != QuantType.W4A8MXFP
             and self.token_dispatcher.global_bs == 0
@@ -519,6 +528,9 @@ class FusedMC2CommImpl(MoECommMethod):
         # pre-allocated in/out buffer. The MegaMoe op returns a fresh
         # expert_tokens tensor that is consumed by the caller via the
         # return value, so there is nothing to keep on the instance.
+        if invalid_mxfp_tokens is not None:
+            # Unpermute reads fixed route slots even for masked tokens.
+            out.masked_fill_(invalid_mxfp_tokens.unsqueeze(-1), 0)
         return out, expert_tokens
 
     def fused_experts(

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -30,6 +30,10 @@ from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInp
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput, build_mlp_compute_input
 from vllm_ascend.ops.fused_moe.dataclass.prepare_finalize import MoEPrepareOutput
 from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import build_token_dispatch_input
+from vllm_ascend.ops.fused_moe.mega_moe_adapter import (
+    CannMegaMoeLayerCapability,
+    resolve_cann_mega_moe_activation,
+)
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.prepare_finalize import (
     PrepareAndFinalize,
@@ -52,12 +56,19 @@ def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | No
     return _MoECommMethods.get(moe_comm_type)
 
 
-def setup_moe_comm_method(moe_config):
+def setup_moe_comm_method(
+    moe_config,
+    *,
+    cann_mega_moe_capability: CannMegaMoeLayerCapability | None = None,
+):
     if moe_config.ep_size > 1:
         _MoECommMethods[MoECommType.ALLTOALL] = AlltoAllCommImpl(moe_config)
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
         _MoECommMethods[MoECommType.MC2] = MC2CommImpl(moe_config)
-        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(moe_config)
+        _MoECommMethods[MoECommType.FUSED_MC2] = FusedMC2CommImpl(
+            moe_config,
+            cann_mega_moe_capability=cann_mega_moe_capability,
+        )
     else:
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl(moe_config)
 
@@ -257,12 +268,26 @@ class FusedMC2CommImpl(MoECommMethod):
     Communication and Computation parallelism on Ascend devices.
     """
 
-    def __init__(self, moe_config):
+    def __init__(
+        self,
+        moe_config,
+        *,
+        cann_mega_moe_capability: CannMegaMoeLayerCapability | None = None,
+    ):
+        self.cann_mega_moe_capability = cann_mega_moe_capability or CannMegaMoeLayerCapability(
+            False,
+            "layer capability was not registered",
+            QuantType.NONE,
+        )
         super().__init__(moe_config)
         self.enable_fused_mc2 = get_ascend_config().enable_fused_mc2
-        if self.enable_fused_mc2 == 1 and is_mega_moe_supported():
-            self.mega_moe_symm_buffer = None
-            self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops()
+        self.mega_moe_symm_buffer = None
+        self.get_symm_buffer_for_mega_moe = None
+        self.mega_moe = None
+        if self.enable_fused_mc2 == 1 and self.cann_mega_moe_capability.supported:
+            self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops(
+                preload_comm_context=self.token_dispatcher.a5_need_extra_args,
+            )
         if self.enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -276,7 +301,9 @@ class FusedMC2CommImpl(MoECommMethod):
         return self.prepare_finalize.pad_and_split_input_ids(input_ids)  # type: ignore[attr-defined]
 
     def _get_token_dispatcher(self):
-        return TokenDispatcherWithMC2()
+        return TokenDispatcherWithMC2(
+            cann_mega_moe_supported=self.cann_mega_moe_capability.supported,
+        )
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)
@@ -319,7 +346,10 @@ class FusedMC2CommImpl(MoECommMethod):
             num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank),
         )
 
-        if is_decode_only_node:
+        if self.token_dispatcher.a5_need_extra_args:
+            # A5 uses the operator automatic receive-buffer mode.
+            max_recv_token_num = 0
+        elif is_decode_only_node:
             max_recv_token_num = absolute_safe_max_recv_token_num
         else:
             # P nodes and PD-mixed nodes use the configured value. This keeps
@@ -349,6 +379,7 @@ class FusedMC2CommImpl(MoECommMethod):
             self.token_dispatcher.global_bs,
         )
 
+        assert self.get_symm_buffer_for_mega_moe is not None
         return self.get_symm_buffer_for_mega_moe(
             group,
             num_experts,
@@ -364,6 +395,7 @@ class FusedMC2CommImpl(MoECommMethod):
     def _apply_cann_mega_moe(
         self,
         fused_experts_input: MoEFusedExpertsInput,
+        topk_ids: torch.Tensor,
         is_decode_only_node: bool,
     ):
         # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
@@ -381,16 +413,31 @@ class FusedMC2CommImpl(MoECommMethod):
         def to_list(x):
             return x if isinstance(x, list) else [x]
 
-        weight1 = to_list(fused_experts_input.weights.w1)
-        weight2 = to_list(fused_experts_input.weights.w2)
+        if fused_experts_input.quant.quant_type == QuantType.W4A8MXFP:
+            # W4A8 MXFP weights are stored as transposed views for grouped
+            # matmul. Transpose those views back without duplicating storage.
+            # Relative dimensions also handle one tensor per expert.
+            weight1 = [tensor.transpose(-2, -1) for tensor in to_list(fused_experts_input.weights.w1)]
+            weight2 = [tensor.transpose(-2, -1) for tensor in to_list(fused_experts_input.weights.w2)]
+            weight_scales1 = [tensor.transpose(-3, -2) for tensor in to_list(fused_experts_input.weights.w1_scale)]
+            weight_scales2 = [tensor.transpose(-3, -2) for tensor in to_list(fused_experts_input.weights.w2_scale)]
+        else:
+            weight1 = to_list(fused_experts_input.weights.w1)
+            weight2 = to_list(fused_experts_input.weights.w2)
+            weight_scales1 = to_list(fused_experts_input.weights.w1_scale)
+            weight_scales2 = to_list(fused_experts_input.weights.w2_scale)
         # A8W4-INT MegaMoe reads N from weight1.storageShape.lastDim treated as int8 (N = lastDim*2)
         # and checks weight2.dim0 == N/2, so the weights MUST be int8-shaped (two int4 per byte), NOT
         # the eight-int4-per-int32 packing (that makes the op read N four times too small and fail
         # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
         # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
         # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
-        weight_scales1 = fused_experts_input.weights.w1_scale
-        weight_scales2 = fused_experts_input.weights.w2_scale
+        weight_scales1 = [
+            tensor.squeeze(0) if tensor.dim() == 2 and tensor.shape[0] == 1 else tensor for tensor in weight_scales1
+        ]
+        weight_scales2 = [
+            tensor.squeeze(0) if tensor.dim() == 2 and tensor.shape[0] == 1 else tensor for tensor in weight_scales2
+        ]
         dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = moe_utils._get_cann_mega_moe_quant_settings(
             fused_experts_input.quant.quant_type
         )
@@ -405,9 +452,21 @@ class FusedMC2CommImpl(MoECommMethod):
             self.mega_moe_symm_buffer.dispatch_quant_mode = dispatch_quant_mode
             self.mega_moe_symm_buffer.dispatch_quant_out_dtype = dispatch_quant_out_dtype
 
-        activation_clamp = self.swiglu_limit if self.swiglu_limit > 0 else None
+        activation_config = resolve_cann_mega_moe_activation(
+            fused_experts_input.activation,
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        if activation_config is None:
+            raise RuntimeError(f"Unsupported CANN MegaMoe activation: {fused_experts_input.activation}")
+        activation = activation_config.name
+        activation_clamp = None if activation == "situglu" else self.swiglu_limit if self.swiglu_limit > 0 else None
         x_active_mask = None
-        if self.token_dispatcher.global_bs == 0 and fused_experts_input.routing.mc2_mask is not None:
+        if (
+            fused_experts_input.quant.quant_type != QuantType.W4A8MXFP
+            and self.token_dispatcher.global_bs == 0
+            and fused_experts_input.routing.mc2_mask is not None
+        ):
             # mc2_mask comes from the reserved bool buffer in
             # ascend_forward_context.set_mc2_mask. MegaMoe wants int8 as
             # the per-token active mask, so cast only when the dtype does
@@ -422,9 +481,21 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
+        activation_kwargs = {}
+        if activation == "situglu":
+            activation_kwargs = {
+                "activation": activation,
+                "activation_params": {
+                    "beta": activation_config.beta,
+                    "linear_beta": activation_config.alpha,
+                },
+            }
+
+        assert self.mega_moe is not None
+
         out, expert_tokens = self.mega_moe(
             fused_experts_input.hidden_states,
-            fused_experts_input.topk_ids.to(torch.int32),
+            topk_ids.to(torch.int32),
             fused_experts_input.topk_weights.to(torch.float32),
             weight1,
             weight2,
@@ -437,6 +508,7 @@ class FusedMC2CommImpl(MoECommMethod):
             activation_clamp=activation_clamp,
             weight1_type=weight_type,
             weight2_type=weight_type,
+            **activation_kwargs,
         )
         # NOTE: self.expert_token_nums is only used by the
         # mega_moe path (enable_fused_mc2 == 1) as a
@@ -453,11 +525,29 @@ class FusedMC2CommImpl(MoECommMethod):
             "token_dispatcher must be an instance of TokenDispatcherWithMC2."
         )
 
+        runtime_activation = resolve_cann_mega_moe_activation(
+            fused_experts_input.activation,
+            situ_beta=getattr(self.moe_config, "activation_situ_beta", None),
+            situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
+        )
+        use_cann_mega_moe = (
+            self.cann_mega_moe_capability.supported
+            and self.mega_moe is not None
+            and fused_experts_input.quant.quant_type == self.cann_mega_moe_capability.quant_type
+            and runtime_activation == self.cann_mega_moe_capability.activation
+        )
+        if is_mega_moe_supported() and not use_cann_mega_moe:
+            return super().fused_experts(fused_experts_input)
+
+        topk_ids = fused_experts_input.topk_ids
+        if fused_experts_input.routing.log2phy is not None:
+            topk_ids = fused_experts_input.routing.log2phy[topk_ids]
+
         expert_tokens = None
         if get_ascend_config().enable_fused_mc2 == 1:
-            if _EXTRA_CTX.use_mega_moe:
+            if use_cann_mega_moe:
                 out, expert_tokens = self._apply_cann_mega_moe(
-                    fused_experts_input, is_decode_only_node=_EXTRA_CTX.is_decode_only_node
+                    fused_experts_input, topk_ids, is_decode_only_node=_EXTRA_CTX.is_decode_only_node
                 )
             else:
                 assert not (
@@ -470,7 +560,7 @@ class FusedMC2CommImpl(MoECommMethod):
                     x=fused_experts_input.hidden_states,
                     weight1=fused_experts_input.weights.w1,
                     weight2=fused_experts_input.weights.w2,
-                    expert_idx=fused_experts_input.topk_ids,
+                    expert_idx=topk_ids,
                     scale1=fused_experts_input.weights.w1_scale,
                     scale2=fused_experts_input.weights.w2_scale,
                     bias1=fused_experts_input.weights.w1_scale_bias,

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -284,7 +284,7 @@ class FusedMC2CommImpl(MoECommMethod):
         self.mega_moe_symm_buffer = None
         self.get_symm_buffer_for_mega_moe = None
         self.mega_moe = None
-        if self.enable_fused_mc2 == 1 and self.cann_mega_moe_capability.supported:
+        if self.enable_fused_mc2 == 1 and is_mega_moe_supported() and self.cann_mega_moe_capability.supported:
             self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops(
                 preload_comm_context=self.token_dispatcher.a5_need_extra_args,
             )
@@ -531,7 +531,8 @@ class FusedMC2CommImpl(MoECommMethod):
             situ_linear_beta=getattr(self.moe_config, "activation_situ_linear_beta", None),
         )
         use_cann_mega_moe = (
-            self.cann_mega_moe_capability.supported
+            is_mega_moe_supported()
+            and self.cann_mega_moe_capability.supported
             and self.mega_moe is not None
             and fused_experts_input.quant.quant_type == self.cann_mega_moe_capability.quant_type
             and runtime_activation == self.cann_mega_moe_capability.activation

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -19,7 +19,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import torch
-from vllm.config import get_current_vllm_config
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
@@ -350,15 +349,10 @@ class FusedMC2CommImpl(MoECommMethod):
         )
 
         if self.token_dispatcher.a5_need_extra_args:
-            # Use the same configured chunk capacity on every EP rank,
+            # Use the same fixed receive capacity on every EP rank,
             # including decode and idle dummy batches.
-            chunk_prefill_size = get_current_vllm_config().scheduler_config.max_num_batched_tokens
-            max_recv_token_num = 3 * chunk_prefill_size
-            logger.info(
-                "A5 MegaMoe receive capacity: chunk_prefill_size=%d recv_factor=3 max_recv_token_num=%d",
-                chunk_prefill_size,
-                max_recv_token_num,
-            )
+            max_recv_token_num = 65536
+            logger.info("A5 MegaMoe receive capacity: max_recv_token_num=%d (fixed)", max_recv_token_num)
         elif is_decode_only_node:
             max_recv_token_num = absolute_safe_max_recv_token_num
         else:

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,9 +18,11 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.triton_utils import HAS_TRITON
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul
@@ -36,6 +38,14 @@ from vllm_ascend.utils import (
 ASCEND_DEVICE_TYPE = get_ascend_device_type()
 # CANN uses 36 to select FP8 E4M3FN output for situ_mx_quant.
 SITU_MX_DST_TYPE_E4M3FN = 36
+ENABLE_MOE_SYNTHETIC_BALANCE = envs.VLLM_ASCEND_ENABLE_MOE_SYNTHETIC_BALANCE
+logger = init_logger(__name__)
+
+if ENABLE_MOE_SYNTHETIC_BALANCE:
+    logger.warning(
+        "MoE synthetic group_list balancing is enabled. Expert semantics are changed; "
+        "use this mode only for profiling, never for production or accuracy evaluation."
+    )
 
 
 def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation=None):
@@ -81,6 +91,40 @@ def cumsum_group_list(
         f"Conversion from src_list_type={src_list_type} to dst_list_type={dst_list_type} is not implemented yet. "
         "This feature is under development."
     )
+
+
+def synthetic_balance_group_list(group_list: torch.Tensor, group_list_type: int) -> torch.Tensor:
+    """Evenly divide routed rows across experts for performance diagnosis.
+
+    This deliberately changes only the grouped-matmul boundaries; it does not
+    reroute or reorder tokens. Consequently, output semantics are changed and
+    results from this mode must not be used for accuracy evaluation.
+
+    Args:
+        group_list: Expert row counts (type 1) or cumulative boundaries
+            (type 0).
+        group_list_type: Ascend grouped-matmul group-list representation.
+    """
+    if group_list_type not in (0, 1):
+        raise ValueError(
+            "Forced MoE group_list balancing supports only count (1) and "
+            f"cumulative (0) formats, but received {group_list_type}."
+        )
+    if group_list.ndim != 1 or group_list.numel() == 0:
+        raise ValueError(
+            "Forced MoE group_list balancing requires a non-empty 1-D "
+            f"tensor, but received shape {tuple(group_list.shape)}."
+        )
+
+    expert_num = group_list.shape[0]
+    total_rows = group_list[-1] if group_list_type == 0 else group_list.sum()
+    base_rows = torch.div(total_rows, expert_num, rounding_mode="floor")
+    remainder = torch.remainder(total_rows, expert_num)
+    expert_indices = torch.arange(expert_num, dtype=group_list.dtype, device=group_list.device)
+    balanced_counts = base_rows + (expert_indices < remainder).to(group_list.dtype)
+    if group_list_type == 0:
+        return balanced_counts.cumsum(dim=0, dtype=group_list.dtype)
+    return balanced_counts
 
 
 def _require_single_tensor_for_swiglu_quant(
@@ -779,6 +823,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     hidden_states = mlp_compute_input.hidden_states
     group_list = mlp_compute_input.group_list
     group_list_type = mlp_compute_input.group_list_type
+    if ENABLE_MOE_SYNTHETIC_BALANCE:
+        group_list = synthetic_balance_group_list(group_list, group_list_type)
     dynamic_scale = mlp_compute_input.dynamic_scale
     topk_scales = mlp_compute_input.topk_scales
     w1 = mlp_compute_input.weights.w1

--- a/vllm_ascend/ops/fused_moe/moe_utils.py
+++ b/vllm_ascend/ops/fused_moe/moe_utils.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from functools import lru_cache
+from functools import cache, lru_cache
 from importlib import import_module
 
 import torch
@@ -31,6 +31,7 @@ _CANN_ACL_INT8 = 258
 _CANN_ACL_INT4 = 285
 _CANN_MEGA_MOE_QUANT_MODE_None = 0
 _CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
+_CANN_MEGA_MOE_QUANT_MODE_MX = 4
 
 
 def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event=None):
@@ -114,14 +115,24 @@ def gather_from_sequence_parallel_region(
     return _gather_along_first_dim(input_, group, output_split_sizes)
 
 
-def load_cann_mega_moe_ops():
+@cache
+def load_cann_mega_moe_ops(*, preload_comm_context: bool = False):
+    if preload_comm_context:
+        # A5 multi-node MegaMoe must build the communication-context extension
+        # during model initialization. Deferring it until the first collective
+        # serializes local workers on the JIT lock and can make other ranks time
+        # out in HCCL. Preserve the existing lazy behavior on A2/A3.
+        comm_context_module = import_module("cann_ops_transformer.ops.mc2.common.comm_context")
+        comm_context_module.comm_context_op_builder.load()
     ops_module = import_module("cann_ops_transformer.ops")
     get_symm_buffer_for_mega_moe = ops_module.get_symm_buffer_for_mega_moe
     mega_moe = ops_module.mega_moe
     return get_symm_buffer_for_mega_moe, mega_moe
 
 
-def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int | None, int | None]:
+def _get_cann_mega_moe_quant_settings(
+    quant_type: QuantType,
+) -> tuple[int, int | torch.dtype | None, int | torch.dtype | None]:
     # Returns (dispatch_quant_mode, dispatch_quant_out_dtype, weight_type).
     # The current custom op package still requires explicit INT4 for W4A8
     # packed weights; otherwise it derives W4A8's packed N as an INT8 N and
@@ -137,6 +148,15 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
     if quant_type == QuantType.W4A8:
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
+    if quant_type == QuantType.W4A8MXFP:
+        # The packaged wrapper maps torch dtypes via _TORCH_DTYPE_TO_INT. Raw
+        # ACL enum integers are passed through unchanged and corrupt the ACL
+        # parameter binding (surfacing later as moeExpertNum=0).
+        return (
+            _CANN_MEGA_MOE_QUANT_MODE_MX,
+            torch.float8_e4m3fn,
+            torch_npu.float4_e2m1fn_x2,
+        )
     if quant_type == QuantType.NONE:
         return (_CANN_MEGA_MOE_QUANT_MODE_None, None, None)
 

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 
 import torch
 import torch_npu
-from vllm.config import get_current_vllm_config
+from vllm.config import CUDAGraphMode, get_current_vllm_config
 from vllm.distributed.utils import is_weak_contiguous
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 from vllm.model_executor.utils import replace_parameter
 
+from vllm_ascend import envs
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType, use_cann_megamoe
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
@@ -40,6 +41,34 @@ from vllm_ascend.ops.fused_moe.moe_utils import get_moe_num_logical_experts
 from vllm_ascend.ops.fused_moe.shared_experts import FusedMoEEvents
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, maybe_trans_nz
+
+ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE = envs.VLLM_ASCEND_ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE
+
+
+def should_force_moe_load_balance(
+    *,
+    quant_type: QuantType,
+    in_profile_run: bool,
+    use_mega_moe: bool,
+    capturing: bool,
+    cudagraph_runtime_mode: CUDAGraphMode | None,
+) -> bool:
+    """Enable the explicit eager-only load probe without touching MegaMoe."""
+    if in_profile_run:
+        return True
+    if (
+        not ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE
+        or quant_type != QuantType.W4A8MXFP
+        or use_mega_moe
+    ):
+        return False
+    if capturing or cudagraph_runtime_mode not in (None, CUDAGraphMode.NONE):
+        logger.warning_once(
+            "VLLM_ASCEND_ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE is ignored for graph-mode requests; "
+            "the debug routing override applies only to eager execution."
+        )
+        return False
+    return True
 
 
 class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
@@ -506,8 +535,17 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             moe_layer_index = forward_context.moe_layer_index % (len(forward_context.all_moe_layers))
             forward_context.moe_layer_index = moe_layer_index
 
-        # Load balancing for token distribution among experts in dummy_run.
-        enable_force_load_balance = _EXTRA_CTX.in_profile_run
+        # Profile runs preserve the existing routing behavior. The explicit
+        # probe switch enables the same routing override for eager W4A8 MXFP
+        # requests, while leaving MegaMoe and graph-mode execution unchanged.
+        probe_force_load_balance = should_force_moe_load_balance(
+            quant_type=self.quant_type,
+            in_profile_run=False,
+            use_mega_moe=getattr(_EXTRA_CTX, "use_mega_moe", False),
+            capturing=getattr(forward_context, "capturing", False),
+            cudagraph_runtime_mode=getattr(forward_context, "cudagraph_runtime_mode", None),
+        )
+        enable_force_load_balance = _EXTRA_CTX.in_profile_run or probe_force_load_balance
 
         lora_context = getattr(self, "_ascend_moe_lora_context", None)
         if lora_context is not None:
@@ -533,6 +571,10 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             enable_force_load_balance=enable_force_load_balance,
             input_ids=input_ids,
         )
+        if probe_force_load_balance and mc2_mask is not None:
+            # Include DP padding rows in the probe workload. Finalization
+            # still removes padded outputs.
+            mc2_mask = torch.ones_like(mc2_mask)
         self.ascend_pertoken_scale = pertoken_scale
         self.ascend_mc2_mask = mc2_mask
         try:

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -53,13 +53,12 @@ def should_force_moe_load_balance(
     capturing: bool,
     cudagraph_runtime_mode: CUDAGraphMode | None,
 ) -> bool:
-    """Enable the explicit eager-only load probe without touching MegaMoe."""
+    """Enable the explicit eager-only load probe for supported MoE backends."""
     if in_profile_run:
         return True
     if (
         not ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE
         or quant_type != QuantType.W4A8MXFP
-        or use_mega_moe
     ):
         return False
     if capturing or cudagraph_runtime_mode not in (None, CUDAGraphMode.NONE):

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -110,7 +110,7 @@ class MoETokenDispatcher(ABC, Generic[TMoECombineMetadata]):
 
 
 class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
-    def __init__(self, **kwargs):
+    def __init__(self, *, cann_mega_moe_supported: bool | None = None, **kwargs):
         super().__init__(**kwargs)
         device_group = get_mc2_group().device_group
         # TODO: Try local_rank = ep_group.rank_in_group
@@ -132,18 +132,28 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
-        # Surface the per-rank capacity for CANN MegaMoe's get_symm_buffer
-        # sizing (used by FusedMC2CommImpl._get_cann_symm_buffer). Without
-        # this, MegaMoe falls back to hidden_states.shape[0] which jitters
-        # under eager mode and forces sym-buffer rebuilds every step.
+        # MegaMoe is selected for prefill as well as decode. Preserve the
+        # existing decode-derived MC2 capacity for global_bs, but size its
+        # symmetric buffer for the larger of decode and a full prefill shard.
         self.max_num_tokens_per_rank = num_tokens_per_tp_rank
+        if self.a5_need_extra_args:
+            max_num_batched_tokens = int(vllm_config.scheduler_config.max_num_batched_tokens)
+            prefill_tokens_per_tp_rank = (max_num_batched_tokens + tp_size - 1) // tp_size
+            self.max_num_tokens_per_rank = max(num_tokens_per_tp_rank, prefill_tokens_per_tp_rank)
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:
         # use global_bs=0 (uniform mode) and pass mc2_mask.
         # When allreduce is skipped, tokens may differ per rank:
         # use the real global_bs and do NOT pass mc2_mask.
-        self.global_bs = _max_global_bs if should_skip_allreduce_across_dp_group(vllm_config) else 0
+        self.global_bs = (
+            _max_global_bs
+            if should_skip_allreduce_across_dp_group(
+                vllm_config,
+                cann_mega_moe_supported=cann_mega_moe_supported,
+            )
+            else 0
+        )
 
     def refresh_hccl_group(self) -> None:
         """Refresh MC2 communicator metadata after HCCL groups are recreated."""

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -38,7 +38,7 @@ from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 
 import vllm_ascend.envs as envs_ascend
-from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_config import get_ascend_config, is_mega_moe_supported
 from vllm_ascend.device.device_config import (  # noqa: F401
     AscendDeviceType,
     check_ascend_device_type,
@@ -1148,10 +1148,11 @@ def should_skip_allreduce_across_dp_group(
     from vllm_ascend.ops.fused_moe.mega_moe_adapter import get_model_cann_mega_moe_capability
     from vllm_ascend.ops.fused_moe.moe_comm_method import MoECommType
 
-    if cann_mega_moe_supported is None and model_instance is not None:
-        cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
-    if use_cann_megamoe(vllm_config) or cann_mega_moe_supported:
-        return False
+    if ascend_config.enable_fused_mc2 == 1 and is_mega_moe_supported():
+        if cann_mega_moe_supported is None and model_instance is not None:
+            cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
+        if use_cann_megamoe(vllm_config) or cann_mega_moe_supported:
+            return False
 
     def needs_mc2(n: int) -> bool:
         return select_moe_comm_method(

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1102,7 +1102,13 @@ def get_potential_max_tokens() -> int:
     return _potential_max_tokens
 
 
-def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_model: bool = False) -> bool:
+def should_skip_allreduce_across_dp_group(
+    vllm_config: VllmConfig,
+    is_draft_model: bool = False,
+    *,
+    model_instance: torch.nn.Module | None = None,
+    cann_mega_moe_supported: bool | None = None,
+) -> bool:
     """Decide whether to skip the all-reduce across the DP group.
 
     Skipping is applicable for all dense models and for moe models only on ranks
@@ -1139,13 +1145,21 @@ def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_mode
         return False
 
     from vllm_ascend.ascend_forward_context import select_moe_comm_method, use_cann_megamoe
+    from vllm_ascend.ops.fused_moe.mega_moe_adapter import get_model_cann_mega_moe_capability
     from vllm_ascend.ops.fused_moe.moe_comm_method import MoECommType
 
-    if use_cann_megamoe(vllm_config):
+    if cann_mega_moe_supported is None and model_instance is not None:
+        cann_mega_moe_supported = get_model_cann_mega_moe_capability(model_instance).supported
+    if use_cann_megamoe(vllm_config) or cann_mega_moe_supported:
         return False
 
     def needs_mc2(n: int) -> bool:
-        return select_moe_comm_method(n, vllm_config) in {MoECommType.MC2, MoECommType.FUSED_MC2}
+        return select_moe_comm_method(
+            n,
+            vllm_config,
+            model_instance=model_instance,
+            cann_mega_moe_supported=cann_mega_moe_supported,
+        ) in {MoECommType.MC2, MoECommType.FUSED_MC2}
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3508,6 +3508,7 @@ class NPUModelRunner(GPUModelRunner):
         profile_seq_lens: int | None = None,
         profile_cpp: bool = False,
         skip_gdn_state_update: bool = False,
+        num_actual_tokens: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
@@ -3773,7 +3774,7 @@ class NPUModelRunner(GPUModelRunner):
                 num_tokens=num_tokens_padded,
                 num_tokens_across_dp=num_tokens_across_dp,
                 in_profile_run=is_profile,
-                num_actual_tokens=num_tokens_padded,
+                num_actual_tokens=num_tokens_padded if num_actual_tokens is None else num_actual_tokens,
                 aclgraph_runtime_mode=cudagraph_runtime_mode,
                 batch_descriptor=batch_desc,
                 model_instance=self.model,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -731,7 +731,11 @@ class NPUModelRunner(GPUModelRunner):
         if self.dp_size == 1:
             return num_tokens, None, cudagraph_mode
 
-        if should_skip_allreduce_across_dp_group(self.vllm_config, is_draft_model):
+        if should_skip_allreduce_across_dp_group(
+            self.vllm_config,
+            is_draft_model,
+            model_instance=None if is_draft_model else self.model,
+        ):
             num_tokens_after_padding = torch.tensor([num_tokens] * self.dp_size, device="cpu", dtype=torch.int32)
             return num_tokens, num_tokens_after_padding, cudagraph_mode
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -83,8 +83,10 @@ from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
+    AscendDeviceType,
     check_ascend_device_type,
     enable_sp,
+    get_ascend_device_type,
     register_ascend_customop,
     setup_ascend_local_comm_res,
 )
@@ -1098,7 +1100,10 @@ class NPUWorker(WorkerBase):
     def execute_dummy_batch(self) -> None:
         self.log_memory_stats()
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)
-        self.model_runner._dummy_run(num_tokens, uniform_decode=True)
+        if not self.use_v2_model_runner and get_ascend_device_type() == AscendDeviceType.A5:
+            self.model_runner._dummy_run(num_tokens, uniform_decode=True, num_actual_tokens=0)
+        else:
+            self.model_runner._dummy_run(num_tokens, uniform_decode=True)
 
     def _init_worker_distributed_environment(self) -> None:
         """Initialize the distributed environment."""


### PR DESCRIPTION
## Summary

Add an explicit, diagnostic-only force-load-balance path on top of PR #16048 for W4A8 MXFP probing.

## Changes

- Add `VLLM_ASCEND_ENABLE_W4A8_MXFP_FORCE_LOAD_BALANCE`, disabled by default.
- Reuse the existing force-routing path for eager W4A8 MXFP requests only.
- Keep graph-mode requests unchanged and bypass the CANN MegaMoe path so PR #16048 MegaMoe selection, capacity, and routing semantics remain unchanged.
- Include DP padding rows in the probe workload when an MC2 mask is present.
- Add synthetic grouped-MoE boundary balancing as a separate opt-in diagnostic switch.

## Validation

- `python -m compileall -q` on changed Python files: passed.
- `python -m ruff check` on changed Python files: passed.
- `git diff --check`: passed.
- Targeted pytest collection is blocked in this local workstation because the `vllm` package is not installed.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
