### PR TITLE
[Doc][Misc] Document batch invariance scheduling limitations

### DIFF
--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -187,6 +187,14 @@ Chunked prefill, prefix caching, and request preemption (eviction and recomputat
 
 These scheduling features are not disabled automatically. You must explicitly disable chunked prefill and prefix caching in your configuration, and pair the chunked prefill disabling with a KV cache block size of 128 — pass `--block-size 128` together with `--no-enable-chunked-prefill` when starting the server, or `block_size=128` together with `enable_chunked_prefill=False` for offline inference — as shown in the examples above.
 
+Request preemption is triggered when the KV cache runs out: running requests are evicted and their KV cache is recomputed later, which breaks batch invariance and degrades performance. To reduce the chance of preemption, increase the available KV cache or lower the per-request and concurrent pressure:
+
+- Decrease `--max-num-seqs` so fewer requests share the KV cache.
+- Set `--max-model-len` to the smallest value your workload needs, and cap the per-request output length (`max_tokens`).
+- Increase `--gpu-memory-utilization` to leave more memory for the KV cache.
+
+Use the startup logs (`GPU KV cache size` and `Maximum concurrency for ... tokens per request`) to size your workload against the KV cache capacity, and watch the engine stats: `GPU KV cache usage` approaching 100% signals imminent preemption. See the [preemption FAQ](../../faqs.md#22-why-does-tpot-increase-drastically-as-concurrency-grows) for details.
+
 ## Tested Models
 
 Batch invariance has been tested and verified on the following models:

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -187,7 +187,7 @@ Chunked prefill, prefix caching, and request preemption (eviction and recomputat
 
 These scheduling features are not disabled automatically. You must explicitly disable chunked prefill and prefix caching in your configuration, and pair the chunked prefill disabling with a KV cache block size of 128 — pass `--block-size 128` together with `--no-enable-chunked-prefill` when starting the server, or `block_size=128` together with `enable_chunked_prefill=False` for offline inference — as shown in the examples above.
 
-Request preemption is triggered when the KV cache runs out: running requests are evicted and their KV cache is recomputed later, which breaks batch invariance and degrades performance. To reduce the chance of preemption, increase the available KV cache or lower the per-request and concurrent pressure:
+Request preemption is triggered when the KV cache runs out: the preempted request is evicted and recomputed later. The recomputed prefill includes the tokens generated before the preemption, so attention processes them through the prefill (P) path instead of the original decode (D) path — the P and D computations cannot be aligned, which breaks batch invariance. To reduce the chance of preemption, increase the available KV cache or lower the per-request and concurrent pressure:
 
 - Decrease `--max-num-seqs` so fewer requests share the KV cache.
 - Set `--max-model-len` to the smallest value your workload needs, and cap the per-request output length (`max_tokens`).

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -185,7 +185,7 @@ for output in outputs:
 
 Chunked prefill, prefix caching, and request preemption (eviction and recomputation) are not supported with batch invariance.
 
-These scheduling features are not disabled automatically. You must explicitly disable chunked prefill and prefix caching and set the KV cache block size to 128 in your configuration — for example, `--no-enable-chunked-prefill`, `--no-enable-prefix-caching`, and `--block-size 128` when starting the server, or `enable_chunked_prefill=False`, `enable_prefix_caching=False`, and `block_size=128` for offline inference — as shown in the examples above.
+These scheduling features are not disabled automatically. You must explicitly disable chunked prefill and prefix caching in your configuration, and pair the chunked prefill disabling with a KV cache block size of 128 — pass `--block-size 128` together with `--no-enable-chunked-prefill` when starting the server, or `block_size=128` together with `enable_chunked_prefill=False` for offline inference — as shown in the examples above.
 
 ## Tested Models
 

--- a/docs/source/user_guide/feature_guide/batch_invariance.md
+++ b/docs/source/user_guide/feature_guide/batch_invariance.md
@@ -112,7 +112,10 @@ export VLLM_BATCH_INVARIANT=1
 To start a vLLM server with batch invariance enabled:
 
 ```bash
-VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B
+VLLM_BATCH_INVARIANT=1 vllm serve Qwen/Qwen3-8B \
+    --no-enable-chunked-prefill \
+    --no-enable-prefix-caching \
+    --block-size 128
 ```
 
 Then use the OpenAI-compatible client:
@@ -163,6 +166,9 @@ sampling_params = SamplingParams(
 llm = LLM(
     model="Qwen/Qwen3-8B",
     tensor_parallel_size=1,
+    enable_prefix_caching=False,
+    enable_chunked_prefill=False,
+    block_size=128,
 )
 
 # Outputs will be deterministic regardless of batch size
@@ -174,6 +180,12 @@ for output in outputs:
     print(f"Prompt: {prompt!r}")
     print(f"Generated: {generated_text!r}\n")
 ```
+
+## Scheduling Limitations
+
+Chunked prefill, prefix caching, and request preemption (eviction and recomputation) are not supported with batch invariance.
+
+These scheduling features are not disabled automatically. You must explicitly disable chunked prefill and prefix caching and set the KV cache block size to 128 in your configuration — for example, `--no-enable-chunked-prefill`, `--no-enable-prefix-caching`, and `--block-size 128` when starting the server, or `enable_chunked_prefill=False`, `enable_prefix_caching=False`, and `block_size=128` for offline inference — as shown in the examples above.
 
 ## Tested Models
 

--- a/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
+++ b/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
@@ -116,6 +116,8 @@ def _extract_step_logprobs(request_output):
     dtype="bfloat16",
     tensor_parallel_size=int(os.getenv("VLLM_TEST_TP_SIZE", "4")),
     enable_prefix_caching=False,
+    enable_chunked_prefill=False,
+    block_size=128,
     distributed_executor_backend="mp",
     compilation_config={
         "cudagraph_capture_sizes": [1, 32, 64],

--- a/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
+++ b/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py
@@ -116,8 +116,6 @@ def _extract_step_logprobs(request_output):
     dtype="bfloat16",
     tensor_parallel_size=int(os.getenv("VLLM_TEST_TP_SIZE", "4")),
     enable_prefix_caching=False,
-    enable_chunked_prefill=False,
-    block_size=128,
     distributed_executor_backend="mp",
     compilation_config={
         "cudagraph_capture_sizes": [1, 32, 64],
@@ -125,6 +123,8 @@ def _extract_step_logprobs(request_output):
     extra_kwargs={
         "load_format": "dummy",
         "hf_overrides": SMALL_QWEN3_OVERRIDES,
+        "enable_chunked_prefill": False,
+        "block_size": 128,
     },
 )
 def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(vllm_runner, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### What this PR does / why we need it?
Documents the scheduling limitations of batch invariance in the user guide: chunked prefill, prefix caching, and request preemption (eviction and recomputation) are not supported. These features are not disabled automatically, so the guide now instructs users to explicitly disable chunked prefill and prefix caching, and pairs `--block-size 128` with the chunked prefill disabling. The online/offline inference examples and the batch invariance e2e test are updated with the same config.

### Does this PR introduce _any_ user-facing change?
Documentation-only update plus an e2e test configuration adjustment.

### How was this patch tested?
Doc-only change; the e2e test config (`test_batch_invariant_tp4.py`) follows the documented settings. CI verification is sufficient.
- VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -sv tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py 
```bash
[DEBUG] Final model_config: {'model_name': ..Qwen3-30B-A3B', 'max_num_seqs': 144, 'gpu_memory_utilization': 0.95, 'max_model_len': 8192, 'dtype': 'bfloat16', 'tensor_parallel_size': 4, 'enable_prefix_caching': False, 'distributed_executor_backend': 'mp', 'compilation_config': {'cudagraph_capture_sizes': [1, 32, 64]}, 'extra_kwargs': {'load_format': 'dummy', 'hf_overrides': {'num_hidden_layers': 2}, 'enable_chunked_prefill': False, 'block_size': 128}}
[DEBUG] vllm_runner fixture - model_config: {'model_name': '..Qwen3-30B-A3B', 'max_num_seqs': 144, 'gpu_memory_utilization': 0.95, 'max_model_len': 8192, 'dtype': 'bfloat16', 'tensor_parallel_size': 4, 'enable_prefix_caching': False, 'distributed_executor_backend': 'mp', 'compilation_config': {'cudagraph_capture_sizes': [1, 32, 64]}, 'extra_kwargs': {'load_format': 'dummy', 'hf_overrides': {'num_hidden_layers': 2}, 'enable_chunked_prefill': False, 'block_size': 128}}
...
PASSEDINFO 09-10 20:42:39 [utils.py:620] [shutdown] Process manager: send sigterm to process EngineCore
(EngineCore pid=64849) INFO 09-10 20:42:39 [core.py:1350] [shutdown] EngineCore: trigger received signal=SIGTERM
(EngineCore pid=64849) INFO 09-10 20:42:39 [core.py:1501] [shutdown] EngineCore: start mode=abort timeout=0s
(EngineCore pid=64849) INFO 09-10 20:42:39 [core.py:1532] [shutdown] EngineCore: request processing complete; starting resource teardown
(EngineCore pid=64849) INFO 09-10 20:42:39 [core.py:1363] [shutdown] EngineCore: exiting busy loop
(EngineCore pid=64849) INFO 09-10 20:42:39 [multiproc_executor.py:472] [shutdown] Executor: waiting for worker exit count=4
(Worker_TP0 pid=65187) INFO 09-10 20:42:39 [multiproc_executor.py:836] Parent process exited, terminating worker queues
WARNING 09-10 20:42:44 [utils.py:640] [shutdown] Process manager: force killing remaining processes count=1
WARNING 09-10 20:42:44 [utils.py:645] [shutdown] Process manager: force killing remaining process EngineCore pid 64849
(EngineCore pid=64849) WARNING 09-10 20:42:44 [multiproc_executor.py:484] [shutdown] Executor: workers still running after grace period; sending SIGTERM count=3
[INFO] Model cache cleared

=============================== warnings summary ===============================
../../../../../usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: 14 warnings
  /usr/local/python3.11.10/lib/python3.11/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py:111
  /mnt/share/w00899129/vllm_code_0908/vllm-ascend/tests/e2e/pull_request/four_card/rlhf/consistency/test_batch_invariant_tp4.py:111: PytestUnknownMarkWarning: Unknown pytest.mark.model - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.model(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 1 passed, 15 warnings in 118.88s (0:01:58) ==================
/usr/local/python3.11.10/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '

```


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
