### PR TITLE
[Bugfix] Diable chunked prefill, prefix cache and request preempt for batch invariance

### DIFF
--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -107,6 +107,36 @@ Batch invariance can be enabled by setting the `VLLM_BATCH_INVARIANT` environmen
 export VLLM_BATCH_INVARIANT=1
 ```
 
+### Scheduling limitations
+
+Chunked prefill, request preemption (eviction and recomputation), and prefix
+caching are not supported with batch invariance. At runtime,
+`VLLM_BATCH_INVARIANT=1` automatically disables chunked prefill and prefix caching,
+overriding their configuration flags, and selects a non-preemptive scheduler.
+It also forces `cache_config.block_size=128` for the standard Ascend attention
+backends, overriding any explicit `--block-size` value. You do not need to pass
+`--block-size 128` separately. A single startup warning prefixed with
+`VLLM_BATCH_INVARIANT=1:` summarizes these changes and the resolved block size
+and prefill token budget.
+The prefill token budget is raised to at least `max_model_len` so a complete
+prompt can be processed in one iteration.
+
+The scheduler reserves KV blocks for each admitted request's prompt and maximum
+generation length (`max_tokens`, capped by `max_model_len`, including speculative
+lookahead). New requests wait when the remaining capacity is insufficient;
+running requests retain their KV blocks until completion or cancellation.
+A request whose reservation exceeds the total usable KV capacity raises an error
+instead of waiting indefinitely. Reduce `max_tokens`/`max_model_len` or increase
+KV cache memory in that case. Resetting the prefix cache with eviction of running
+requests is refused while requests are running.
+
+This reservation policy currently requires full-attention KV cache layouts.
+Other cache layouts, KV transfer, and custom or specialized schedulers are
+rejected rather than running without the preemption guarantee. Both standard
+synchronous and asynchronous scheduling are supported. Reserving generation
+capacity can reduce concurrency, and the larger prefill budget can increase
+memory usage.
+
 ### Online Inference (Server Mode)
 
 To start a vLLM server with batch invariance enabled:

--- a/tests/ut/core/test_batch_invariant_scheduler.py
+++ b/tests/ut/core/test_batch_invariant_scheduler.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+from vllm.config import CacheConfig, ObservabilityConfig, ParallelConfig, SchedulerConfig
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, KVCacheSpecRegistry
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec, SlidingWindowSpec
+from vllm.v1.request import Request, RequestStatus
+
+from vllm_ascend.batch_invariant_config import (
+    ASYNC_SCHEDULER,
+    SCHEDULER,
+    configure_batch_invariant,
+    select_batch_invariant_scheduler,
+)
+from vllm_ascend.core.batch_invariant_scheduler import (
+    BatchInvariantAsyncScheduler,
+    BatchInvariantScheduler,
+    reserve_generation_slots,
+)
+
+
+def make_manager(num_blocks=7, max_model_len=128):
+    KVCacheSpecRegistry.register(FullAttentionSpec, FullAttentionManager, uniform_type_base_spec=FullAttentionSpec)
+    spec = FullAttentionSpec(block_size=16, num_kv_heads=1, head_size=8, dtype=torch.float16)
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names=["layer"], kv_cache_spec=spec)],
+    )
+    return KVCacheManager(config, max_model_len, scheduler_block_size=16, hash_block_size=16, enable_caching=False)
+
+
+def make_request(request_id, prompt=16, output=48):
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=[1] * prompt,
+        sampling_params=SamplingParams(max_tokens=output),
+        pooling_params=None,
+    )
+
+
+def make_config(async_scheduling=False):
+    return SimpleNamespace(
+        kv_transfer_config=None,
+        model_config=SimpleNamespace(max_model_len=128),
+        cache_config=CacheConfig(enable_prefix_caching=True),
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=True,
+            long_prefill_token_threshold=8,
+            max_num_batched_tokens=32,
+            max_num_scheduled_tokens=24,
+            max_num_encoder_input_tokens=32,
+            encoder_cache_size=32,
+            scheduler_cls=None,
+            async_scheduling=async_scheduling,
+        ),
+    )
+
+
+@pytest.mark.parametrize("async_scheduling", [False, True])
+@pytest.mark.parametrize("block_size", [None, 16, 128, 256])
+def test_config_disables_unsupported_features(monkeypatch, async_scheduling, block_size):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    logger = Mock()
+    monkeypatch.setattr("vllm_ascend.batch_invariant_config.logger", logger)
+    config = make_config(async_scheduling)
+    config.cache_config = CacheConfig(block_size=block_size, enable_prefix_caching=True)
+    configure_batch_invariant(config)
+    select_batch_invariant_scheduler(config)
+    scheduler = config.scheduler_config
+    assert not scheduler.enable_chunked_prefill
+    assert not config.cache_config.enable_prefix_caching
+    assert config.cache_config.block_size == 128
+    assert scheduler.long_prefill_token_threshold == 0
+    assert scheduler.max_num_batched_tokens == scheduler.max_num_scheduled_tokens == 128
+    assert scheduler.encoder_cache_size == scheduler.max_num_encoder_input_tokens == 128
+    assert scheduler.scheduler_cls == (ASYNC_SCHEDULER if async_scheduling else SCHEDULER)
+    logger.warning.assert_called_once_with(
+        "VLLM_BATCH_INVARIANT=1: Batch invariance disables chunked prefill, prefix caching and request preemption. "
+        "block_size=%d, max_num_batched_tokens=%d; reserving generation KV capacity may reduce concurrency.",
+        128,
+        128,
+    )
+    # Repeated platform initialization must be harmless.
+    configure_batch_invariant(config)
+    select_batch_invariant_scheduler(config)
+
+
+def test_disabled_mode_preserves_config(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "0")
+    logger = Mock()
+    monkeypatch.setattr("vllm_ascend.batch_invariant_config.logger", logger)
+    config = make_config()
+    config.cache_config.block_size = 256
+    config.scheduler_config.scheduler_cls = "custom.Scheduler"
+    configure_batch_invariant(config)
+    select_batch_invariant_scheduler(config)
+    assert config.cache_config.enable_prefix_caching
+    assert config.cache_config.block_size == 256
+    assert config.scheduler_config.enable_chunked_prefill
+    assert config.scheduler_config.max_num_batched_tokens == 32
+    assert config.scheduler_config.scheduler_cls == "custom.Scheduler"
+    logger.warning.assert_not_called()
+
+
+def test_reject_unsupported_config(monkeypatch):
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    config = make_config()
+    config.kv_transfer_config = object()
+    with pytest.raises(ValueError, match="KV transfer"):
+        configure_batch_invariant(config)
+    config.scheduler_config.scheduler_cls = "custom.Scheduler"
+    with pytest.raises(ValueError, match="custom"):
+        select_batch_invariant_scheduler(config)
+
+
+def test_reservation_queues_until_running_request_frees_blocks():
+    # Six usable blocks: each 16-token prompt plus 48-token output needs four.
+    manager = make_manager()
+    reserve_generation_slots(manager)
+    first, second = make_request("first"), make_request("second")
+    assert manager.allocate_slots(first, 16) is not None
+    assert manager.block_pool.get_num_free_blocks() == 2
+    assert manager.allocate_slots(second, 16) is None
+    # Every decode step fits without taking any more blocks from the pool.
+    first.num_computed_tokens = 16
+    for _ in range(47):
+        first.append_output_token_ids(2)
+        assert manager.allocate_slots(first, 1) is not None
+        first.num_computed_tokens += 1
+        assert manager.block_pool.get_num_free_blocks() == 2
+    assert first.num_preemptions == second.num_preemptions == 0
+    manager.free(first)
+    assert manager.allocate_slots(second, 16) is not None
+
+
+def test_oversized_request_fails_without_allocating():
+    manager = make_manager(num_blocks=4)
+    reserve_generation_slots(manager)
+    with pytest.raises(ValueError, match="total KV capacity"):
+        manager.allocate_slots(make_request("oversized"), 16)
+    assert manager.block_pool.get_num_free_blocks() == 3
+
+
+def test_max_model_len_caps_reservation():
+    manager = make_manager(num_blocks=5, max_model_len=64)
+    reserve_generation_slots(manager)
+    assert manager.allocate_slots(make_request("capped", output=1024), 16) is not None
+    assert manager.block_pool.get_num_free_blocks() == 0
+
+
+def test_speculative_headroom_reserved_at_admission():
+    manager = make_manager(num_blocks=6)
+    reserve_generation_slots(manager, num_spec_tokens=4)
+    request = make_request("spec")
+    assert manager.allocate_slots(request, num_new_tokens=16, num_lookahead_tokens=0) is not None
+    assert manager.block_pool.get_num_free_blocks() == 0
+    request.num_computed_tokens = 60
+    assert manager.allocate_slots(request, num_new_tokens=4, num_lookahead_tokens=4) is not None
+
+
+def test_reject_recycling_cache_layout():
+    manager = make_manager()
+    manager.kv_cache_config.kv_cache_groups[0].kv_cache_spec = SlidingWindowSpec(
+        block_size=16, num_kv_heads=1, head_size=8, dtype=torch.float16, sliding_window=32
+    )
+    with pytest.raises(ValueError, match="full-attention"):
+        reserve_generation_slots(manager)
+
+
+@pytest.mark.parametrize("scheduler_cls", [BatchInvariantScheduler, BatchInvariantAsyncScheduler])
+def test_explicit_eviction_refused_without_removing_running_request(scheduler_cls):
+    scheduler = object.__new__(scheduler_cls)
+    request = make_request("running")
+    scheduler.running = [request]
+    assert scheduler.reset_prefix_cache(reset_running_requests=True) is False
+    assert scheduler.running == [request]
+    with pytest.raises(RuntimeError, match="preemption"):
+        scheduler._preempt_request(request, 0)
+
+
+@pytest.mark.parametrize("scheduler_cls", [BatchInvariantScheduler, BatchInvariantAsyncScheduler])
+def test_schedule_admission_and_cancellation(scheduler_cls):
+    manager = make_manager()
+    cache_config = CacheConfig(block_size=16, enable_prefix_caching=False)
+    cache_config.num_gpu_blocks = 7
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            is_encoder_decoder=False,
+            is_diffusion=False,
+            max_model_len=128,
+            enable_return_routed_experts=False,
+            uses_mrope=False,
+            uses_xdrope=False,
+            return_sampling_mask=False,
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_batched_tokens=128,
+            max_model_len=128,
+            is_encoder_decoder=False,
+            max_num_seqs=2,
+            enable_chunked_prefill=False,
+            watermark=0,
+        ),
+        cache_config=cache_config,
+        parallel_config=ParallelConfig(),
+        observability_config=ObservabilityConfig(),
+        lora_config=None,
+        kv_events_config=None,
+        kv_transfer_config=None,
+        ec_transfer_config=None,
+        ec_manager_config=SimpleNamespace(get_encoder_cache_manager_obj=lambda: None),
+        speculative_config=None,
+        num_speculative_tokens=0,
+        num_lookahead_tokens=0,
+        is_mm_encoder_only=False,
+        max_in_flight_tokens=128,
+        use_v2_model_runner=False,
+    )
+    scheduler = scheduler_cls(
+        vllm_config=config,
+        kv_cache_config=manager.kv_cache_config,
+        structured_output_manager=Mock(),
+        block_size=16,
+        mm_registry=Mock(supports_multimodal_inputs=Mock(return_value=False)),
+    )
+    first, second = make_request("first"), make_request("second")
+    scheduler.add_request(first)
+    scheduler.add_request(second)
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {"first": 16}
+    assert second.status == RequestStatus.WAITING
+    assert not output.preempted_req_ids
+    # Cancellation uses the ordinary release path and admits the waiting request.
+    scheduler.finish_requests("first", RequestStatus.FINISHED_ABORTED)
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {"second": 16}
+    assert not output.preempted_req_ids
+    assert first.num_preemptions == second.num_preemptions == 0

--- a/vllm_ascend/batch_invariant_config.py
+++ b/vllm_ascend/batch_invariant_config.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from vllm import envs
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+SCHEDULER = "vllm_ascend.core.batch_invariant_scheduler.BatchInvariantScheduler"
+ASYNC_SCHEDULER = "vllm_ascend.core.batch_invariant_scheduler.BatchInvariantAsyncScheduler"
+BATCH_INVARIANT_BLOCK_SIZE = 128
+
+
+def configure_batch_invariant(vllm_config) -> None:
+    """Apply before compilation sizes and worker buffers are derived."""
+    if not envs.VLLM_BATCH_INVARIANT:
+        return
+
+    if vllm_config.kv_transfer_config is not None:
+        raise ValueError("Batch invariance does not support KV transfer with non-preemptive scheduling.")
+
+    scheduler = vllm_config.scheduler_config
+    scheduler.enable_chunked_prefill = False
+    scheduler.long_prefill_token_threshold = 0
+    vllm_config.cache_config.enable_prefix_caching = False
+    # refresh_block_size no longer promotes the default after both prefix
+    # caching and chunked prefill have been disabled. Standard Ascend attention
+    # backends require 128-token blocks, including when a user supplied a size.
+    vllm_config.cache_config.block_size = BATCH_INVARIANT_BLOCK_SIZE
+
+    # A complete prompt must fit into one iteration. Update derived encoder
+    # budgets too, since SchedulerConfig.__post_init__ has already run.
+    scheduler.max_num_batched_tokens = max(scheduler.max_num_batched_tokens, vllm_config.model_config.max_model_len)
+    if scheduler.max_num_scheduled_tokens is not None:
+        scheduler.max_num_scheduled_tokens = max(
+            scheduler.max_num_scheduled_tokens, vllm_config.model_config.max_model_len
+        )
+    scheduler.max_num_encoder_input_tokens = scheduler.max_num_batched_tokens
+    scheduler.encoder_cache_size = scheduler.max_num_batched_tokens
+
+
+def select_batch_invariant_scheduler(vllm_config) -> None:
+    """Run after Ascend's specialized scheduler selection."""
+    if not envs.VLLM_BATCH_INVARIANT:
+        return
+    scheduler = vllm_config.scheduler_config
+    if scheduler.scheduler_cls not in (None, SCHEDULER, ASYNC_SCHEDULER):
+        raise ValueError("Batch invariance does not support a custom or specialized scheduler.")
+    scheduler.scheduler_cls = ASYNC_SCHEDULER if scheduler.async_scheduling else SCHEDULER
+    logger.warning(
+        "VLLM_BATCH_INVARIANT=1: Batch invariance disables chunked prefill, prefix caching and request preemption. "
+        "block_size=%d, max_num_batched_tokens=%d; reserving generation KV capacity may reduce concurrency.",
+        vllm_config.cache_config.block_size,
+        scheduler.max_num_batched_tokens,
+    )

--- a/vllm_ascend/core/batch_invariant_scheduler.py
+++ b/vllm_ascend/core/batch_invariant_scheduler.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from functools import wraps
+from inspect import signature
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import FullAttentionSpec, UniformTypeKVCacheSpecs
+
+
+def _supports_reservation(spec) -> bool:
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        return all(_supports_reservation(child) for child in spec.kv_cache_specs.values())
+    # Other cache managers can recycle blocks or allocate state using the
+    # computed-token boundary rather than the lookahead-token boundary.
+    return type(spec) is FullAttentionSpec
+
+
+def reserve_generation_slots(manager, num_spec_tokens: int = 0) -> None:
+    """Reserve real blocks through the existing lookahead allocation API.
+
+    Computed tokens and scheduled work are unchanged. Full-attention blocks
+    remain owned by the request until the normal finish/cancel path frees them.
+    """
+    if manager.enable_caching or any(
+        not _supports_reservation(group.kv_cache_spec) for group in manager.kv_cache_config.kv_cache_groups
+    ):
+        raise ValueError("Batch-invariant scheduling requires full-attention KV caches with prefix caching disabled.")
+
+    allocate = manager.allocate_slots
+    allocate_signature = signature(allocate)
+
+    @wraps(allocate)
+    def allocate_slots(*args, **kwargs):
+        bound = allocate_signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        arguments = bound.arguments
+        request = arguments["request"]
+        total_computed = (
+            request.num_computed_tokens
+            + arguments["num_new_computed_tokens"]
+            + arguments["num_external_computed_tokens"]
+        )
+        target = min(request.num_prompt_tokens + request.max_tokens + num_spec_tokens, manager.max_model_len)
+        main_tokens = total_computed + arguments["num_new_tokens"]
+        arguments["num_lookahead_tokens"] = max(arguments["num_lookahead_tokens"], target - main_tokens)
+
+        if request.num_computed_tokens == 0:
+            required = manager.coordinator.get_num_blocks_to_allocate(
+                request_id=request.request_id,
+                num_tokens=target,
+                new_computed_blocks=manager.empty_kv_cache_blocks.blocks,
+                num_encoder_tokens=arguments["num_encoder_tokens"],
+                total_computed_tokens=0,
+                num_local_computed_tokens=0,
+                num_tokens_main_model=target,
+            )
+            # The block pool always keeps one null block. Do not leave a
+            # request that cannot fit even on an idle engine waiting forever.
+            if required > manager.block_pool.num_gpu_blocks - 1:
+                raise ValueError(
+                    "Request exceeds total KV capacity with batch-invariant generation reservation; "
+                    "reduce max_tokens/max_model_len or increase KV cache memory."
+                )
+        return allocate(*bound.args, **bound.kwargs)
+
+    manager.allocate_slots = allocate_slots
+
+
+class _BatchInvariantSchedulerMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        reserve_generation_slots(self.kv_cache_manager, max(self.num_spec_tokens, self.num_lookahead_tokens))
+
+    def _preempt_request(self, *args, **kwargs):
+        # Fail closed if an explicit eviction path bypasses capacity admission.
+        raise RuntimeError("Request preemption is not supported with VLLM_BATCH_INVARIANT=1.")
+
+    def reset_prefix_cache(self, reset_running_requests=False, reset_connector=False):
+        if reset_running_requests and self.running:
+            return False
+        return super().reset_prefix_cache(reset_running_requests, reset_connector)
+
+
+class BatchInvariantScheduler(_BatchInvariantSchedulerMixin, Scheduler):
+    """Full-prefill scheduling with generation KV reservation and no eviction."""
+
+
+class BatchInvariantAsyncScheduler(_BatchInvariantSchedulerMixin, AsyncScheduler):
+    """Async equivalent of BatchInvariantScheduler."""

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -33,6 +33,7 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
 
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.batch_invariant_config import configure_batch_invariant, select_batch_invariant_scheduler
 from vllm_ascend.device.hardware_profile import (
     AttentionBackendFamily,
     HardwareCapability,
@@ -484,6 +485,7 @@ class NPUPlatform(Platform):
         # (fused MC2 exclusivity + scheduler extension policies)
         # ascend_config is only used for verification, this object must NOT be modified here
         ascend_config = init_ascend_config(vllm_config)
+        configure_batch_invariant(vllm_config)
         _check_ascend_config(vllm_config, ascend_config)
 
         # 6.Update compilation / cudagraph modes (ascend_config -> vllm_config).
@@ -499,6 +501,7 @@ class NPUPlatform(Platform):
 
         # 8.Setup worker class, custom ops and scheduler (ascend_config -> vllm_config).
         _setup_worker_and_scheduler(vllm_config, ascend_config)
+        select_batch_invariant_scheduler(vllm_config)
 
         # 9.Validate SFA / DCP / KV and SP consistency (vllm_config)
         _validate_sfa_dcp_kv_sp(vllm_config)


### PR DESCRIPTION

### What this PR does / why we need it?
This PR implements batch-invariant scheduling for Ascend attention backends. When `VLLM_BATCH_INVARIANT=1` is enabled, it automatically disables chunked prefill, prefix caching, and request preemption, while forcing a block size of 128. It introduces a reservation policy that pre-allocates KV blocks for each request's prompt and maximum generation length to guarantee non-preemptive execution.

Feedback:
- In `vllm_ascend/platform.py`, `configure_batch_invariant` should be called before `init_ascend_config` to prevent initializing the Ascend configuration with stale values.
- In `vllm_ascend/core/batch_invariant_scheduler.py`, `manager.block_pool.num_gpu_blocks` should be updated to `manager.block_pool.num_blocks` to avoid an `AttributeError` at runtime.

### Does this PR introduce _any_ user-facing change?
Yes, enabling `VLLM_BATCH_INVARIANT=1` now automatically configures a non-preemptive scheduler, disables chunked prefill and prefix caching, and forces a block size of 128.

### How was this patch tested?
Tested with unit tests in `tests/ut/core/test_batch_invariant_scheduler.py` covering configuration overrides, slot reservation, and scheduling.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
