### PR TITLE
[Feature][Ops] Add sparse flash MLA metadata generation on A5

### DIFF
--- a/csrc/attention/common/op_kernel/sparse_flash_mla_metadata.h
+++ b/csrc/attention/common/op_kernel/sparse_flash_mla_metadata.h
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata.h
+ * \brief
+ */
+
+#ifndef SPARSE_FLASH_MLA_METADATA_H
+#define SPARSE_FLASH_MLA_METADATA_H
+
+#include <cstdint>
+
+namespace optiling {
+
+// Constants
+constexpr uint32_t AIC_CORE_MAX_NUM = 36;
+constexpr uint32_t AIV_CORE_MAX_NUM = 72;
+constexpr uint32_t SMLA_METADATA_TOTAL_SIZE = 1024;
+using SMLA_METADATA_T = int32_t;
+
+constexpr uint32_t FA_METADATA_SIZE = 9;
+constexpr uint32_t FD_METADATA_SIZE = 8;
+
+// FA Metadata Index Definitions
+constexpr uint32_t FA_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FA_BN2_START_INDEX = 1;
+constexpr uint32_t FA_M_START_INDEX = 2;
+constexpr uint32_t FA_S2_START_INDEX = 3;
+constexpr uint32_t FA_BN2_END_INDEX = 4;
+constexpr uint32_t FA_M_END_INDEX = 5;
+constexpr uint32_t FA_S2_END_INDEX = 6;
+constexpr uint32_t FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX = 7;
+constexpr uint32_t FA_S2_MAX_NUM = 8;
+
+// FD Metadata Index Definitions
+constexpr uint32_t FD_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FD_BN2_IDX_INDEX = 1;
+constexpr uint32_t FD_M_IDX_INDEX = 2;
+constexpr uint32_t FD_WORKSPACE_IDX_INDEX = 3;
+constexpr uint32_t FD_WORKSPACE_NUM_INDEX = 4;
+constexpr uint32_t FD_M_START_INDEX = 5;
+constexpr uint32_t FD_M_NUM_INDEX = 6;
+
+/**
+ * @brief 获取属性的绝对索引
+ * @param coreIdx 核索引
+ * @param metaIdx 元数据索引
+ * @param isAIV 是否为AIV数据，默认为false
+ * @return 返回属性的绝对索引
+ */
+#ifdef __CCE_AICORE__
+__aicore__ inline uint32_t GetAttrAbsIndex(uint32_t coreIdx, uint32_t metaIdx, bool isAIV = false)
+{
+    if (isAIV) {
+        return FA_METADATA_SIZE * AIC_CORE_MAX_NUM + FD_METADATA_SIZE * coreIdx + metaIdx;
+    } else {
+        return FA_METADATA_SIZE * coreIdx + metaIdx;
+    }
+}
+#endif
+
+namespace detail {
+    struct SmlaMetadata {
+        uint32_t faMetadata[AIC_CORE_MAX_NUM][FA_METADATA_SIZE];
+        uint32_t fdMetadata[AIV_CORE_MAX_NUM][FD_METADATA_SIZE];
+    };
+};
+
+static_assert(SMLA_METADATA_TOTAL_SIZE * sizeof(SMLA_METADATA_T) >= sizeof(detail::SmlaMetadata));
+};
+
+#endif // SPARSE_FLASH_MLA_METADATA_H

--- a/csrc/attention/sparse_flash_mla_metadata/CMakeLists.txt
+++ b/csrc/attention/sparse_flash_mla_metadata/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/sparse_flash_mla_metadata/examples/test_aclnn_sparse_flash_mla_metadata.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/examples/test_aclnn_sparse_flash_mla_metadata.cpp
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/**
+ * @file test_aclnn_sparse_flash_mla_metadata.cpp
+ */
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <functional>
+#include <utility>
+#include "acl/acl.h"
+#include "aclnnop/aclnn_sparse_flash_mla_metadata.h"
+
+#define CHECK_LOG_RET(cond, ret_val, fmt, ...)      \
+    do {                                            \
+        if (!(cond)) {                              \
+            printf(fmt "\n", ##__VA_ARGS__);        \
+            return (ret_val);                       \
+        }                                           \
+    } while (0)
+
+// 参考 sparse_flash_mla_metadata.h
+constexpr uint32_t AIC_CORE_MAX_NUM = 36;
+constexpr uint32_t AIV_CORE_MAX_NUM = 72;
+constexpr uint32_t SMLA_METADATA_TOTAL_SIZE = 1024;
+constexpr uint32_t FA_METADATA_SIZE = 9;
+constexpr uint32_t FD_METADATA_SIZE = 8;
+
+// FA Metadata Index Definitions
+constexpr uint32_t FA_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FA_BN2_START_INDEX = 1;
+constexpr uint32_t FA_M_START_INDEX = 2;
+constexpr uint32_t FA_S2_START_INDEX = 3;
+constexpr uint32_t FA_BN2_END_INDEX = 4;
+constexpr uint32_t FA_M_END_INDEX = 5;
+constexpr uint32_t FA_S2_END_INDEX = 6;
+constexpr uint32_t FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX = 7;
+constexpr uint32_t FA_S2_MAX_NUM = 8;
+
+// FD Metadata Index Definitions
+constexpr uint32_t FD_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FD_BN2_IDX_INDEX = 1;
+constexpr uint32_t FD_M_IDX_INDEX = 2;
+constexpr uint32_t FD_WORKSPACE_IDX_INDEX = 3;
+constexpr uint32_t FD_WORKSPACE_NUM_INDEX = 4;
+constexpr uint32_t FD_M_START_INDEX = 5;
+constexpr uint32_t FD_M_NUM_INDEX = 6;
+
+struct SmlaMetadata {
+    uint32_t faMetadata[AIC_CORE_MAX_NUM][FA_METADATA_SIZE];
+    uint32_t fdMetadata[AIV_CORE_MAX_NUM][FD_METADATA_SIZE];
+};
+
+struct ScopeGuard
+{
+    explicit ScopeGuard(std::function<void()> onExitScope) : m_exitFunc(std::move(onExitScope)),
+        m_isDismissed(false) {}
+    // 禁止拷贝
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+
+    ~ScopeGuard()
+    {
+        if (!m_isDismissed) {
+            m_exitFunc();
+        }
+    }
+
+    void Dismiss()
+    {
+        m_isDismissed = true;
+    }
+
+    std::function<void()> m_exitFunc;
+    bool m_isDismissed;
+};
+
+struct Tensor {
+    void *hostAddr { nullptr };
+    void *deviceAddr { nullptr };
+    aclTensor *data { nullptr };
+};
+
+struct ArgScenario {
+    bool hasCuSeq { false };
+    bool hasSeqused { false };
+};
+
+struct ArgContext {
+    // required input
+    int64_t numHeadsQ { 0 };
+    int64_t numHeadsKv { 0 };
+    int64_t headDim { 0 };
+    // optional input
+    Tensor cuSeqlensQOptional {};
+    Tensor cuSeqlensOriKvOptional {};
+    Tensor cuSeqlensCmpKvOptional {};
+    Tensor sequsedQOptional {};
+    Tensor sequsedOriKvOptional {};
+    Tensor sequsedCmpKvOptional {};
+    Tensor cmpResidualKvOptional {};
+    Tensor oriTopkLengthOptional {};
+    Tensor cmpTopkLengthOptional {};
+    int64_t batchSize { 0 };
+    int64_t maxSeqlenQ { 0 };
+    int64_t maxSeqlenOriKv { 0 };
+    int64_t maxSeqlenCmpKv { 0 };
+    int64_t oriTopk { 0 };
+    int64_t cmpTopk { 0 };
+    int64_t cmpRatio { 0 };
+    int64_t oriMaskMode { 0 };
+    int64_t cmpMaskMode { 0 };
+    int64_t oriWinLeft { -1 };
+    int64_t oriWinRight { -1 };
+    char *layoutQOptional { nullptr };
+    char *layoutKvOptional { nullptr };
+    bool hasOriKv { true };
+    bool hasCmpKv { true };
+    // output
+    Tensor metadata {};
+};
+
+int64_t GetShapeSize(const std::vector<int64_t>& shape)
+{
+    int64_t shapeSize = 1;
+    for (auto i : shape) {
+        shapeSize *= i;
+    }
+    return shapeSize;
+}
+
+aclnnStatus Init(int32_t deviceId, aclrtStream* stream)
+{
+    // 固定写法，初始化
+    auto ret = aclInit(nullptr);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclInit failed. ERROR: %d", ret);
+    ret = aclrtSetDevice(deviceId);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtSetDevice failed. ERROR: %d", ret);
+    ret = aclrtCreateStream(stream);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtCreateStream failed. ERROR: %d", ret);
+    return ACL_SUCCESS;
+}
+
+void Finalize(int32_t deviceId, aclrtStream stream)
+{
+    aclrtDestroyStream(stream);
+    aclrtResetDevice(deviceId);
+    aclFinalize();
+}
+
+aclnnStatus CreateTensor(aclDataType dataType, const std::vector<int64_t> &shape, Tensor &tensor)
+{
+    auto size = GetShapeSize(shape) * aclDataTypeSize(dataType);
+    // 调用aclrtMallocHost申请host侧内存
+    auto ret = aclrtMallocHost(&(tensor.hostAddr), size);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtMallocHost failed. ERROR: %d", ret);
+    memset(tensor.hostAddr, 0, size);
+    // 调用aclrtMalloc申请device侧内存
+    ret = aclrtMalloc(&(tensor.deviceAddr), size, ACL_MEM_MALLOC_HUGE_FIRST);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtMalloc failed. ERROR: %d", ret);
+    // 调用aclCreateTensor接口创建aclTensor
+    tensor.data = aclCreateTensor(shape.data(), shape.size(), dataType, nullptr, 0, aclFormat::ACL_FORMAT_ND,
+        shape.data(), shape.size(), tensor.deviceAddr);
+    CHECK_LOG_RET(tensor.data != nullptr, ACL_ERROR_FAILURE, "aclCreateTensor failed");
+    // 调用aclrtMemcpy将host侧数据拷贝到device侧内存上
+    ret = aclrtMemcpy(tensor.deviceAddr, size, tensor.hostAddr, size, ACL_MEMCPY_HOST_TO_DEVICE);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtMemcpy failed. ERROR: %d", ret);
+    return ACL_SUCCESS;
+}
+
+void DestroyTensor(Tensor &tensor)
+{
+    if (tensor.data != nullptr) {
+        aclDestroyTensor(tensor.data);
+        tensor.data = nullptr;
+    }
+    if (tensor.deviceAddr != nullptr) {
+        aclrtFree(tensor.deviceAddr);
+        tensor.deviceAddr = nullptr;
+    }
+    if (tensor.hostAddr != nullptr) {
+        aclrtFreeHost(tensor.hostAddr);
+        tensor.hostAddr = nullptr;
+    }
+}
+
+void DestroyArgs(ArgContext &context)
+{
+    DestroyTensor(context.metadata);
+    DestroyTensor(context.cuSeqlensQOptional);
+    DestroyTensor(context.cuSeqlensOriKvOptional);
+    DestroyTensor(context.cuSeqlensCmpKvOptional);
+    DestroyTensor(context.sequsedQOptional);
+    DestroyTensor(context.sequsedOriKvOptional);
+    DestroyTensor(context.sequsedCmpKvOptional);
+    DestroyTensor(context.cmpResidualKvOptional);
+    DestroyTensor(context.oriTopkLengthOptional);
+    DestroyTensor(context.cmpTopkLengthOptional);
+
+    if (context.layoutQOptional != nullptr) {
+        free(context.layoutQOptional);
+        context.layoutQOptional = nullptr;
+    }
+    if (context.layoutKvOptional != nullptr) {
+        free(context.layoutKvOptional);
+        context.layoutKvOptional = nullptr;
+    }
+}
+
+aclnnStatus CreateArgs(const ArgScenario &scenario, ArgContext &context)
+{
+    ScopeGuard argsGuard([&] { DestroyArgs(context); });
+    aclnnStatus ret;
+
+    context.numHeadsQ = 64;
+    context.numHeadsKv = 1;
+    context.headDim = 512;
+    ret = CreateTensor(aclDataType::ACL_INT32, { SMLA_METADATA_TOTAL_SIZE }, context.metadata);     // 1024: Fix size
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create metadata failed. Error: %d", ret);
+    context.oriTopk = 0;
+    context.cmpTopk = 0;
+    context.cmpRatio = 128;
+    context.oriMaskMode = 4;
+    context.cmpMaskMode = 3;
+    context.oriWinLeft = 127;
+    context.oriWinRight = 0;
+    context.layoutQOptional = (char *)malloc(sizeof(char) * 16);
+    context.layoutKvOptional = (char *)malloc(sizeof(char) * 16);
+    CHECK_LOG_RET(context.layoutQOptional != nullptr, ACL_ERROR_FAILURE, "Create layoutQOptional failed");
+    CHECK_LOG_RET(context.layoutKvOptional != nullptr, ACL_ERROR_FAILURE, "Create layoutKvOptional failed");
+    strcpy(context.layoutQOptional, "BSND");                // BSND,TND
+    strcpy(context.layoutKvOptional, "BSND");               // BSND,TND,PA_BBND
+    context.hasOriKv = true;
+    context.hasCmpKv = true;
+
+    context.batchSize = 4;
+    context.maxSeqlenOriKv = 1024;
+    context.maxSeqlenCmpKv = 1024;
+    context.maxSeqlenQ = 1024;
+
+    if (scenario.hasCuSeq) {
+        // (B+1,), first element is always 0
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize + 1 }, context.cuSeqlensQOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create cuSeqlensQOptional failed. Error: %d", ret);
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize + 1 }, context.cuSeqlensOriKvOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create cuSeqlensOriKvOptional failed. Error: %d", ret);
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize + 1 }, context.cuSeqlensCmpKvOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create cuSeqlensCmpKvOptional failed. Error: %d", ret);
+    }
+
+    if (scenario.hasSeqused) {
+        // (B,)
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize }, context.sequsedQOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create sequsedQOptional failed. Error: %d", ret);
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize }, context.sequsedOriKvOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create sequsedOriKvOptional failed. Error: %d", ret);
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize }, context.sequsedCmpKvOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create sequsedCmpKvOptional failed. Error: %d", ret);
+    }
+
+    if (context.hasCmpKv && context.cmpRatio != 1 && context.cmpMaskMode == 3) {
+        // (B,)
+        ret = CreateTensor(aclDataType::ACL_INT32, { context.batchSize }, context.cmpResidualKvOptional);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create cmpResidualKvOptional failed. Error: %d", ret);
+    }
+
+    argsGuard.Dismiss();
+    return ACL_SUCCESS;
+}
+
+int main() {
+    // 1. （固定写法）device/stream初始化，参考对外接口列表
+    // 根据自己的实际device填写deviceId
+    int32_t deviceId = 0;
+    aclrtStream stream;
+    auto ret = Init(deviceId, &stream);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Init acl failed. ERROR: %d", ret);
+    ScopeGuard sysGuard([&] { Finalize(deviceId, stream); });
+
+    // 2. 构造输入与输出，需要根据API的接口定义构造
+    ArgScenario scenario {};
+    scenario.hasCuSeq = false;
+    scenario.hasSeqused = false;
+    ArgContext context {};
+    ret = CreateArgs(scenario, context);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "Create input arguments failed. ERROR: %d", ret);
+    ScopeGuard argsGuard([&] { DestroyArgs(context); });
+
+    // 3. 调用CANN算子库API，需要修改为具体的API
+    // 调用aclnnSparseFlashMlaMetadata第一段接口
+    uint64_t workspaceSize = 0;
+    aclOpExecutor *executor = nullptr;
+    void *workspaceAddr = nullptr;
+    ret = aclnnSparseFlashMlaMetadataGetWorkspaceSize(
+        context.cuSeqlensQOptional.data, context.cuSeqlensOriKvOptional.data, context.cuSeqlensCmpKvOptional.data,
+        context.sequsedQOptional.data, context.sequsedOriKvOptional.data, context.sequsedCmpKvOptional.data,
+        context.cmpResidualKvOptional.data, context.oriTopkLengthOptional.data, context.cmpTopkLengthOptional.data,
+        context.numHeadsQ, context.numHeadsKv, context.headDim, context.batchSize, context.maxSeqlenQ,
+        context.maxSeqlenOriKv, context.maxSeqlenCmpKv, context.oriTopk, context.cmpTopk, context.cmpRatio,
+        context.oriMaskMode, context.cmpMaskMode, context.oriWinLeft, context.oriWinRight, context.layoutQOptional,
+        context.layoutKvOptional, context.hasOriKv, context.hasCmpKv, context.metadata.data, &workspaceSize, &executor);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret,
+        "aclnnSparseFlashMlaMetadataGetWorkspaceSize failed. ERROR: %d\n", ret);
+
+    if (workspaceSize > static_cast<uint64_t>(0)) {
+        ret = aclrtMalloc(&workspaceAddr, workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+        CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "allocate workspace failed. ERROR: %d\n", ret);
+    }
+    ScopeGuard workspaceGuard([&] {
+        if (workspaceAddr != nullptr) {
+            aclrtFree(workspaceAddr);
+            workspaceAddr = nullptr;
+        }
+    });
+
+    // 调用aclnnSparseFlashMlaMetadata第二段接口
+    ret = aclnnSparseFlashMlaMetadata(workspaceAddr, workspaceSize, executor, stream);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclnnSparseFlashMlaMetadata failed. ERROR: %d\n", ret);
+
+    // 4. （固定写法）同步等待任务执行结束
+    ret = aclrtSynchronizeStream(stream);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtSynchronizeStream failed. ERROR: %d\n", ret);
+
+    // 5. 打印输出
+    SmlaMetadata result {};
+    ret = aclrtMemcpy(&result, sizeof(result), context.metadata.deviceAddr, sizeof(result), ACL_MEMCPY_DEVICE_TO_HOST);
+    CHECK_LOG_RET(ret == ACL_SUCCESS, ret, "aclrtMemcpy failed. ERROR: %d\n", ret);
+
+    for (uint32_t i = 0; i < AIC_CORE_MAX_NUM; ++i) {
+        printf("AIC Core%u\n", i);
+        printf("    Core Enable : %u\n", result.faMetadata[i][FA_CORE_ENABLE_INDEX]);
+        printf("    Start BN2   : %u\n", result.faMetadata[i][FA_BN2_START_INDEX]);
+        printf("    Start M     : %u\n", result.faMetadata[i][FA_M_START_INDEX]);
+        printf("    Start S2    : %u\n", result.faMetadata[i][FA_S2_START_INDEX]);
+        printf("    End BN2     : %u\n", result.faMetadata[i][FA_BN2_END_INDEX]);
+        printf("    End M       : %u\n", result.faMetadata[i][FA_M_END_INDEX]);
+        printf("    End S2      : %u\n", result.faMetadata[i][FA_S2_END_INDEX]);
+        printf("    First Worksapce Index : %u\n", result.faMetadata[i][FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX]);
+        printf("    Max S2 Block Num : %u\n", result.faMetadata[i][FA_S2_MAX_NUM]);
+    }
+    for (uint32_t i = 0; i < AIV_CORE_MAX_NUM; ++i) {
+        printf("AIV Core%u\n", i);
+        printf("    Core Enable             : %u\n", result.fdMetadata[i][FD_CORE_ENABLE_INDEX]);
+        printf("    FD Task BN2 Idx         : %u\n", result.fdMetadata[i][FD_BN2_IDX_INDEX]);
+        printf("    FD Task M Idx           : %u\n", result.fdMetadata[i][FD_M_IDX_INDEX]);
+        printf("    FD Task S2 Idx          : %u\n", result.fdMetadata[i][FD_WORKSPACE_IDX_INDEX]);
+        printf("    FD Task Workspace Num   : %u\n", result.fdMetadata[i][FD_WORKSPACE_NUM_INDEX]);
+        printf("    FD Subtask M Start      : %u\n", result.fdMetadata[i][FD_M_START_INDEX]);
+        printf("    FD Subtask M Num        : %u\n", result.fdMetadata[i][FD_M_NUM_INDEX]);
+    }
+
+    return 0;
+}

--- a/csrc/attention/sparse_flash_mla_metadata/examples/test_torch_sparse_flash_mla_metadata.py
+++ b/csrc/attention/sparse_flash_mla_metadata/examples/test_torch_sparse_flash_mla_metadata.py
@@ -1,0 +1,41 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import torch
+
+metadata = torch.ops.cann_ops_transformer.sparse_flash_mla_metadata(
+    cu_seqlens_q=torch.tensor([0, 10], dtype=torch.int32).npu(),
+    cu_seqlens_ori_kv=None,
+    cu_seqlens_cmp_kv=None,
+    seqused_q=None,
+    seqused_ori_kv=torch.tensor([8192], dtype=torch.int32).npu(),
+    seqused_cmp_kv=torch.tensor([64], dtype=torch.int32).npu(),
+    cmp_residual_kv=torch.tensor([1], dtype=torch.int32).npu(),
+    ori_topk_length=None,
+    cmp_topk_length=None,
+    num_heads_q=128,
+    num_heads_kv=1,
+    head_dim=512,
+    batch_size=1,
+    max_seqlen_q=1,
+    max_seqlen_ori_kv=512,
+    max_seqlen_cmp_kv=32,
+    ori_topk=0,
+    cmp_topk=512,
+    cmp_ratio=4,
+    ori_mask_mode=4,
+    cmp_mask_mode=3,
+    ori_win_left=127,
+    ori_win_right=0,
+    layout_q="TND",
+    layout_kv="PA_BBND",
+    has_ori_kv=True,
+    has_cmp_kv=True,
+)

--- a/csrc/attention/sparse_flash_mla_metadata/op_api/aclnn_sparse_flash_mla_metadata.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_api/aclnn_sparse_flash_mla_metadata.cpp
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_sparse_flash_mla_metadata.cpp
+ * \brief
+ */
+
+#include "aclnn_sparse_flash_mla_metadata.h"
+#include "sparse_flash_mla_metadata.h"
+#include "aclnn_kernels/contiguous.h"
+#include "aclnn_kernels/reshape.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+#include "../op_host/sparse_flash_mla_metadata_check.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+aclnnStatus aclnnSparseFlashMlaMetadataGetWorkspaceSize(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const aclTensor *metaData, uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    if (workspaceSize == nullptr) {
+        OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "workspaceSize is nullptr");
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    if (executor == nullptr) {
+        OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "executor is nullptr");
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    L2_DFX_PHASE_1(aclnnSparseFlashMlaMetadata,
+                   DFX_IN(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                          sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                          cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv,
+                          maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight,
+                          layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv),
+                   DFX_OUT(metaData));
+
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+
+    const op::PlatformInfo &npuInfo = op::GetCurrentPlatformInfo();
+    uint32_t aicCoreNum = npuInfo.GetCubeCoreNum();
+    uint32_t aivCoreNum = npuInfo.GetVectorCoreNum();
+    std::string socVersionStr = npuInfo.GetSocLongVersion();
+    const char *socVersion = socVersionStr.c_str();
+
+    auto ret = ParamsCheck(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                           sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                           cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv,
+                           maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft,
+                           oriWinRight, layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv, aicCoreNum, aivCoreNum,
+                           socVersion, metaData);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+
+    const aclTensor *cuSeqlensQOptionalContiguous = nullptr;
+    if (cuSeqlensQOptional != nullptr) {
+        cuSeqlensQOptionalContiguous = l0op::Contiguous(cuSeqlensQOptional, uniqueExecutor.get());
+        if (cuSeqlensQOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_q contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cuSeqlensOriKvOptionalContiguous = nullptr;
+    if (cuSeqlensOriKvOptional != nullptr) {
+        cuSeqlensOriKvOptionalContiguous = l0op::Contiguous(cuSeqlensOriKvOptional, uniqueExecutor.get());
+        if (cuSeqlensOriKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_ori_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cuSeqlensCmpKvOptionalContiguous = nullptr;
+    if (cuSeqlensCmpKvOptional != nullptr) {
+        cuSeqlensCmpKvOptionalContiguous = l0op::Contiguous(cuSeqlensCmpKvOptional, uniqueExecutor.get());
+        if (cuSeqlensCmpKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_cmp_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedQOptionalContiguous = nullptr;
+    if (sequsedQOptional != nullptr) {
+        sequsedQOptionalContiguous = l0op::Contiguous(sequsedQOptional, uniqueExecutor.get());
+        if (sequsedQOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_q contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedOriKvOptionalContiguous = nullptr;
+    if (sequsedOriKvOptional != nullptr) {
+        sequsedOriKvOptionalContiguous = l0op::Contiguous(sequsedOriKvOptional, uniqueExecutor.get());
+        if (sequsedOriKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_ori_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedCmpKvOptionalContiguous = nullptr;
+    if (sequsedCmpKvOptional != nullptr) {
+        sequsedCmpKvOptionalContiguous = l0op::Contiguous(sequsedCmpKvOptional, uniqueExecutor.get());
+        if (sequsedCmpKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_cmp_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cmpResidualKvOptionalContiguous = nullptr;
+    if (cmpResidualKvOptional != nullptr) {
+        cmpResidualKvOptionalContiguous = l0op::Contiguous(cmpResidualKvOptional, uniqueExecutor.get());
+        if (cmpResidualKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cmp_residual_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *oriTopkLengthOptionalContiguous = nullptr;
+    if (oriTopkLengthOptional != nullptr) {
+        oriTopkLengthOptionalContiguous = l0op::Contiguous(oriTopkLengthOptional, uniqueExecutor.get());
+        if (oriTopkLengthOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "ori_topk_length contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cmpTopkLengthOptionalContiguous = nullptr;
+    if (cmpTopkLengthOptional != nullptr) {
+        cmpTopkLengthOptionalContiguous = l0op::Contiguous(cmpTopkLengthOptional, uniqueExecutor.get());
+        if (cmpTopkLengthOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cmp_topk_length contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+
+    auto output = l0op::SparseFlashMlaMetadata(
+        cuSeqlensQOptionalContiguous, cuSeqlensOriKvOptionalContiguous, cuSeqlensCmpKvOptionalContiguous,
+        sequsedQOptionalContiguous, sequsedOriKvOptionalContiguous, sequsedCmpKvOptionalContiguous,
+        cmpResidualKvOptionalContiguous, oriTopkLengthOptionalContiguous, cmpTopkLengthOptionalContiguous, numHeadsQ,
+        numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio,
+        oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv,
+        socVersion, aicCoreNum, aivCoreNum, metaData, uniqueExecutor.get());
+    CHECK_RET(output != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    *workspaceSize = 0;
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadata(
+    void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnSparseFlashMlaMetadata);
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_api/aclnn_sparse_flash_mla_metadata.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_api/aclnn_sparse_flash_mla_metadata.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef ACLNN_SPARSE_FLASH_MLA_METADATA_H
+#define ACLNN_SPARSE_FLASH_MLA_METADATA_H
+
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadataGetWorkspaceSize(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const aclTensor *metaData, uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadata(
+    void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ACLNN_SPARSE_FLASH_MLA_METADATA_H

--- a/csrc/attention/sparse_flash_mla_metadata/op_api/sparse_flash_mla_metadata.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_api/sparse_flash_mla_metadata.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata.cpp
+ * \brief
+ */
+
+#include "sparse_flash_mla_metadata.h"
+#include "opdev/aicpu/aicpu_task.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_def.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/shape_utils.h"
+
+using namespace op;
+namespace l0op {
+OP_TYPE_REGISTER(SparseFlashMlaMetadata);
+
+const aclTensor *SparseFlashMlaMetadata(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const char *socVersion, int64_t aicCoreNum,
+    int64_t aivCoreNum, const aclTensor *metaData, aclOpExecutor *executor)
+{
+    L0_DFX(SparseFlashMlaMetadata, cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional,
+           sequsedQOptional, sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+           cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv,
+           oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional,
+           layoutKvOptional, hasOriKv, hasCmpKv, socVersion, aicCoreNum, aivCoreNum, metaData);
+
+    static internal::AicpuTaskSpace space("SparseFlashMlaMetadata");
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICPU(
+        SparseFlashMlaMetadata,
+        OP_ATTR_NAMES({"num_heads_q", "num_heads_kv", "head_dim", "batch_size", "max_seqlen_q", "max_seqlen_ori_kv",
+                       "max_seqlen_cmp_kv", "ori_topk", "cmp_topk", "cmp_ratio", "ori_mask_mode", "cmp_mask_mode",
+                       "ori_win_left", "ori_win_right", "layout_q", "layout_kv", "has_ori_kv", "has_cmp_kv",
+                       "soc_version", "aic_core_num", "aiv_core_num"}),
+        OP_INPUT(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                 sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                 cmpTopkLengthOptional),
+        OP_OUTPUT(metaData),
+        OP_ATTR(numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv, oriTopk, cmpTopk,
+                cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional, layoutKvOptional,
+                hasOriKv, hasCmpKv, socVersion, aicCoreNum, aivCoreNum));
+    OP_CHECK(ret == ACL_SUCCESS,
+             OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "SparseFlashMlaMetadata ADD_TO_LAUNCHER_LIST_AICPU failed."),
+             return nullptr);
+    return metaData;
+}
+
+} // namespace l0op

--- a/csrc/attention/sparse_flash_mla_metadata/op_api/sparse_flash_mla_metadata.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_api/sparse_flash_mla_metadata.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef L0_SPARSE_FLASH_MLA_METADATA_H
+#define L0_SPARSE_FLASH_MLA_METADATA_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const aclTensor* SparseFlashMlaMetadata(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const char *socVersion, int64_t aicCoreNum,
+    int64_t aivCoreNum, const aclTensor *metaData, aclOpExecutor *executor);
+} // namespace l0op
+
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_graph/sparse_flash_mla_metadata_proto.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_graph/sparse_flash_mla_metadata_proto.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata_proto.h
+ * \brief
+ */
+#ifndef SPARSE_FLASH_MLA_METADATA_PROTO_H
+#define SPARSE_FLASH_MLA_METADATA_PROTO_H
+
+#include "graph/operator_reg.h"
+#include "graph/types.h"
+
+namespace ge {
+
+REG_OP(SparseFlashMlaMetadata)
+    .OPTIONAL_INPUT(cu_seqlens_q, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(cu_seqlens_ori_kv, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(cu_seqlens_cmp_kv, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(seqused_q, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(seqused_ori_kv, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(seqused_cmp_kv, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(cmp_residual_kv, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(ori_topk_length, TensorType({DT_INT32}))
+    .OPTIONAL_INPUT(cmp_topk_length, TensorType({DT_INT32}))
+    .OUTPUT(metadata, TensorType({DT_INT32}))
+    .REQUIRED_ATTR(num_heads_q, Int)
+    .REQUIRED_ATTR(num_heads_kv, Int)
+    .REQUIRED_ATTR(head_dim, Int)
+    .ATTR(batch_size, Int, 0)
+    .ATTR(max_seqlen_q, Int, 0)
+    .ATTR(max_seqlen_ori_kv, Int, 0)
+    .ATTR(max_seqlen_cmp_kv, Int, 0)
+    .ATTR(ori_topk, Int, 0)
+    .ATTR(cmp_topk, Int, 0)
+    .ATTR(cmp_ratio, Int, 1)
+    .ATTR(ori_mask_mode, Int, 0)
+    .ATTR(cmp_mask_mode, Int, 0)
+    .ATTR(ori_win_left, Int, -1)
+    .ATTR(ori_win_right, Int, -1)
+    .ATTR(layout_q, String, "BSND")
+    .ATTR(layout_kv, String, "BSND")
+    .ATTR(has_ori_kv, Bool, false)
+    .ATTR(has_cmp_kv, Bool, false)
+    .REQUIRED_ATTR(soc_version, String)
+    .REQUIRED_ATTR(aic_core_num, Int)
+    .REQUIRED_ATTR(aiv_core_num, Int)
+    .OP_END_FACTORY_REG(SparseFlashMlaMetadata)
+
+} // namespace ge
+
+#endif // SPARSE_FLASH_MLA_METADATA_PROTO_H

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/CMakeLists.txt
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/CMakeLists.txt
@@ -1,0 +1,12 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+
+add_modules_sources(OPTYPE sparse_flash_mla_metadata ACLNNTYPE aclnn)

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/aclnn_sparse_flash_mla_metadata.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/aclnn_sparse_flash_mla_metadata.cpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_sparse_flash_mla_metadata.cpp
+ * \brief
+ */
+
+#include "log/log.h"
+#include "aclnn_sparse_flash_mla_metadata.h"
+#include "sparse_flash_mla_metadata.h"
+#include "aclnn_kernels/contiguous.h"
+#include "aclnn_kernels/reshape.h"
+#include "aclnn/aclnn_base.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/make_op_executor.h"
+#include "../sparse_flash_mla_metadata_check.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+aclnnStatus aclnnSparseFlashMlaMetadataGetWorkspaceSize(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const aclTensor *metaData, uint64_t *workspaceSize,
+    aclOpExecutor **executor)
+{
+    if (workspaceSize == nullptr) {
+        OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "workspaceSize is nullptr");
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    if (executor == nullptr) {
+        OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "executor is nullptr");
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
+    L2_DFX_PHASE_1(aclnnSparseFlashMlaMetadata,
+                   DFX_IN(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                          sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                          cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv,
+                          maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight,
+                          layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv),
+                   DFX_OUT(metaData));
+
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+
+    const op::PlatformInfo &npuInfo = op::GetCurrentPlatformInfo();
+    uint32_t aicCoreNum = npuInfo.GetCubeCoreNum();
+    uint32_t aivCoreNum = npuInfo.GetVectorCoreNum();
+    std::string socVersionStr = npuInfo.GetSocLongVersion();
+    const char *socVersion = socVersionStr.c_str();
+
+    auto ret = ParamsCheck(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                           sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                           cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv,
+                           maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft,
+                           oriWinRight, layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv, aicCoreNum, aivCoreNum,
+                           socVersion, metaData);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+
+    const aclTensor *cuSeqlensQOptionalContiguous = nullptr;
+    if (cuSeqlensQOptional != nullptr) {
+        cuSeqlensQOptionalContiguous = l0op::Contiguous(cuSeqlensQOptional, uniqueExecutor.get());
+        if (cuSeqlensQOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_q contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cuSeqlensOriKvOptionalContiguous = nullptr;
+    if (cuSeqlensOriKvOptional != nullptr) {
+        cuSeqlensOriKvOptionalContiguous = l0op::Contiguous(cuSeqlensOriKvOptional, uniqueExecutor.get());
+        if (cuSeqlensOriKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_ori_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cuSeqlensCmpKvOptionalContiguous = nullptr;
+    if (cuSeqlensCmpKvOptional != nullptr) {
+        cuSeqlensCmpKvOptionalContiguous = l0op::Contiguous(cuSeqlensCmpKvOptional, uniqueExecutor.get());
+        if (cuSeqlensCmpKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cu_seqlens_cmp_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedQOptionalContiguous = nullptr;
+    if (sequsedQOptional != nullptr) {
+        sequsedQOptionalContiguous = l0op::Contiguous(sequsedQOptional, uniqueExecutor.get());
+        if (sequsedQOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_q contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedOriKvOptionalContiguous = nullptr;
+    if (sequsedOriKvOptional != nullptr) {
+        sequsedOriKvOptionalContiguous = l0op::Contiguous(sequsedOriKvOptional, uniqueExecutor.get());
+        if (sequsedOriKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_ori_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *sequsedCmpKvOptionalContiguous = nullptr;
+    if (sequsedCmpKvOptional != nullptr) {
+        sequsedCmpKvOptionalContiguous = l0op::Contiguous(sequsedCmpKvOptional, uniqueExecutor.get());
+        if (sequsedCmpKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "seqused_cmp_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cmpResidualKvOptionalContiguous = nullptr;
+    if (cmpResidualKvOptional != nullptr) {
+        cmpResidualKvOptionalContiguous = l0op::Contiguous(cmpResidualKvOptional, uniqueExecutor.get());
+        if (cmpResidualKvOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cmp_residual_kv contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *oriTopkLengthOptionalContiguous = nullptr;
+    if (oriTopkLengthOptional != nullptr) {
+        oriTopkLengthOptionalContiguous = l0op::Contiguous(oriTopkLengthOptional, uniqueExecutor.get());
+        if (oriTopkLengthOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "ori_topk_length contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+    const aclTensor *cmpTopkLengthOptionalContiguous = nullptr;
+    if (cmpTopkLengthOptional != nullptr) {
+        cmpTopkLengthOptionalContiguous = l0op::Contiguous(cmpTopkLengthOptional, uniqueExecutor.get());
+        if (cmpTopkLengthOptionalContiguous == nullptr) {
+            OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "cmp_topk_length contiguous is null");
+            return ACLNN_ERR_INNER_NULLPTR;
+        }
+    }
+
+    auto output = l0op::SparseFlashMlaMetadata(
+        cuSeqlensQOptionalContiguous, cuSeqlensOriKvOptionalContiguous, cuSeqlensCmpKvOptionalContiguous,
+        sequsedQOptionalContiguous, sequsedOriKvOptionalContiguous, sequsedCmpKvOptionalContiguous,
+        cmpResidualKvOptionalContiguous, oriTopkLengthOptionalContiguous, cmpTopkLengthOptionalContiguous, numHeadsQ,
+        numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv, oriTopk, cmpTopk, cmpRatio,
+        oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv,
+        socVersion, aicCoreNum, aivCoreNum, metaData, uniqueExecutor.get());
+    CHECK_RET(output != nullptr, ACLNN_ERR_INNER_NULLPTR);
+
+    *workspaceSize = 0;
+    uniqueExecutor.ReleaseTo(executor);
+    return ACLNN_SUCCESS;
+}
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadata(
+    void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnSparseFlashMlaMetadata);
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/aclnn_sparse_flash_mla_metadata.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/aclnn_sparse_flash_mla_metadata.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef ACLNN_SPARSE_FLASH_MLA_METADATA_H
+#define ACLNN_SPARSE_FLASH_MLA_METADATA_H
+
+#include "aclnn/aclnn_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadataGetWorkspaceSize(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const aclTensor *metaData, uint64_t *workspaceSize,
+    aclOpExecutor **executor);
+
+__attribute__((visibility("default"))) aclnnStatus aclnnSparseFlashMlaMetadata(
+    void *workspace, uint64_t workspaceSize, aclOpExecutor *executor, aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ACLNN_SPARSE_FLASH_MLA_METADATA_H

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/sparse_flash_mla_metadata.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/sparse_flash_mla_metadata.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata.cpp
+ * \brief
+ */
+
+#include "sparse_flash_mla_metadata.h"
+#include "opdev/aicpu/aicpu_task.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_def.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/shape_utils.h"
+
+using namespace op;
+namespace l0op {
+OP_TYPE_REGISTER(SparseFlashMlaMetadata);
+
+const aclTensor *SparseFlashMlaMetadata(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const char *socVersion, int64_t aicCoreNum,
+    int64_t aivCoreNum, const aclTensor *metaData, aclOpExecutor *executor)
+{
+    L0_DFX(SparseFlashMlaMetadata, cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional,
+           sequsedQOptional, sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+           cmpTopkLengthOptional, numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv,
+           oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional,
+           layoutKvOptional, hasOriKv, hasCmpKv, socVersion, aicCoreNum, aivCoreNum, metaData);
+
+    static internal::AicpuTaskSpace space("SparseFlashMlaMetadata");
+
+    auto ret = ADD_TO_LAUNCHER_LIST_AICPU(
+        SparseFlashMlaMetadata,
+        OP_ATTR_NAMES({"num_heads_q", "num_heads_kv", "head_dim", "batch_size", "max_seqlen_q", "max_seqlen_ori_kv",
+                       "max_seqlen_cmp_kv", "ori_topk", "cmp_topk", "cmp_ratio", "ori_mask_mode", "cmp_mask_mode",
+                       "ori_win_left", "ori_win_right", "layout_q", "layout_kv", "has_ori_kv", "has_cmp_kv",
+                       "soc_version", "aic_core_num", "aiv_core_num"}),
+        OP_INPUT(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                 sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                 cmpTopkLengthOptional),
+        OP_OUTPUT(metaData),
+        OP_ATTR(numHeadsQ, numHeadsKv, headDim, batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv, oriTopk, cmpTopk,
+                cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight, layoutQOptional, layoutKvOptional,
+                hasOriKv, hasCmpKv, socVersion, aicCoreNum, aivCoreNum));
+    OP_CHECK(ret == ACL_SUCCESS,
+             OP_LOGE(ACLNN_ERR_INNER_NULLPTR, "SparseFlashMlaMetadata ADD_TO_LAUNCHER_LIST_AICPU failed."),
+             return nullptr);
+    return metaData;
+}
+
+} // namespace l0op

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/sparse_flash_mla_metadata.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/op_api/sparse_flash_mla_metadata.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef L0_SPARSE_FLASH_MLA_METADATA_H
+#define L0_SPARSE_FLASH_MLA_METADATA_H
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const aclTensor* SparseFlashMlaMetadata(
+    const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+    const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional, const aclTensor *sequsedOriKvOptional,
+    const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+    const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ,
+    int64_t numHeadsKv, int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+    int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+    int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+    const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const char *socVersion, int64_t aicCoreNum,
+    int64_t aivCoreNum, const aclTensor *metaData, aclOpExecutor *executor);
+} // namespace l0op
+
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/sparse_flash_mla_metadata_check.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/sparse_flash_mla_metadata_check.h
@@ -1,0 +1,921 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata_check.h
+ * \brief
+ */
+
+#include "log/log.h"
+#include "opdev/format_utils.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/tensor_view_utils.h"
+#include "../../common/op_kernel/sparse_flash_mla_metadata.h"
+#include <cstring>
+#include <string>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+
+static constexpr const char *SMLA_ACLNN_OP_NAME = "aclnnSparseFlashMlaMetadata";
+
+enum class SparseModeSmla : uint8_t {
+    DEFAULT_MASK = 0,
+    ALL_MASK,
+    LEFT_UP_CAUSAL,
+    RIGHT_DOWN_CAUSAL,
+    BAND,
+    SPARSE_BUTT,
+};
+
+inline constexpr int64_t SMLA_CMP_RATIO_LOWER_BOUND = 1;
+inline constexpr int64_t SMLA_CMP_RATIO_UPPER_BOUND = 128;
+inline constexpr int64_t SMLA_NUM_HEADS_Q_LOWER_BOUND = 1;
+inline constexpr int64_t SMLA_NUM_HEADS_Q_UPPER_BOUND = 128;
+
+inline bool IsPowerOfTwoInRangeSmla(int64_t value, int64_t minValue, int64_t maxValue)
+{
+    return value >= minValue && value <= maxValue && ((value & (value - 1)) == 0);
+}
+
+inline bool IsCmpRatioSupportSmla(const char *socVersion, bool hasCmpKv, int64_t cmpTopk, int64_t cmpRatio)
+{
+    if (!hasCmpKv) {
+        return cmpRatio == 1;
+    }
+    if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+        return cmpRatio >= SMLA_CMP_RATIO_LOWER_BOUND && cmpRatio <= SMLA_CMP_RATIO_UPPER_BOUND;
+    }
+    return (cmpTopk > 0) ? (cmpRatio == 4) : (cmpRatio == 128);
+}
+
+inline bool IsTensorExistSmla(const aclTensor *tensor)
+{
+    return (tensor != nullptr) && (tensor->GetViewShape().GetDimNum() > 0) && (tensor->GetViewShape().GetDim(0) > 0);
+}
+
+aclnnStatus CheckReservedOptionalTensorSmla(const aclTensor *tensor, const char *tensorName)
+{
+    if (!IsTensorExistSmla(tensor)) {
+        return ACLNN_SUCCESS;
+    }
+    OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, tensorName,
+                                             std::string(tensorName) + " is reserved and does not support "
+                                                                       "non-empty tensor");
+    return ACLNN_ERR_PARAM_INVALID;
+}
+
+int64_t GetDimNumSmla(const aclTensor *tensor)
+{
+    if (tensor == nullptr) {
+        return -1;
+    }
+    return tensor->GetViewShape().GetDimNum();
+}
+
+aclDataType GetDataTypeSmla(const aclTensor *tensor)
+{
+    aclDataType dataType = aclDataType::ACL_DT_UNDEFINED;
+    if (tensor == nullptr) {
+        return dataType;
+    }
+    aclGetDataType(tensor, &dataType);
+    return dataType;
+}
+
+inline bool IsTensorSourceSmla(const std::string &source) { return source != "batch_size"; }
+
+inline int64_t GetRawShapeSizeSmla(const std::string &source, int64_t batchValue)
+{
+    if (source.find("cu_seqlens") != std::string::npos) {
+        return batchValue + 1;
+    }
+    return batchValue;
+}
+
+inline std::string GetSourceDescSmla(const std::string &source)
+{
+    if (source == "batch_size") {
+        return "batch_size";
+    }
+    if (source.find("cu_seqlens") != std::string::npos) {
+        return "the shape size of " + source + " minus 1";
+    }
+    return "the shape size of " + source;
+}
+
+aclnnStatus CheckSingleParamSmla(int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv, int64_t maxSeqlenCmpKv,
+                                 int64_t numHeadsQ, int64_t numHeadsKv, int64_t headDim, int64_t oriTopk,
+                                 int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode, int64_t cmpMaskMode,
+                                 int64_t oriWinLeft, int64_t oriWinRight, const char *layoutQOptional,
+                                 const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, uint32_t aicCoreNum,
+                                 uint32_t aivCoreNum, const char *socVersion)
+{
+    // batch_size >= 0
+    if (batchSize < 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "batch_size", std::to_string(batchSize),
+                                              "The value of batch_size must be greater than or equal to 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // max_seqlen_q >= 0
+    if (maxSeqlenQ < 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "max_seqlen_q", std::to_string(maxSeqlenQ),
+                                              "The value of max_seqlen_q must be greater than or equal to 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // max_seqlen_ori_kv >= 0
+    if (maxSeqlenOriKv < 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "max_seqlen_ori_kv",
+                                              std::to_string(maxSeqlenOriKv),
+                                              "The value of max_seqlen_ori_kv must be greater than or equal to 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // max_seqlen_cmp_kv >= 0
+    if (maxSeqlenCmpKv < 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "max_seqlen_cmp_kv",
+                                              std::to_string(maxSeqlenCmpKv),
+                                              "The value of max_seqlen_cmp_kv must be greater than or equal to 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // num_heads_q [1, 128]
+    if (numHeadsQ < SMLA_NUM_HEADS_Q_LOWER_BOUND || numHeadsQ > SMLA_NUM_HEADS_Q_UPPER_BOUND) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "num_heads_q", std::to_string(numHeadsQ),
+                                              "The current value is not within the valid range. "
+                                              "The valid range is [" +
+                                                  std::to_string(SMLA_NUM_HEADS_Q_LOWER_BOUND) + ", " +
+                                                  std::to_string(SMLA_NUM_HEADS_Q_UPPER_BOUND) + "]");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // num_heads_kv: 1
+    if (numHeadsKv != 1) {
+        OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "num_heads_kv", std::to_string(numHeadsKv), "1");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (numHeadsQ % numHeadsKv != 0) {
+        OP_LOGE_FOR_INVALID_VALUES_WITH_REASON(SMLA_ACLNN_OP_NAME, "num_heads_q, num_heads_kv",
+                                               std::to_string(numHeadsQ) + ", " + std::to_string(numHeadsKv),
+                                               "The value of num_heads_q must be divisible by "
+                                               "that of num_heads_kv");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    int64_t headRatio = numHeadsQ / numHeadsKv;
+    if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+        if (headRatio < SMLA_NUM_HEADS_Q_LOWER_BOUND || headRatio > SMLA_NUM_HEADS_Q_UPPER_BOUND) {
+            OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "num_heads_q / num_heads_kv",
+                                                  std::to_string(headRatio),
+                                                  "The current value is not within the valid range. "
+                                                  "The valid range is [" +
+                                                      std::to_string(SMLA_NUM_HEADS_Q_LOWER_BOUND) + ", " +
+                                                      std::to_string(SMLA_NUM_HEADS_Q_UPPER_BOUND) + "]");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    } else if (!IsPowerOfTwoInRangeSmla(headRatio, SMLA_NUM_HEADS_Q_LOWER_BOUND, SMLA_NUM_HEADS_Q_UPPER_BOUND)) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "num_heads_q / num_heads_kv",
+                                              std::to_string(headRatio),
+                                              "The current value is not within the valid range. "
+                                              "The valid range is power of two in [" +
+                                                  std::to_string(SMLA_NUM_HEADS_Q_LOWER_BOUND) + ", " +
+                                                  std::to_string(SMLA_NUM_HEADS_Q_UPPER_BOUND) + "]");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // head_dim: 512
+    if (headDim != 512) {
+        OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "head_dim", std::to_string(headDim), "512");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (hasOriKv) {
+        // ori_topk >= 0
+        if (oriTopk < 0) {
+            OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk", std::to_string(oriTopk),
+                                                  "When has_ori_kv is true, the value of ori_topk must be "
+                                                  "greater than or equal to 0");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        if (!(socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) && oriTopk != 0) {
+            OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk", std::to_string(oriTopk),
+                                                  "ori_topk is reserved and "
+                                                  "the value of ori_topk must be 0");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+            // ori_mask_mode: 0, 3, or 4
+            if (oriMaskMode != static_cast<int64_t>(SparseModeSmla::DEFAULT_MASK) &&
+                oriMaskMode != static_cast<int64_t>(SparseModeSmla::RIGHT_DOWN_CAUSAL) &&
+                oriMaskMode != static_cast<int64_t>(SparseModeSmla::BAND)) {
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_mask_mode",
+                                                      std::to_string(oriMaskMode),
+                                                      "When has_ori_kv is true, the value of ori_mask_mode "
+                                                      "must be in [0, 3, 4]");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // A5 treats -1 as unlimited window
+            if (oriWinLeft < -1 || oriWinRight < -1) {
+                OP_LOGE_FOR_INVALID_VALUES_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_win_left, ori_win_right",
+                                                       std::to_string(oriWinLeft) + ", " + std::to_string(oriWinRight),
+                                                       "When has_ori_kv is true, the value of ori_win_left, "
+                                                       "ori_win_right must be greater than or equal to -1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        } else {
+            if (oriMaskMode != static_cast<int64_t>(SparseModeSmla::BAND)) {
+                OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "ori_mask_mode", std::to_string(oriMaskMode),
+                                          "4");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            if (oriWinLeft != 127 || oriWinRight != 0) {
+                OP_LOGE_FOR_INVALID_VALUES_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_win_left, ori_win_right",
+                                                       std::to_string(oriWinLeft) + ", " + std::to_string(oriWinRight),
+                                                       "When has_ori_kv is true, the value of ori_win_left "
+                                                       "must be 127 and the value of ori_win_right must be 0");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    if (hasCmpKv) {
+        // cmp_topk >= 0
+        if (cmpTopk < 0) {
+            OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk", std::to_string(cmpTopk),
+                                                  "When has_cmp_kv is true, the value of cmp_topk must be "
+                                                  "greater than or equal to 0");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        if (!(socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) && cmpTopk != 0 && cmpTopk != 512 &&
+            cmpTopk != 1024) {
+            OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk", std::to_string(cmpTopk),
+                                                  "When has_cmp_kv is true, the value of cmp_topk must be "
+                                                  "in [0, 512, 1024]");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+            // cmp_mask_mode: 0 or 3
+            if (cmpMaskMode != static_cast<int64_t>(SparseModeSmla::DEFAULT_MASK) &&
+                cmpMaskMode != static_cast<int64_t>(SparseModeSmla::RIGHT_DOWN_CAUSAL)) {
+                OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "cmp_mask_mode", std::to_string(cmpMaskMode),
+                                          "0 or 3");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        } else {
+            if (cmpMaskMode != static_cast<int64_t>(SparseModeSmla::RIGHT_DOWN_CAUSAL)) {
+                OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "cmp_mask_mode", std::to_string(cmpMaskMode),
+                                          "3");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        if (!IsCmpRatioSupportSmla(socVersion, hasCmpKv, cmpTopk, cmpRatio)) {
+            if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_ratio", std::to_string(cmpRatio),
+                                                      "When has_cmp_kv is true, the current value is not "
+                                                      "within the valid range. The valid range is [" +
+                                                          std::to_string(SMLA_CMP_RATIO_LOWER_BOUND) + ", " +
+                                                          std::to_string(SMLA_CMP_RATIO_UPPER_BOUND) + "]");
+            } else {
+                int64_t expectedCmpRatio = (cmpTopk > 0) ? 4 : 128;
+                if (cmpTopk > 0) {
+                    OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_ratio",
+                                                          std::to_string(cmpRatio),
+                                                          "When has_cmp_kv is true and cmp_topk is non-zero"
+                                                          "(CSA with cmp_sparse_indices), "
+                                                          "the value of cmp_ratio must be " +
+                                                              std::to_string(expectedCmpRatio));
+                } else {
+                    OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_ratio",
+                                                          std::to_string(cmpRatio),
+                                                          "When has_cmp_kv is true and cmp_topk is 0"
+                                                          "(HCA without cmp_sparse_indices), "
+                                                          "the value of cmp_ratio must be " +
+                                                              std::to_string(expectedCmpRatio));
+                }
+            }
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    } else if (!(socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) &&
+               !IsCmpRatioSupportSmla(socVersion, hasCmpKv, cmpTopk, cmpRatio)) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_ratio", std::to_string(cmpRatio),
+                                              "When has_cmp_kv is false, the value of cmp_ratio must be 1");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (layoutQOptional == nullptr) {
+        OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "layout_q", "layout_q cannot be empty");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (layoutKvOptional == nullptr) {
+        OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "layout_kv", "layout_kv cannot be empty");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // layout_q: BSND or TND
+    if (strcmp(layoutQOptional, "TND") != 0 && strcmp(layoutQOptional, "BSND") != 0) {
+        OP_LOGE_FOR_INVALID_VALUE(SMLA_ACLNN_OP_NAME, "layout_q", layoutQOptional, "TND or BSND");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // layout_kv: BSND, TND, or PA_BBND
+    if (strcmp(layoutKvOptional, "BSND") != 0 && strcmp(layoutKvOptional, "TND") != 0 &&
+        strcmp(layoutKvOptional, "PA_BBND") != 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "layout_kv", layoutKvOptional,
+                                              "The value of layout_kv must be in [TND, BSND, PA_BBND]");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (strcmp(layoutKvOptional, "PA_BBND") != 0 && strcmp(layoutQOptional, layoutKvOptional) != 0) {
+        OP_LOGE_FOR_INVALID_VALUES_WITH_REASON(
+            SMLA_ACLNN_OP_NAME, "layout_q, layout_kv",
+            std::string(layoutQOptional) + ", " + std::string(layoutKvOptional),
+            "When layout_kv is not PA_BBND, the values of layout_q, layout_kv must be the same");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // 核数校验
+    if (aicCoreNum == 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "aic_core_num", std::to_string(aicCoreNum),
+                                              "The value of aic_core_num must be greater than 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (aicCoreNum > optiling::AIC_CORE_MAX_NUM) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "aic_core_num", std::to_string(aicCoreNum),
+                                              "The current value is not within the valid range. "
+                                              "The valid range is [1, " +
+                                                  std::to_string(optiling::AIC_CORE_MAX_NUM) + "]");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (aivCoreNum == 0) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "aiv_core_num", std::to_string(aivCoreNum),
+                                              "The value of aiv_core_num must be greater than 0");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    if (aivCoreNum > optiling::AIV_CORE_MAX_NUM) {
+        OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(SMLA_ACLNN_OP_NAME, "aiv_core_num", std::to_string(aivCoreNum),
+                                              "The current value is not within the valid range. "
+                                              "The valid range is [1, " +
+                                                  std::to_string(optiling::AIV_CORE_MAX_NUM) + "]");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    // 校验切g模板核数
+    if (numHeadsQ == 128) {
+        if (aicCoreNum == 1 || aivCoreNum == 1) {
+            OP_LOGE_FOR_INVALID_VALUES_WITH_REASON(
+                SMLA_ACLNN_OP_NAME, "num_heads_q and aic_core_num and aiv_core_num",
+                std::to_string(numHeadsQ) + " and " + std::to_string(aicCoreNum) + " and " + std::to_string(aivCoreNum),
+                "When num_heads_q is 128, the value of aic_core_num, "
+                "aiv_core_num cannot be 1");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus CheckExistenceSmla(const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+                               const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedOriKvOptional,
+                               const aclTensor *sequsedCmpKvOptional, const aclTensor *cmpResidualKvOptional,
+                               const aclTensor *oriTopkLengthOptional, const aclTensor *cmpTopkLengthOptional,
+                               int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio, int64_t oriMaskMode,
+                               int64_t cmpMaskMode, bool hasOriKv, bool hasCmpKv, const char *layoutQOptional,
+                               const char *layoutKvOptional, const char *socVersion, const aclTensor *metadata)
+{
+    // cu_seqlens_q 存在性校验
+    if (strcmp(layoutQOptional, "TND") == 0) {
+        if (!IsTensorExistSmla(cuSeqlensQOptional)) {
+            OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_q",
+                                                     "When layout_q is TND, cu_seqlens_q cannot be empty");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    if (hasOriKv) {
+        // cu_seqlens_ori_kv 存在性校验
+        if (strcmp(layoutKvOptional, "TND") == 0) {
+            if (!IsTensorExistSmla(cuSeqlensOriKvOptional)) {
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_ori_kv",
+                                                         "When has_ori_kv is true and layout_kv is TND, "
+                                                         "cu_seqlens_ori_kv cannot be empty");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // seqused_ori_kv 存在性校验
+        if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+            if ((oriMaskMode != 0 || oriTopk == 0) && strcmp(layoutKvOptional, "PA_BBND") == 0) {
+                if (!IsTensorExistSmla(sequsedOriKvOptional)) {
+                    OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_ori_kv",
+                                                             "When has_ori_kv is true, ori_mask_mode != 0 or "
+                                                             "ori_topk == 0, and layout_kv is PA_BBND, "
+                                                             "seqused_ori_kv cannot be empty");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+        } else {
+            if (strcmp(layoutKvOptional, "PA_BBND") == 0) {
+                if (!IsTensorExistSmla(sequsedOriKvOptional)) {
+                    OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_ori_kv",
+                                                             "When has_ori_kv is true and layout_kv is PA_BBND, "
+                                                             "seqused_ori_kv cannot be empty");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+        }
+        // ori_topk_length 存在性校验
+        if (oriTopk != 0 && oriMaskMode == static_cast<int64_t>(SparseModeSmla::DEFAULT_MASK)) {
+            if (!IsTensorExistSmla(oriTopkLengthOptional)) {
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk_length",
+                                                         "When has_ori_kv is true, ori_topk is not 0 and "
+                                                         "ori_mask_mode is 0, ori_topk_length cannot be empty");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    if (hasCmpKv) {
+        // cu_seqlens_cmp_kv 存在性校验
+        if (strcmp(layoutKvOptional, "TND") == 0) {
+            if (!IsTensorExistSmla(cuSeqlensCmpKvOptional)) {
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_cmp_kv",
+                                                         "When has_cmp_kv is true and layout_kv is TND, "
+                                                         "cu_seqlens_cmp_kv cannot be empty");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // seqused_cmp_kv 存在性校验
+        if (socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) {
+            if ((cmpMaskMode != 0 || cmpTopk == 0) && strcmp(layoutKvOptional, "PA_BBND") == 0) {
+                if (!IsTensorExistSmla(sequsedCmpKvOptional)) {
+                    OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_cmp_kv",
+                                                             "When has_cmp_kv is true, cmp_mask_mode != 0 or "
+                                                             "cmp_topk == 0, and layout_kv is PA_BBND, "
+                                                             "seqused_cmp_kv cannot be empty");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+        } else {
+            if (strcmp(layoutKvOptional, "PA_BBND") == 0) {
+                if (!IsTensorExistSmla(sequsedCmpKvOptional)) {
+                    OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_cmp_kv",
+                                                             "When has_cmp_kv is true and layout_kv is PA_BBND, "
+                                                             "seqused_cmp_kv cannot be empty");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+        }
+        // cmp_residual_kv 存在性校验
+        if (cmpRatio != 1 && cmpMaskMode == static_cast<int64_t>(SparseModeSmla::RIGHT_DOWN_CAUSAL)) {
+            if (!IsTensorExistSmla(cmpResidualKvOptional)) {
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_residual_kv",
+                                                         "When has_cmp_kv is true, cmp_ratio is not 1 and "
+                                                         "cmp_mask_mode is 3, cmp_residual_kv cannot be empty");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // cmp_topk_length 存在性校验
+        if (cmpTopk != 0 && cmpMaskMode == static_cast<int64_t>(SparseModeSmla::DEFAULT_MASK)) {
+            if (!IsTensorExistSmla(cmpTopkLengthOptional)) {
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk_length",
+                                                         "When has_cmp_kv is true, cmp_topk is not 0 and "
+                                                         "cmp_mask_mode is 0, cmp_topk_length cannot be empty");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    // metadata 存在性校验
+    if (!IsTensorExistSmla(metadata)) {
+        OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(SMLA_ACLNN_OP_NAME, "metadata", "metadata cannot be empty");
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+    return ACLNN_SUCCESS;
+}
+
+int64_t GetQueryBatchSizeSmla(const aclTensor *sequsedQOptional, const aclTensor *cuSeqlensQOptional,
+                              const char *layoutQOptional, int64_t batchSize, std::string *source)
+{
+    if (IsTensorExistSmla(sequsedQOptional)) {
+        *source = "seqused_q";
+        return sequsedQOptional->GetViewShape().GetDim(0);
+    }
+    if (strcmp(layoutQOptional, "TND") == 0) {
+        if (IsTensorExistSmla(cuSeqlensQOptional)) {
+            *source = "cu_seqlens_q";
+            return cuSeqlensQOptional->GetViewShape().GetDim(0) - 1;
+        }
+    }
+    *source = "batch_size";
+    return batchSize;
+}
+
+int64_t GetOriKvBatchSizeSmla(const aclTensor *sequsedOriKvOptional, const aclTensor *cuSeqlensOriKvOptional,
+                              const char *layoutKvOptional, int64_t batchSize, std::string *source)
+{
+    if (IsTensorExistSmla(sequsedOriKvOptional)) {
+        *source = "seqused_ori_kv";
+        return sequsedOriKvOptional->GetViewShape().GetDim(0);
+    }
+    if (strcmp(layoutKvOptional, "TND") == 0) {
+        if (IsTensorExistSmla(cuSeqlensOriKvOptional)) {
+            *source = "cu_seqlens_ori_kv";
+            return cuSeqlensOriKvOptional->GetViewShape().GetDim(0) - 1;
+        }
+    }
+    *source = "batch_size";
+    return batchSize;
+}
+
+int64_t GetCmpKvBatchSizeSmla(const aclTensor *sequsedCmpKvOptional, const aclTensor *cuSeqlensCmpKvOptional,
+                              const char *layoutKvOptional, int64_t batchSize, std::string *source)
+{
+    if (IsTensorExistSmla(sequsedCmpKvOptional)) {
+        *source = "seqused_cmp_kv";
+        return sequsedCmpKvOptional->GetViewShape().GetDim(0);
+    }
+    if (strcmp(layoutKvOptional, "TND") == 0) {
+        if (IsTensorExistSmla(cuSeqlensCmpKvOptional)) {
+            *source = "cu_seqlens_cmp_kv";
+            return cuSeqlensCmpKvOptional->GetViewShape().GetDim(0) - 1;
+        }
+    }
+    *source = "batch_size";
+    return batchSize;
+}
+
+aclnnStatus CheckConsistencySmla(const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+                                 const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional,
+                                 const aclTensor *sequsedOriKvOptional, const aclTensor *sequsedCmpKvOptional,
+                                 const aclTensor *cmpResidualKvOptional, const aclTensor *oriTopkLengthOptional,
+                                 const aclTensor *cmpTopkLengthOptional, int64_t batchSize, const char *layoutQOptional,
+                                 const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv, const char *socVersion,
+                                 const aclTensor *metadata)
+{
+    aclDataType dataType = aclDataType::ACL_DT_UNDEFINED;
+    int64_t dimNum = -1;
+    if (!(socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr)) {
+        if (CheckReservedOptionalTensorSmla(oriTopkLengthOptional, "ori_topk_length") != ACLNN_SUCCESS ||
+            CheckReservedOptionalTensorSmla(cmpTopkLengthOptional, "cmp_topk_length") != ACLNN_SUCCESS) {
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    // 校验 cu_seqlens_q
+    if (IsTensorExistSmla(cuSeqlensQOptional)) {
+        // 校验 cu_seqlens_q 维度
+        dimNum = GetDimNumSmla(cuSeqlensQOptional);
+        if (dimNum != 1) {
+            OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "cu_seqlens_q", std::to_string(dimNum), "1");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验 cu_seqlens_q 数据类型
+        dataType = GetDataTypeSmla(cuSeqlensQOptional);
+        if (dataType != aclDataType::ACL_INT32) {
+            OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_q", ToString(dataType).GetString(),
+                                                  "The dtype of cu_seqlens_q must be int32");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    // 校验 seqused_q
+    if (IsTensorExistSmla(sequsedQOptional)) {
+        // 校验 seqused_q 维度
+        dimNum = GetDimNumSmla(sequsedQOptional);
+        if (dimNum != 1) {
+            OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "seqused_q", std::to_string(dimNum), "1");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验 seqused_q 数据类型
+        dataType = GetDataTypeSmla(sequsedQOptional);
+        if (dataType != aclDataType::ACL_INT32) {
+            OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_q", ToString(dataType).GetString(),
+                                                  "The dtype of seqused_q must be int32");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    // ori_kv部分
+    if (hasOriKv) {
+        // 校验 cu_seqlens_ori_kv
+        if (IsTensorExistSmla(cuSeqlensOriKvOptional)) {
+            // 校验 cu_seqlens_ori_kv 维度
+            dimNum = GetDimNumSmla(cuSeqlensOriKvOptional);
+            if (dimNum != 1) {
+                OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "cu_seqlens_ori_kv", std::to_string(dimNum),
+                                             "1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // 校验 cu_seqlens_ori_kv 数据类型
+            dataType = GetDataTypeSmla(cuSeqlensOriKvOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_ori_kv",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of cu_seqlens_ori_kv must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 seqused_ori_kv
+        if (IsTensorExistSmla(sequsedOriKvOptional)) {
+            // 校验 seqused_ori_kv 维度
+            dimNum = GetDimNumSmla(sequsedOriKvOptional);
+            if (dimNum != 1) {
+                OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "seqused_ori_kv", std::to_string(dimNum), "1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // 校验 seqused_ori_kv 数据类型
+            dataType = GetDataTypeSmla(sequsedOriKvOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_ori_kv",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of seqused_ori_kv must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 ori_topk_length
+        if ((socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) &&
+            IsTensorExistSmla(oriTopkLengthOptional)) {
+            // 校验 ori_topk_length 维度
+            dimNum = GetDimNumSmla(oriTopkLengthOptional);
+            if (strcmp(layoutQOptional, "TND") == 0) {
+                if (dimNum != 2) {
+                    OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk_length",
+                                                             std::to_string(dimNum),
+                                                             "The shape dim of ori_topk_length must be 2 "
+                                                             "when layout_q is TND");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            } else if (strcmp(layoutQOptional, "BSND") == 0) {
+                if (dimNum != 3) {
+                    OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk_length",
+                                                             std::to_string(dimNum),
+                                                             "The shape dim of ori_topk_length must be 3 "
+                                                             "when layout_q is BSND");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+            // 校验 ori_topk_length 数据类型
+            dataType = GetDataTypeSmla(oriTopkLengthOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "ori_topk_length",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of ori_topk_length must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    // cmp_kv部分
+    if (hasCmpKv) {
+        // 校验 cu_seqlens_cmp_kv
+        if (IsTensorExistSmla(cuSeqlensCmpKvOptional)) {
+            // 校验 cu_seqlens_cmp_kv 维度
+            dimNum = GetDimNumSmla(cuSeqlensCmpKvOptional);
+            if (dimNum != 1) {
+                OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "cu_seqlens_cmp_kv", std::to_string(dimNum),
+                                             "1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // 校验 cu_seqlens_cmp_kv 数据类型
+            dataType = GetDataTypeSmla(cuSeqlensCmpKvOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_cmp_kv",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of cu_seqlens_cmp_kv must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 seqused_cmp_kv
+        if (IsTensorExistSmla(sequsedCmpKvOptional)) {
+            // 校验 seqused_cmp_kv 维度
+            dimNum = GetDimNumSmla(sequsedCmpKvOptional);
+            if (dimNum != 1) {
+                OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "seqused_cmp_kv", std::to_string(dimNum), "1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // 校验 seqused_cmp_kv 数据类型
+            dataType = GetDataTypeSmla(sequsedCmpKvOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "seqused_cmp_kv",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of seqused_cmp_kv must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 cmp_residual_kv
+        if (IsTensorExistSmla(cmpResidualKvOptional)) {
+            // 校验 cmp_residual_kv 维度
+            dimNum = GetDimNumSmla(cmpResidualKvOptional);
+            if (dimNum != 1) {
+                OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "cmp_residual_kv", std::to_string(dimNum),
+                                             "1");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+            // 校验 cmp_residual_kv 数据类型
+            dataType = GetDataTypeSmla(cmpResidualKvOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_residual_kv",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of cmp_residual_kv must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 cmp_topk_length
+        if ((socVersion != nullptr && strstr(socVersion, "Ascend950") != nullptr) &&
+            IsTensorExistSmla(cmpTopkLengthOptional)) {
+            // 校验 cmp_topk_length 维度
+            dimNum = GetDimNumSmla(cmpTopkLengthOptional);
+            if (strcmp(layoutQOptional, "TND") == 0) {
+                if (dimNum != 2) {
+                    OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk_length",
+                                                             std::to_string(dimNum),
+                                                             "The shape dim of cmp_topk_length must be 2 "
+                                                             "when layout_q is TND");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            } else if (strcmp(layoutQOptional, "BSND") == 0) {
+                if (dimNum != 3) {
+                    OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk_length",
+                                                             std::to_string(dimNum),
+                                                             "The shape dim of cmp_topk_length must be 3 "
+                                                             "when layout_q is BSND");
+                    return ACLNN_ERR_PARAM_INVALID;
+                }
+            }
+            // 校验 cmp_topk_length 数据类型
+            dataType = GetDataTypeSmla(cmpTopkLengthOptional);
+            if (dataType != aclDataType::ACL_INT32) {
+                OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "cmp_topk_length",
+                                                      ToString(dataType).GetString(),
+                                                      "The dtype of cmp_topk_length must be int32");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    // 校验 metadata
+    if (IsTensorExistSmla(metadata)) {
+        // 校验 metadata 维度
+        dimNum = GetDimNumSmla(metadata);
+        if (dimNum != 1) {
+            OP_LOGE_FOR_INVALID_SHAPEDIM(SMLA_ACLNN_OP_NAME, "metadata", std::to_string(dimNum), "1");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验 metadata 元素数
+        if (metadata->GetViewShape().GetDim(0) != optiling::SMLA_METADATA_TOTAL_SIZE) {
+            OP_LOGE_FOR_INVALID_SHAPESIZE(SMLA_ACLNN_OP_NAME, "metadata",
+                                          std::to_string(metadata->GetViewShape().GetDim(0)),
+                                          std::to_string(optiling::SMLA_METADATA_TOTAL_SIZE));
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验 metadata 数据类型
+        dataType = GetDataTypeSmla(metadata);
+        if (dataType != aclDataType::ACL_INT32) {
+            OP_LOGE_FOR_INVALID_DTYPE_WITH_REASON(SMLA_ACLNN_OP_NAME, "metadata", ToString(dataType).GetString(),
+                                                  "The dtype of metadata must be int32");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    // 校验 q/kv 维度一致性
+    std::string querySource;
+    int64_t queryBatchSize =
+        GetQueryBatchSizeSmla(sequsedQOptional, cuSeqlensQOptional, layoutQOptional, batchSize, &querySource);
+    // 校验TND场景q维度一致性
+    if (strcmp(layoutQOptional, "TND") == 0 && IsTensorExistSmla(sequsedQOptional)) {
+        int64_t cuSeqlensQBatchSize = cuSeqlensQOptional->GetViewShape().GetDim(0) - 1;
+        if (cuSeqlensQBatchSize != queryBatchSize) {
+            OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(SMLA_ACLNN_OP_NAME, "cu_seqlens_q and seqused_q",
+                                                       std::to_string(cuSeqlensQOptional->GetViewShape().GetDim(0)) +
+                                                           " and " +
+                                                           std::to_string(sequsedQOptional->GetViewShape().GetDim(0)),
+                                                       "When layout_q is TND and seqused_q is passed, "
+                                                       "the shape size of cu_seqlens_q minus 1 must be equal to "
+                                                       "the shape size of seqused_q");
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+    }
+    if (hasOriKv) {
+        std::string oriKvSource;
+        int64_t oriKvBatchSize = GetOriKvBatchSizeSmla(sequsedOriKvOptional, cuSeqlensOriKvOptional, layoutKvOptional,
+                                                       batchSize, &oriKvSource);
+        // 校验q与ori_kv维度一致性
+        if (queryBatchSize != oriKvBatchSize) {
+            if (IsTensorSourceSmla(querySource) && IsTensorSourceSmla(oriKvSource)) {
+                OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, querySource + " and " + oriKvSource,
+                    std::to_string(GetRawShapeSizeSmla(querySource, queryBatchSize)) + " and " +
+                        std::to_string(GetRawShapeSizeSmla(oriKvSource, oriKvBatchSize)),
+                    "When has_ori_kv is true, " + GetSourceDescSmla(querySource) + " must be equal to " +
+                        GetSourceDescSmla(oriKvSource));
+            } else if (IsTensorSourceSmla(querySource)) {
+                OP_LOGE_FOR_INVALID_SHAPESIZE_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, querySource,
+                    std::to_string(GetRawShapeSizeSmla(querySource, queryBatchSize)),
+                    "When has_ori_kv is true, " + GetSourceDescSmla(querySource) + " must be equal to batch_size");
+            } else {
+                OP_LOGE_FOR_INVALID_SHAPESIZE_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, oriKvSource,
+                    std::to_string(GetRawShapeSizeSmla(oriKvSource, oriKvBatchSize)),
+                    "When has_ori_kv is true, " + GetSourceDescSmla(oriKvSource) + " must be equal to batch_size");
+            }
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验TND场景ori_kv维度一致性
+        if (strcmp(layoutKvOptional, "TND") == 0 && IsTensorExistSmla(sequsedOriKvOptional)) {
+            int64_t cuSeqlensOriKvBatchSize = cuSeqlensOriKvOptional->GetViewShape().GetDim(0) - 1;
+            if (cuSeqlensOriKvBatchSize != oriKvBatchSize) {
+                OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, "cu_seqlens_ori_kv and seqused_ori_kv",
+                    std::to_string(cuSeqlensOriKvOptional->GetViewShape().GetDim(0)) + " and " +
+                        std::to_string(sequsedOriKvOptional->GetViewShape().GetDim(0)),
+                    "When layout_kv is TND and seqused_ori_kv is passed, "
+                    "the shape size of cu_seqlens_ori_kv minus 1 must be "
+                    "equal to the shape size of seqused_ori_kv");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    if (hasCmpKv) {
+        std::string cmpKvSource;
+        int64_t cmpKvBatchSize = GetCmpKvBatchSizeSmla(sequsedCmpKvOptional, cuSeqlensCmpKvOptional, layoutKvOptional,
+                                                       batchSize, &cmpKvSource);
+        // 校验q与cmp_kv维度一致性
+        if (queryBatchSize != cmpKvBatchSize) {
+            if (IsTensorSourceSmla(querySource) && IsTensorSourceSmla(cmpKvSource)) {
+                OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, querySource + " and " + cmpKvSource,
+                    std::to_string(GetRawShapeSizeSmla(querySource, queryBatchSize)) + " and " +
+                        std::to_string(GetRawShapeSizeSmla(cmpKvSource, cmpKvBatchSize)),
+                    "When has_cmp_kv is true, " + GetSourceDescSmla(querySource) + " must be equal to " +
+                        GetSourceDescSmla(cmpKvSource));
+            } else if (IsTensorSourceSmla(querySource)) {
+                OP_LOGE_FOR_INVALID_SHAPESIZE_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, querySource,
+                    std::to_string(GetRawShapeSizeSmla(querySource, queryBatchSize)),
+                    "When has_cmp_kv is true, " + GetSourceDescSmla(querySource) + " must be equal to batch_size");
+            } else {
+                OP_LOGE_FOR_INVALID_SHAPESIZE_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, cmpKvSource,
+                    std::to_string(GetRawShapeSizeSmla(cmpKvSource, cmpKvBatchSize)),
+                    "When has_cmp_kv is true, " + GetSourceDescSmla(cmpKvSource) + " must be equal to batch_size");
+            }
+            return ACLNN_ERR_PARAM_INVALID;
+        }
+        // 校验TND场景cmp_kv维度一致性
+        if (strcmp(layoutKvOptional, "TND") == 0 && IsTensorExistSmla(sequsedCmpKvOptional)) {
+            int64_t cuSeqlensCmpKvBatchSize = cuSeqlensCmpKvOptional->GetViewShape().GetDim(0) - 1;
+            if (cuSeqlensCmpKvBatchSize != cmpKvBatchSize) {
+                OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(
+                    SMLA_ACLNN_OP_NAME, "cu_seqlens_cmp_kv and seqused_cmp_kv",
+                    std::to_string(cuSeqlensCmpKvOptional->GetViewShape().GetDim(0)) + " and " +
+                        std::to_string(sequsedCmpKvOptional->GetViewShape().GetDim(0)),
+                    "When layout_kv is TND and seqused_cmp_kv is passed, "
+                    "the shape size of cu_seqlens_cmp_kv minus 1 must be "
+                    "equal to the shape size of seqused_cmp_kv");
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+        // 校验 cmp_residual_kv 元素数
+        if (IsTensorExistSmla(cmpResidualKvOptional)) {
+            if (cmpResidualKvOptional->GetViewShape().GetDim(0) != queryBatchSize) {
+                if (IsTensorSourceSmla(querySource)) {
+                    OP_LOGE_FOR_INVALID_SHAPESIZES_WITH_REASON(
+                        SMLA_ACLNN_OP_NAME, "cmp_residual_kv and " + querySource,
+                        std::to_string(cmpResidualKvOptional->GetViewShape().GetDim(0)) + " and " +
+                            std::to_string(GetRawShapeSizeSmla(querySource, queryBatchSize)),
+                        "The shape size of cmp_residual_kv must be equal to " + GetSourceDescSmla(querySource));
+                } else {
+                    OP_LOGE_FOR_INVALID_SHAPESIZE_WITH_REASON(
+                        SMLA_ACLNN_OP_NAME, "cmp_residual_kv",
+                        std::to_string(cmpResidualKvOptional->GetViewShape().GetDim(0)),
+                        "The shape size of cmp_residual_kv must be equal "
+                        "to batch_size");
+                }
+                return ACLNN_ERR_PARAM_INVALID;
+            }
+        }
+    }
+    return ACLNN_SUCCESS;
+}
+
+static aclnnStatus ParamsCheck(const aclTensor *cuSeqlensQOptional, const aclTensor *cuSeqlensOriKvOptional,
+                               const aclTensor *cuSeqlensCmpKvOptional, const aclTensor *sequsedQOptional,
+                               const aclTensor *sequsedOriKvOptional, const aclTensor *sequsedCmpKvOptional,
+                               const aclTensor *cmpResidualKvOptional, const aclTensor *oriTopkLengthOptional,
+                               const aclTensor *cmpTopkLengthOptional, int64_t numHeadsQ, int64_t numHeadsKv,
+                               int64_t headDim, int64_t batchSize, int64_t maxSeqlenQ, int64_t maxSeqlenOriKv,
+                               int64_t maxSeqlenCmpKv, int64_t oriTopk, int64_t cmpTopk, int64_t cmpRatio,
+                               int64_t oriMaskMode, int64_t cmpMaskMode, int64_t oriWinLeft, int64_t oriWinRight,
+                               const char *layoutQOptional, const char *layoutKvOptional, bool hasOriKv, bool hasCmpKv,
+                               uint32_t aicCoreNum, uint32_t aivCoreNum, const char *socVersion,
+                               const aclTensor *metaData)
+{
+    if (CheckSingleParamSmla(batchSize, maxSeqlenQ, maxSeqlenOriKv, maxSeqlenCmpKv, numHeadsQ, numHeadsKv, headDim,
+                             oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, oriWinLeft, oriWinRight,
+                             layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv, aicCoreNum, aivCoreNum,
+                             socVersion) == ACLNN_SUCCESS &&
+        CheckExistenceSmla(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedOriKvOptional,
+                           sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional, cmpTopkLengthOptional,
+                           oriTopk, cmpTopk, cmpRatio, oriMaskMode, cmpMaskMode, hasOriKv, hasCmpKv, layoutQOptional,
+                           layoutKvOptional, socVersion, metaData) == ACLNN_SUCCESS &&
+        CheckConsistencySmla(cuSeqlensQOptional, cuSeqlensOriKvOptional, cuSeqlensCmpKvOptional, sequsedQOptional,
+                             sequsedOriKvOptional, sequsedCmpKvOptional, cmpResidualKvOptional, oriTopkLengthOptional,
+                             cmpTopkLengthOptional, batchSize, layoutQOptional, layoutKvOptional, hasOriKv, hasCmpKv,
+                             socVersion, metaData) == ACLNN_SUCCESS) {
+        return ACLNN_SUCCESS;
+    } else {
+        return ACLNN_ERR_PARAM_INVALID;
+    }
+}
+} // namespace
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_host/sparse_flash_mla_metadata_infershape.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_host/sparse_flash_mla_metadata_infershape.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata_infershape.cpp
+ * \brief
+ */
+#include "register/op_impl_registry.h"
+#include "../../common/op_kernel/sparse_flash_mla_metadata.h"
+
+using namespace ge;
+
+namespace ops {
+static ge::graphStatus InferShapeSparseFlashMlaMetadata(gert::InferShapeContext *context)
+{
+    gert::Shape *oShape = context->GetOutputShape(0);
+    // output shape (SMLA_METADATA_SIZE, )
+    oShape->SetDimNum(1);
+    oShape->SetDim(0, optiling::SMLA_METADATA_TOTAL_SIZE);
+    return GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDtypeSparseFlashMlaMetadata(gert::InferDataTypeContext *context)
+{
+    context->SetOutputDataType(0, DT_INT32);
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(SparseFlashMlaMetadata)
+    .InferShape(InferShapeSparseFlashMlaMetadata)
+    .InferDataType(InferDtypeSparseFlashMlaMetadata);
+} // namespace ops

--- a/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/CMakeLists.txt
+++ b/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/CMakeLists.txt
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# ---------------------------------------------------------------------------------------------------------
+
+if (BUILD_WITH_INSTALLED_DEPENDENCY_CANN_PKG)
+  if (NOT (UT_TEST_ALL OR OP_KERNEL_AICPU_UT))
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+    set(CMAKE_CXX_COMPILER ${ASCEND_DIR}/toolkit/toolchain/hcc/bin/aarch64-target-linux-gnu-g++)
+  endif()
+
+  file(GLOB_RECURSE JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/*.json)
+  file(GLOB AICPU_SRC ${CMAKE_CURRENT_SOURCE_DIR}/*_aicpu*.cpp)
+  message(STATUS "[sparse_flash_mla_metadata] Found aicpu sources: ${AICPU_SRC}, ascend dir: ${ASCEND_DIR}, ophost name: ${OPHOST_NAME}")
+
+  add_aicpu_cust_kernel_modules(sparse_flash_mla_metadata ${AICPU_SRC} ${JSON_FILE})
+endif()
+
+if(UT_TEST_ALL OR OP_KERNEL_AICPU_UT)
+    AddAicpuOpTestCase(sparse_flash_mla_metadata)
+endif()

--- a/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.cpp
+++ b/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.cpp
@@ -1,0 +1,1423 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata_aicpu.cpp
+ * \brief
+ */
+
+#include "log.h"
+#include "status.h"
+#include <cstdio>
+#include <cmath>
+#include "sparse_flash_mla_metadata_aicpu.h"
+
+using namespace optiling;
+
+namespace aicpu {
+uint32_t SparseFlashMlaMetadataCpuKernel::Compute(CpuKernelContext &ctx)
+{
+    bool success = Prepare(ctx);
+    if (!success) {
+        return KERNEL_STATUS_PARAM_INVALID;
+    }
+    SplitResult splitRes{aicCoreNum_, aivCoreNum_};
+    success = BalanceSchedule(splitRes) && GenMetadata(splitRes);
+    return success ? KERNEL_STATUS_OK : KERNEL_STATUS_PARAM_INVALID;
+}
+
+bool SparseFlashMlaMetadataCpuKernel::Prepare(CpuKernelContext &ctx)
+{
+    // input
+    cuSeqlensQ_ = ctx.Input(static_cast<uint32_t>(ParamId::cuSeqlensQ));
+    cuSeqlensOriKv_ = ctx.Input(static_cast<uint32_t>(ParamId::cuSeqlensOriKv));
+    cuSeqlensCmpKv_ = ctx.Input(static_cast<uint32_t>(ParamId::cuSeqlensCmpKv));
+    sequsedQ_ = ctx.Input(static_cast<uint32_t>(ParamId::sequsedQ));
+    sequsedOriKv_ = ctx.Input(static_cast<uint32_t>(ParamId::sequsedOriKv));
+    sequsedCmpKv_ = ctx.Input(static_cast<uint32_t>(ParamId::sequsedCmpKv));
+    cmpResidualKv_ = ctx.Input(static_cast<uint32_t>(ParamId::cmpResidualKv));
+    oriTopkLength_ = ctx.Input(static_cast<uint32_t>(ParamId::oriTopkLength));
+    cmpTopkLength_ = ctx.Input(static_cast<uint32_t>(ParamId::cmpTopkLength));
+    // output
+    metadata_ = ctx.Output(static_cast<uint32_t>(ParamId::metaData));
+
+    bool requiredAttrs = GetAttrValue(ctx, "num_heads_q", numHeadsQ_) &&
+                         GetAttrValue(ctx, "num_heads_kv", numHeadsKv_) && GetAttrValue(ctx, "head_dim", headDim_);
+    if (!requiredAttrs) {
+        return false;
+    }
+
+    // attributes optional
+    GetAttrValueOpt(ctx, "soc_version", socVersion_);
+    GetAttrValueOpt(ctx, "aic_core_num", aicCoreNum_);
+    GetAttrValueOpt(ctx, "aiv_core_num", aivCoreNum_);
+    GetAttrValueOpt(ctx, "batch_size", batchSize_);
+    GetAttrValueOpt(ctx, "max_seqlen_q", maxSeqlenQ_);
+    GetAttrValueOpt(ctx, "max_seqlen_ori_kv", maxSeqlenOriKv_);
+    GetAttrValueOpt(ctx, "max_seqlen_cmp_kv", maxSeqlenCmpKv_);
+    GetAttrValueOpt(ctx, "ori_topk", oriTopK_);
+    GetAttrValueOpt(ctx, "cmp_topk", cmpTopK_);
+    GetAttrValueOpt(ctx, "cmp_ratio", cmpRatio_);
+    GetAttrValueOpt(ctx, "ori_mask_mode", oriMaskMode_);
+    GetAttrValueOpt(ctx, "cmp_mask_mode", cmpMaskMode_);
+    GetAttrValueOpt(ctx, "ori_win_left", oriWinLeft_);
+    GetAttrValueOpt(ctx, "ori_win_right", oriWinRight_);
+    GetAttrValueOpt(ctx, "layout_q", layoutQ_);
+    GetAttrValueOpt(ctx, "layout_kv", layoutKv_);
+    GetAttrValueOpt(ctx, "has_ori_kv", hasOriKv_);
+    GetAttrValueOpt(ctx, "has_cmp_kv", hasCmpKv_);
+
+    return (ParamsCheck() && ParamsInit());
+}
+
+bool SparseFlashMlaMetadataCpuKernel::ParamsCheck()
+{
+    // 校验输出 metadata 是否为空
+    if (metadata_ == nullptr) {
+        KERNEL_LOG_ERROR("Output metadata is nullptr");
+        return false;
+    } else if (metadata_->GetData() == nullptr) {
+        KERNEL_LOG_ERROR("Output metadata data is nullptr");
+        return false;
+    }
+    int32_t batchSize = GetQueryBatchSize();
+    // 校验 cu_seqlens_q 元素
+    if (layoutQ_ == "TND") {
+        if (cuSeqlensQ_ != nullptr && cuSeqlensQ_->GetData() != nullptr) {
+            const int32_t *cuSeqlensQPtr = static_cast<const int32_t *>(cuSeqlensQ_->GetData());
+            for (int i = 0; i < batchSize + 1; i++) {
+                // 校验 cu_seqlens_q 元素非负
+                if (cuSeqlensQPtr[i] < 0) {
+                    KERNEL_LOG_ERROR("The elements in cu_seqlens_q should be >= 0, but got cu_seqlens_q[%d] = %d", i,
+                                     cuSeqlensQPtr[i]);
+                    return false;
+                }
+                // 校验 cu_seqlens_q 元素递增
+                if (i > 0 && cuSeqlensQPtr[i - 1] > cuSeqlensQPtr[i]) {
+                    KERNEL_LOG_ERROR("The elements in cu_seqlens_q must be in ascending order, "
+                                     "but got cu_seqlens_q[%d] = %d, cu_seqlens_q[%d] = %d",
+                                     i - 1, cuSeqlensQPtr[i - 1], i, cuSeqlensQPtr[i]);
+                    return false;
+                }
+            }
+        }
+    }
+    // 校验 seqused_q 元素
+    if (sequsedQ_ != nullptr && sequsedQ_->GetData() != nullptr) {
+        const int32_t *sequsedQPtr = static_cast<const int32_t *>(sequsedQ_->GetData());
+        for (int i = 0; i < batchSize; i++) {
+            // 校验 seqused_q 元素非负
+            if (sequsedQPtr[i] < 0) {
+                KERNEL_LOG_ERROR("The elements in seqused_q should be >= 0, but got seqused_q[%d] = %d", i,
+                                 sequsedQPtr[i]);
+                return false;
+            }
+        }
+    }
+    if (hasOriKv_) {
+        // 校验 cu_seqlens_ori_kv 元素
+        if (layoutKv_ == "TND") {
+            if (cuSeqlensOriKv_ != nullptr && cuSeqlensOriKv_->GetData() != nullptr) {
+                const int32_t *cuSeqlensOriKvPtr = static_cast<const int32_t *>(cuSeqlensOriKv_->GetData());
+                for (int i = 0; i < batchSize + 1; i++) {
+                    // 校验 cu_seqlens_ori_kv 元素非负
+                    if (cuSeqlensOriKvPtr[i] < 0) {
+                        KERNEL_LOG_ERROR("The elements in cu_seqlens_ori_kv should be >= 0, "
+                                         "but got cu_seqlens_ori_kv[%d] = %d",
+                                         i, cuSeqlensOriKvPtr[i]);
+                        return false;
+                    }
+                    // 校验 cu_seqlens_ori_kv 元素递增
+                    if (i > 0 && cuSeqlensOriKvPtr[i - 1] > cuSeqlensOriKvPtr[i]) {
+                        KERNEL_LOG_ERROR("The elements in cu_seqlens_ori_kv must be in ascending order, "
+                                         "but got cu_seqlens_ori_kv[%d] = %d, cu_seqlens_ori_kv[%d] = %d",
+                                         i - 1, cuSeqlensOriKvPtr[i - 1], i, cuSeqlensOriKvPtr[i]);
+                        return false;
+                    }
+                }
+            }
+        }
+        // 校验 seqused_ori_kv 元素
+        if (sequsedOriKv_ != nullptr && sequsedOriKv_->GetData() != nullptr) {
+            const int32_t *sequsedOriKvPtr = static_cast<const int32_t *>(sequsedOriKv_->GetData());
+            for (int i = 0; i < batchSize; i++) {
+                // 校验 seqused_ori_kv 元素非负
+                if (sequsedOriKvPtr[i] < 0) {
+                    KERNEL_LOG_ERROR("The elements in seqused_ori_kv should be >= 0, but got seqused_ori_kv[%d] = %d",
+                                     i, sequsedOriKvPtr[i]);
+                    return false;
+                }
+            }
+        }
+        // 校验 ori_topk_length 元素
+        if (oriTopkLength_ != nullptr && oriTopkLength_->GetData() != nullptr) {
+            // 校验 ori_topk_length 元素数量
+            int32_t sumOfQuerySeq = GetSumOfQuerySeq();
+            const int32_t *oriTopkLengthPtr = static_cast<const int32_t *>(oriTopkLength_->GetData());
+            auto oriTopkLengthShape = oriTopkLength_->GetTensorShape();
+            int32_t oriTopkLengthSize = layoutQ_ == "TND" ?
+                                            oriTopkLengthShape->GetDimSize(0) * oriTopkLengthShape->GetDimSize(1) :
+                                            oriTopkLengthShape->GetDimSize(0) * oriTopkLengthShape->GetDimSize(1) *
+                                                oriTopkLengthShape->GetDimSize(2);
+            if (oriTopkLengthSize < sumOfQuerySeq) {
+                KERNEL_LOG_ERROR("The size of ori_topk_length %d should not be smaller than "
+                                 "the sum of query sequence %d!",
+                                 oriTopkLengthSize, sumOfQuerySeq);
+                return false;
+            }
+            // 校验 ori_topk_length 元素非负
+            for (int i = 0; i < oriTopkLengthSize; i++) {
+                if (oriTopkLengthPtr[i] < 0) {
+                    KERNEL_LOG_ERROR("The elements in ori_topk_length should be >= 0, but got ori_topk_length[%d] = %d",
+                                     i, oriTopkLengthPtr[i]);
+                    return false;
+                }
+            }
+        }
+    }
+    if (hasCmpKv_) {
+        if (layoutKv_ == "TND") {
+            // 校验 cu_seqlens_cmp_kv 元素
+            if (cuSeqlensCmpKv_ != nullptr && cuSeqlensCmpKv_->GetData() != nullptr) {
+                const int32_t *cuSeqlensCmpKvPtr = static_cast<const int32_t *>(cuSeqlensCmpKv_->GetData());
+                for (int i = 0; i < batchSize + 1; i++) {
+                    // 校验 cu_seqlens_cmp_kv 元素非负
+                    if (cuSeqlensCmpKvPtr[i] < 0) {
+                        KERNEL_LOG_ERROR("The elements in cu_seqlens_cmp_kv should be >= 0, "
+                                         "but got cu_seqlens_cmp_kv[%d] = %d",
+                                         i, cuSeqlensCmpKvPtr[i]);
+                        return false;
+                    }
+                    // 校验 cu_seqlens_cmp_kv 元素递增
+                    if (i > 0 && cuSeqlensCmpKvPtr[i - 1] > cuSeqlensCmpKvPtr[i]) {
+                        KERNEL_LOG_ERROR("The elements in cu_seqlens_cmp_kv must be in ascending order, "
+                                         "but got cu_seqlens_cmp_kv[%d] = %d, cu_seqlens_cmp_kv[%d] = %d",
+                                         i - 1, cuSeqlensCmpKvPtr[i - 1], i, cuSeqlensCmpKvPtr[i]);
+                        return false;
+                    }
+                }
+            }
+        }
+        // 校验 seqused_cmp_kv 元素
+        if (sequsedCmpKv_ != nullptr && sequsedCmpKv_->GetData() != nullptr) {
+            const int32_t *sequsedCmpKvPtr = static_cast<const int32_t *>(sequsedCmpKv_->GetData());
+            for (int i = 0; i < batchSize; i++) {
+                // 校验 seqused_cmp_kv 元素非负
+                if (sequsedCmpKvPtr[i] < 0) {
+                    KERNEL_LOG_ERROR("The elements in seqused_cmp_kv should be >= 0, but got seqused_cmp_kv[%d] = %d",
+                                     i, sequsedCmpKvPtr[i]);
+                    return false;
+                }
+            }
+        }
+        // 校验 cmp_residual_kv 元素
+        if (cmpResidualKv_ != nullptr && cmpResidualKv_->GetData() != nullptr) {
+            const int32_t *cmpResidualKvPtr = static_cast<const int32_t *>(cmpResidualKv_->GetData());
+            for (int i = 0; i < batchSize; i++) {
+                // 校验 cmp_residual_kv 元素非负
+                if (cmpResidualKvPtr[i] < 0 || cmpResidualKvPtr[i] >= cmpRatio_) {
+                    KERNEL_LOG_ERROR("The elements in cmp_residual_kv should be in [0, cmpRatio_), but got "
+                                     "cmp_residual_kv[%d] = %d",
+                                     i, cmpResidualKvPtr[i]);
+                    return false;
+                }
+            }
+        }
+        // 校验 cmp_topk_length 元素
+        if (cmpTopkLength_ != nullptr && cmpTopkLength_->GetData() != nullptr) {
+            // 校验 cmp_topk_length 元素数量
+            int32_t sumOfQuerySeq = GetSumOfQuerySeq();
+            const int32_t *cmpTopkLengthPtr = static_cast<const int32_t *>(cmpTopkLength_->GetData());
+            auto cmpTopkLengthShape = cmpTopkLength_->GetTensorShape();
+            int32_t cmpTopkLengthSize = layoutQ_ == "TND" ?
+                                            cmpTopkLengthShape->GetDimSize(0) * cmpTopkLengthShape->GetDimSize(1) :
+                                            cmpTopkLengthShape->GetDimSize(0) * cmpTopkLengthShape->GetDimSize(1) *
+                                                cmpTopkLengthShape->GetDimSize(2);
+            if (cmpTopkLengthSize < sumOfQuerySeq) {
+                KERNEL_LOG_ERROR("The size of cmp_topk_length %d should not be smaller than "
+                                 "the sum of query sequence %d!",
+                                 cmpTopkLengthSize, sumOfQuerySeq);
+                return false;
+            }
+            // 校验 cmp_topk_length 元素非负
+            for (int i = 0; i < cmpTopkLengthSize; i++) {
+                if (cmpTopkLengthPtr[i] < 0) {
+                    KERNEL_LOG_ERROR("The elements in cmp_topk_length should be >= 0, but got cmp_topk_length[%d] = %d",
+                                     i, cmpTopkLengthPtr[i]);
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+int32_t SparseFlashMlaMetadataCpuKernel::GetSumOfQuerySeq()
+{
+    int32_t batchSize = GetQueryBatchSize();
+    // 如果sequsedQ_ 传了，使用sequsedQ_获取 BsSize
+    if (sequsedQ_ != nullptr && sequsedQ_->GetData() != nullptr) {
+        if (sequsedQ_->GetTensorShape() != nullptr) {
+            const int32_t *seqUsedPtr = static_cast<const int32_t *>(sequsedQ_->GetData());
+            int32_t queryBsSize = 0;
+            for (int i = 0; i < batchSize; i++) {
+                queryBsSize += seqUsedPtr[i];
+            }
+            return queryBsSize;
+        }
+    }
+    // sequsedQ_ 没传，判断 Layout
+    if (layoutQ_ == "TND") {
+        // 如果是 TND，尝试使用 cuSeqlensQ_获取 BsSize
+        if (cuSeqlensQ_ != nullptr && cuSeqlensQ_->GetData() != nullptr) {
+            if (cuSeqlensQ_->GetTensorShape() != nullptr) {
+                const int32_t *s1Ptr = static_cast<const int32_t *>(cuSeqlensQ_->GetData());
+                return s1Ptr[batchSize];
+            }
+        }
+    }
+    // 如果不是 TND，或者 cuSeqlensQ_ 为空，使用shape信息计算 BsSize
+    return batchSize_ * maxSeqlenQ_;
+}
+
+int32_t SparseFlashMlaMetadataCpuKernel::GetQueryBatchSize()
+{
+    // 1. 如果sequsedQ_ 传了，使用sequsedQ_获取BatchSize
+    if (sequsedQ_ != nullptr && sequsedQ_->GetData() != nullptr) {
+        if (sequsedQ_->GetTensorShape() != nullptr) {
+            return sequsedQ_->GetTensorShape()->GetDimSize(0);
+        }
+    }
+    // 2. sequsedQ_ 没传，判断 Layout
+    if (layoutQ_ == "TND") {
+        // 如果是 TND，尝试使用 cuSeqlensQ_获取BatchSize
+        if (cuSeqlensQ_ != nullptr && cuSeqlensQ_->GetData() != nullptr) {
+            if (cuSeqlensQ_->GetTensorShape() != nullptr) {
+                return cuSeqlensQ_->GetTensorShape()->GetDimSize(0) - 1;
+            }
+        }
+    }
+    // 3. 如果不是 TND，或者 cuSeqlensQ_ 为空，使用batchSize_
+    return batchSize_;
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcOriMaskMode()
+{
+    if (oriMaskMode_ == static_cast<int32_t>(SparseMode::DEFAULT_MASK)) {
+        oriPreToken_ = INT64_MAX;
+        oriNextToken_ = INT64_MAX;
+        oriAttentionMode_ = NO_MASK;
+    } else if (oriMaskMode_ == static_cast<int32_t>(SparseMode::RIGHT_DOWN_CAUSAL)) {
+        oriPreToken_ = INT64_MAX;
+        oriNextToken_ = 0;
+        oriAttentionMode_ = HAS_MASK;
+    } else { // SparseMode = 4
+        oriPreToken_ = (oriWinLeft_ > -1) ? oriWinLeft_ : INT64_MAX;
+        oriNextToken_ = (oriWinRight_ > -1) ? oriWinRight_ : INT64_MAX;
+        oriAttentionMode_ = HAS_MASK;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcCmpMaskMode()
+{
+    if (cmpMaskMode_ == static_cast<int32_t>(SparseMode::DEFAULT_MASK)) {
+        cmpPreToken_ = INT64_MAX;
+        cmpNextToken_ = INT64_MAX;
+        cmpAttentionMode_ = NO_MASK;
+    } else if (cmpMaskMode_ == static_cast<int32_t>(SparseMode::RIGHT_DOWN_CAUSAL)) {
+        cmpPreToken_ = INT64_MAX;
+        cmpNextToken_ = 0;
+        cmpAttentionMode_ = HAS_MASK;
+    } else { // SparseMode = 4
+        cmpPreToken_ = (oriWinLeft_ > -1) ? oriWinLeft_ : INT64_MAX;
+        cmpNextToken_ = (oriWinRight_ > -1) ? oriWinRight_ : INT64_MAX;
+        cmpAttentionMode_ = HAS_MASK;
+    }
+}
+
+ValidSocVersion SparseFlashMlaMetadataCpuKernel::ProcessSocVersion()
+{
+    const std::string ascend950 = "Ascend950";
+    if (socVersion_.find(ascend950) != std::string::npos) {
+        return ValidSocVersion::ASCEND950;
+    } else {
+        return ValidSocVersion::ASCEND910;
+    }
+}
+
+bool SparseFlashMlaMetadataCpuKernel::ParamsInit()
+{
+    batchSize_ = GetQueryBatchSize();
+    CalcOriMaskMode();
+    CalcCmpMaskMode();
+    isS1G_ = (layoutQ_ == "BSND" || layoutQ_ == "BSH" || layoutQ_ == "TND");
+    if (numHeadsKv_ == 0) {
+        KERNEL_LOG_ERROR("num_heads_kv should not be 0.");
+        return false;
+    }
+    ValidSocVersion validSocVersion = ProcessSocVersion();
+    groupSize_ = numHeadsQ_ / numHeadsKv_;
+    if (hasOriKv_ && oriTopK_ != 0) {
+        isSparseOriKv_ = true;
+    }
+    if (hasCmpKv_ && cmpTopK_ != 0) {
+        isSparseCmpKv_ = true;
+    }
+    if (validSocVersion == ValidSocVersion::ASCEND910) {
+        mBaseSize_ = isSparseCmpKv_ ? groupSize_ : (256U / groupSize_) * groupSize_;
+        s2BaseSize_ = 512U;
+    } else if (validSocVersion == ValidSocVersion::ASCEND950) {
+        if (groupSize_ > 64U) {
+            isSplitG_ = true;
+            aicCoreNum_ /= 2;
+        }
+        mBaseSize_ = groupSize_;
+        s2BaseSize_ = 128U;
+    } else {
+        mBaseSize_ = groupSize_;
+        s2BaseSize_ = 128U;
+    }
+    return true;
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetS1Idx(uint32_t s1Size, uint32_t s1GIdx)
+{
+    uint32_t s1GToken = s1GIdx * mBaseSize_;
+    uint32_t s1Idx = 0;
+    if (isS1G_) {
+        s1Idx = s1GToken / static_cast<int64_t>(groupSize_);
+    } else {
+        s1Idx = s1GToken % static_cast<int64_t>(s1Size);
+    }
+    return s1Idx;
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetBsStride(uint32_t bIdx, uint32_t s1Idx)
+{
+    uint32_t bsStride = 0;
+    if (layoutQ_ == "TND") {
+        if (cuSeqlensQ_ != nullptr && cuSeqlensQ_->GetData() != nullptr) {
+            const int32_t *s1Ptr = static_cast<const int32_t *>(cuSeqlensQ_->GetData());
+            bsStride = s1Ptr[bIdx] + s1Idx;
+            return bsStride;
+        }
+    }
+    bsStride = bIdx * static_cast<uint32_t>(maxSeqlenQ_) + s1Idx;
+    return bsStride;
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetOriTopkLength(uint32_t bsStride)
+{
+    // 尝试使用 oriTopkLength_
+    if (oriTopkLength_ != nullptr && oriTopkLength_->GetData() != nullptr) {
+        const int32_t *oriTopkPtr = static_cast<const int32_t *>(oriTopkLength_->GetData());
+        return static_cast<uint32_t>(oriTopkPtr[bsStride]);
+    }
+    // 如果不是 DEFAULT_MASK，使用 oriTopK_
+    return static_cast<uint32_t>(oriTopK_);
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetCmpTopkLength(uint32_t bsStride)
+{
+    // 尝试使用 cmpTopkLength_
+    if (cmpTopkLength_ != nullptr && cmpTopkLength_->GetData() != nullptr) {
+        const int32_t *cmpTopkPtr = static_cast<const int32_t *>(cmpTopkLength_->GetData());
+        return static_cast<uint32_t>(cmpTopkPtr[bsStride]);
+    }
+    // 如果不是 DEFAULT_MASK，使用 cmpTopK_
+    return static_cast<uint32_t>(cmpTopK_);
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetS1SeqSize(uint32_t bIdx)
+{
+    // 1. 如果 sequsedQ_ 传了，直接使用
+    if (sequsedQ_ != nullptr && sequsedQ_->GetData() != nullptr) {
+        const int32_t *seqUsedPtr = static_cast<const int32_t *>(sequsedQ_->GetData());
+        return static_cast<uint32_t>(seqUsedPtr[bIdx]);
+    }
+    // 2. sequsedQ_ 没传，判断 Layout
+    if (layoutQ_ == "TND") {
+        // 如果是 TND，尝试使用 cuSeqlensQ_
+        if (cuSeqlensQ_ != nullptr && cuSeqlensQ_->GetData() != nullptr) {
+            const int32_t *s1Ptr = static_cast<const int32_t *>(cuSeqlensQ_->GetData());
+            return static_cast<uint32_t>(s1Ptr[bIdx + 1U] - s1Ptr[bIdx]);
+        }
+    }
+    // 3. 如果不是 TND，或者 cuSeqlensQ_ 为空，使用 maxSeqlenQ_
+    return static_cast<uint32_t>(maxSeqlenQ_);
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetOriS2SeqSize(uint32_t bIdx)
+{
+    // 如果 sequsedOriKv_ 传了，直接使用
+    if (sequsedOriKv_ != nullptr && sequsedOriKv_->GetData() != nullptr) {
+        const int32_t *seqUsedPtr = static_cast<const int32_t *>(sequsedOriKv_->GetData());
+        return static_cast<uint32_t>(seqUsedPtr[bIdx]);
+    }
+    // sequsedOriKv_ 没传，判断 Layout
+    if (layoutKv_ == "TND") {
+        // 如果是 TND，尝试使用 cuSeqlensOriKv_
+        if (cuSeqlensOriKv_ != nullptr && cuSeqlensOriKv_->GetData() != nullptr) {
+            const int32_t *s2Ptr = static_cast<const int32_t *>(cuSeqlensOriKv_->GetData());
+            return static_cast<uint32_t>(s2Ptr[bIdx + 1U] - s2Ptr[bIdx]);
+        }
+    }
+    // 如果 max_seqlen_ori_kv 没传入，且 ori_kv 为稀疏的，则尝试从 topk 中获取
+    if (maxSeqlenOriKv_ == 0 && isSparseOriKv_) {
+        return UINT32_MAX;
+    }
+    // 使用 max_seqlen_ori_kv
+    return static_cast<uint32_t>(maxSeqlenOriKv_);
+}
+
+uint32_t SparseFlashMlaMetadataCpuKernel::GetCmpS2SeqSize(uint32_t bIdx)
+{
+    // 如果 sequsedCmpKv_ 传了，直接使用
+    if (sequsedCmpKv_ != nullptr && sequsedCmpKv_->GetData() != nullptr) {
+        const int32_t *seqUsedPtr = static_cast<const int32_t *>(sequsedCmpKv_->GetData());
+        return static_cast<uint32_t>(seqUsedPtr[bIdx]);
+    }
+    // sequsedCmpKv_ 没传，判断 Layout
+    if (layoutKv_ == "TND") {
+        // 如果是 TND，尝试使用 cuSeqlensCmpKv_
+        if (cuSeqlensCmpKv_ != nullptr && cuSeqlensCmpKv_->GetData() != nullptr) {
+            const int32_t *s2Ptr = static_cast<const int32_t *>(cuSeqlensCmpKv_->GetData());
+            return static_cast<uint32_t>(s2Ptr[bIdx + 1U] - s2Ptr[bIdx]);
+        }
+    }
+    // 如果 max_seqlen_cmp_kv 没传入，且 cmp_kv 为稀疏的，则尝试从topk中获取
+    if (maxSeqlenCmpKv_ == 0 && isSparseCmpKv_) {
+        return UINT32_MAX;
+    }
+    // 使用 max_seqlen_cmp_kv
+    return static_cast<uint32_t>(maxSeqlenCmpKv_);
+}
+
+uint64_t SparseFlashMlaMetadataCpuKernel::GetRevertS2Size(uint32_t bIdx)
+{
+    uint32_t cmpS2Size = GetCmpS2SeqSize(bIdx);
+    if (cmpResidualKv_ != nullptr && cmpResidualKv_->GetData() != nullptr) {
+        const int32_t *residualPtr = static_cast<const int32_t *>(cmpResidualKv_->GetData());
+        return static_cast<uint64_t>(cmpS2Size) * static_cast<uint64_t>(cmpRatio_) + residualPtr[bIdx];
+    } else {
+        return static_cast<uint64_t>(cmpS2Size) * static_cast<uint64_t>(cmpRatio_);
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcSplitInfo(SplitContext &splitContext)
+{
+    // 计算每个batch的切分，统计是否为空batch，记录最后有效batch（每个batch的每个N2切分是一样的）
+    SplitInfo &splitInfo = splitContext.splitInfo;
+    for (uint32_t bIdx = 0; bIdx < batchSize_; bIdx++) {
+        uint32_t s1Size = GetS1SeqSize(bIdx);
+        splitInfo.s1GBaseNum[bIdx] = (static_cast<uint64_t>(s1Size) * groupSize_ + (mBaseSize_ - 1U)) / mBaseSize_;
+        splitInfo.s1GTailSize[bIdx] = (static_cast<uint64_t>(s1Size) * groupSize_) % mBaseSize_;
+        if (hasOriKv_) {
+            uint32_t curOriS2Size = GetOriS2SeqSize(bIdx);
+            splitInfo.oriS2BaseNum[bIdx] = (static_cast<uint64_t>(curOriS2Size) + s2BaseSize_ - 1U) / s2BaseSize_;
+        }
+        if (hasCmpKv_) {
+            uint32_t curCmpS2Size = GetCmpS2SeqSize(bIdx);
+            splitInfo.cmpS2BaseNum[bIdx] = (static_cast<uint64_t>(curCmpS2Size) + s2BaseSize_ - 1U) / s2BaseSize_;
+        }
+        if (splitInfo.s1GBaseNum[bIdx] != 0U &&
+            (splitInfo.oriS2BaseNum[bIdx] != 0U || splitInfo.cmpS2BaseNum[bIdx] != 0U)) {
+            splitInfo.isKvSeqAllZero = false;
+        }
+    }
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CalcOriPreTokenLeftUp(uint32_t s1Size, uint32_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(oriMaskMode_);
+    if (mode == SparseMode::BAND) {
+        return oriPreToken_ == INT64_MAX ? INT64_MAX :
+                                           static_cast<int64_t>(s1Size) - static_cast<int64_t>(s2Size) + oriPreToken_;
+    }
+    return oriPreToken_;
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CalcOriNextTokenLeftUp(uint32_t s1Size, uint32_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(oriMaskMode_);
+    switch (mode) {
+        case SparseMode::DEFAULT_MASK:
+        case SparseMode::ALL_MASK:
+        case SparseMode::LEFT_UP_CAUSAL:
+            return oriNextToken_;
+        case SparseMode::RIGHT_DOWN_CAUSAL:
+            return static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size);
+        case SparseMode::BAND:
+            return oriNextToken_ == INT64_MAX ?
+                       INT64_MAX :
+                       static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size) + oriNextToken_;
+        default:
+            return oriNextToken_;
+    }
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CalcCmpPreTokenLeftUp(uint32_t s1Size, uint64_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(cmpMaskMode_);
+    if (mode == SparseMode::BAND) {
+        return cmpPreToken_ == INT64_MAX ? INT64_MAX :
+                                           static_cast<int64_t>(s1Size) - static_cast<int64_t>(s2Size) + cmpPreToken_;
+    }
+    return cmpPreToken_;
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CalcCmpNextTokenLeftUp(uint32_t s1Size, uint64_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(cmpMaskMode_);
+    switch (mode) {
+        case SparseMode::DEFAULT_MASK:
+        case SparseMode::ALL_MASK:
+        case SparseMode::LEFT_UP_CAUSAL:
+            return cmpNextToken_;
+        case SparseMode::RIGHT_DOWN_CAUSAL:
+            return static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size);
+        case SparseMode::BAND:
+            return cmpNextToken_ == INT64_MAX ?
+                       INT64_MAX :
+                       static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size) + cmpNextToken_;
+        default:
+            return cmpNextToken_;
+    }
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::OriCalcCost(uint32_t basicM, uint32_t basicS2)
+{
+    uint32_t oriAlignCoefM = 16U;
+    uint32_t oriAlignCoefS2 = 64U;
+    uint32_t oriAlignBasicM = (basicM + oriAlignCoefM - 1U) / oriAlignCoefM;
+    uint32_t oriAlignBasicS2 = (basicS2 + oriAlignCoefS2 - 1U) / oriAlignCoefS2;
+    return static_cast<int64_t>(COST_WEIGHT_M * oriAlignBasicM + COST_WEIGHT_S2 * oriAlignBasicS2);
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CmpCalcCost(uint32_t basicM, uint32_t basicS2)
+{
+    uint32_t cmpAlignCoefM = 16U;
+    uint32_t cmpAlignCoefS2 = 64U;
+    uint32_t cmpAlignBasicM = (basicM + cmpAlignCoefM - 1U) / cmpAlignCoefM;
+    uint32_t cmpAlignBasicS2 = (basicS2 + cmpAlignCoefS2 - 1U) / cmpAlignCoefS2;
+    return static_cast<int64_t>(COST_WEIGHT_M * cmpAlignBasicM + COST_WEIGHT_S2 * cmpAlignBasicS2);
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcCostTable(uint32_t s1NormalSize, uint32_t s2NormalSize, uint32_t s1GTailSize,
+                                                    uint32_t oriS2TailSize, uint32_t cmpS2TailSize)
+{
+    // ori 部分 cost
+    if (hasOriKv_) {
+        typeCost_[ORI_NORMAL_BLOCK][ORI_NORMAL_BLOCK] = OriCalcCost(s1NormalSize, s2NormalSize);
+        typeCost_[ORI_TAIL_BLOCK][ORI_NORMAL_BLOCK] = (s1GTailSize == 0U) ? 0U : OriCalcCost(s1GTailSize, s2NormalSize);
+        typeCost_[ORI_NORMAL_BLOCK][ORI_TAIL_BLOCK] =
+            (oriS2TailSize == 0U) ? 0U : OriCalcCost(s1NormalSize, oriS2TailSize);
+        typeCost_[ORI_TAIL_BLOCK][ORI_TAIL_BLOCK] =
+            (s1GTailSize == 0U || oriS2TailSize == 0U) ? 0U : OriCalcCost(s1GTailSize, oriS2TailSize);
+    }
+    // cmp 部分 cost
+    if (hasCmpKv_) {
+        typeCost_[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK] = CmpCalcCost(s1NormalSize, s2NormalSize);
+        typeCost_[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK] = (s1GTailSize == 0U) ? 0U : CmpCalcCost(s1GTailSize, s2NormalSize);
+        typeCost_[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK] =
+            (cmpS2TailSize == 0U) ? 0U : CmpCalcCost(s1NormalSize, cmpS2TailSize);
+        typeCost_[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK] =
+            (s1GTailSize == 0U || cmpS2TailSize == 0U) ? 0U : CmpCalcCost(s1GTailSize, cmpS2TailSize);
+    }
+}
+
+Range<int64_t> SparseFlashMlaMetadataCpuKernel::CalcS2TokenRange(uint32_t s1GIdx, const BatchCache &batchCache,
+                                                                 bool isCmpKv)
+{
+    // actual seq == 0
+    if (!isCmpKv) {
+        if (batchCache.s1Size == 0U || batchCache.oriS2Size == 0U) {
+            return std::make_pair(0, 0);
+        }
+    } else {
+        if (batchCache.s1Size == 0U || batchCache.cmpRevertS2Size == 0U) {
+            return std::make_pair(0, 0);
+        }
+    }
+
+    // no mask
+    uint32_t hasMask = 1;
+    int64_t s2Size =
+        isCmpKv ? static_cast<int64_t>(batchCache.cmpRevertS2Size) : static_cast<int64_t>(batchCache.oriS2Size);
+    hasMask = isCmpKv ? cmpAttentionMode_ : oriAttentionMode_;
+    if (!hasMask) {
+        return std::make_pair(0, s2Size - 1);
+    }
+
+    // 1. calc index of s2FirstToken, s2LastToken by index of s1GFirstToken, s1GLastToken
+    int64_t s1GFirstToken = static_cast<int64_t>(s1GIdx) * static_cast<int64_t>(mBaseSize_);
+    int64_t s1GLastToken = std::min(s1GFirstToken + static_cast<int64_t>(mBaseSize_),
+                                    static_cast<int64_t>(batchCache.s1Size) * static_cast<int64_t>(groupSize_)) -
+                           1;
+
+    int64_t s1FirstToken = 0;
+    int64_t s1LastToken = 0;
+    if (isS1G_) {
+        s1FirstToken = s1GFirstToken / static_cast<int64_t>(groupSize_);
+        s1LastToken = s1GLastToken / static_cast<int64_t>(groupSize_);
+    } else {
+        if (s1GFirstToken / batchCache.s1Size == s1GLastToken / batchCache.s1Size) {
+            // start and end locate in one G
+            s1FirstToken = s1GFirstToken % static_cast<int64_t>(batchCache.s1Size);
+            s1LastToken = s1GLastToken % static_cast<int64_t>(batchCache.s1Size);
+        } else {
+            // start and end locate in tow or more G, but working same as crossing a complete block
+            s1FirstToken = 0;
+            s1LastToken = batchCache.s1Size;
+        }
+    }
+
+    int64_t s2FirstToken = 0;
+    int64_t s2LastToken = 0;
+    if (!isCmpKv) {
+        s2FirstToken = s1FirstToken - batchCache.oriPreTokenLeftUp;
+        s2LastToken =
+            batchCache.oriNextTokenLeftUp == INT64_MAX ? INT64_MAX : s1LastToken + batchCache.oriNextTokenLeftUp;
+    } else {
+        s2FirstToken = s1FirstToken - batchCache.cmpPreTokenLeftUp;
+        s2LastToken =
+            batchCache.cmpNextTokenLeftUp == INT64_MAX ? INT64_MAX : s1LastToken + batchCache.cmpNextTokenLeftUp;
+    }
+    return std::make_pair(s2FirstToken, s2LastToken);
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcBatchCache(uint32_t bIdx, const SplitContext &splitContext,
+                                                     BatchCache &batchCache)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+
+    batchCache.bIdx = bIdx;
+    batchCache.s1Size = GetS1SeqSize(bIdx);
+    if (hasOriKv_) {
+        batchCache.oriS2Size = GetOriS2SeqSize(bIdx);
+        batchCache.oriPreTokenLeftUp = CalcOriPreTokenLeftUp(batchCache.s1Size, batchCache.oriS2Size);
+        batchCache.oriNextTokenLeftUp = CalcOriNextTokenLeftUp(batchCache.s1Size, batchCache.oriS2Size);
+    }
+    if (hasCmpKv_) {
+        batchCache.cmpRevertS2Size = GetRevertS2Size(bIdx);
+        batchCache.cmpPreTokenLeftUp = CalcCmpPreTokenLeftUp(batchCache.s1Size, batchCache.cmpRevertS2Size);
+        batchCache.cmpNextTokenLeftUp = CalcCmpNextTokenLeftUp(batchCache.s1Size, batchCache.cmpRevertS2Size);
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcOriS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo)
+{
+    // 处理 ori 部分 block 信息
+    if (s1GCache.oriS2Start >= s1GCache.oriS2End) {
+        // ori 范围无效, 则整个 s1g 行等效为空行
+        s1GCache.oriS1GBlock = 0;
+        s1GCache.oriS1GCost = 0;
+        s1GCache.oriS1GLastBlockCost = 0;
+        s1GCache.oriS1GNormalBlockCost = 0;
+    } else {
+        // 计算 ori 方向 Block 数量及 Cost
+        s1GCache.oriS1GBlock = s1GCache.oriS2End - s1GCache.oriS2Start;
+        // 判断 ori S2 方向是否包含尾块
+        uint32_t curOriTailS2Num = (s1GCache.oriS2TailSize != 0U) ? 1U : 0U;
+        uint32_t curOriNormalS2Num = s1GCache.oriS1GBlock - curOriTailS2Num;
+        if (s1GCache.s1GIdx == (splitInfo.s1GBaseNum[s1GCache.bIdx] - 1U) &&
+            splitInfo.s1GTailSize[s1GCache.bIdx] != 0U) {
+            s1GCache.oriS1GCost = typeCost_[ORI_TAIL_BLOCK][ORI_NORMAL_BLOCK] * curOriNormalS2Num +
+                                  typeCost_[ORI_TAIL_BLOCK][ORI_TAIL_BLOCK] * curOriTailS2Num;
+            s1GCache.oriS1GLastBlockCost = curOriTailS2Num > 0U ? typeCost_[ORI_TAIL_BLOCK][ORI_TAIL_BLOCK] :
+                                                                  typeCost_[ORI_TAIL_BLOCK][ORI_NORMAL_BLOCK];
+            s1GCache.oriS1GNormalBlockCost = typeCost_[ORI_TAIL_BLOCK][ORI_NORMAL_BLOCK];
+        } else {
+            s1GCache.oriS1GCost = typeCost_[ORI_NORMAL_BLOCK][ORI_NORMAL_BLOCK] * curOriNormalS2Num +
+                                  typeCost_[ORI_NORMAL_BLOCK][ORI_TAIL_BLOCK] * curOriTailS2Num;
+            s1GCache.oriS1GLastBlockCost = curOriTailS2Num > 0U ? typeCost_[ORI_NORMAL_BLOCK][ORI_TAIL_BLOCK] :
+                                                                  typeCost_[ORI_NORMAL_BLOCK][ORI_NORMAL_BLOCK];
+            s1GCache.oriS1GNormalBlockCost = typeCost_[ORI_NORMAL_BLOCK][ORI_NORMAL_BLOCK];
+        }
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcCmpS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo)
+{
+    // 处理cmp部分block信息
+    if (s1GCache.cmpS2Start >= s1GCache.cmpS2End) {
+        // Cmp范围无效, Cost保持为 0
+        s1GCache.cmpS1GBlock = 0;
+        s1GCache.cmpS1GCost = 0;
+        s1GCache.cmpS1GLastBlockCost = 0;
+        s1GCache.cmpS1GNormalBlockCost = 0;
+    } else {
+        // 计算 cmp 方向 Block 数量及 Cost
+        s1GCache.cmpS1GBlock = s1GCache.cmpS2End - s1GCache.cmpS2Start;
+        // 判断 Cmp S2 方向是否包含尾块
+        uint32_t curCmpTailS2Num = (s1GCache.cmpS2TailSize != 0U) ? 1U : 0U; // Updated check using local var
+        uint32_t curCmpNormalS2Num = s1GCache.cmpS1GBlock - curCmpTailS2Num;
+        if (s1GCache.s1GIdx == (splitInfo.s1GBaseNum[s1GCache.bIdx] - 1U) &&
+            splitInfo.s1GTailSize[s1GCache.bIdx] != 0U) {
+            s1GCache.cmpS1GCost = typeCost_[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK] * curCmpNormalS2Num +
+                                  typeCost_[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK] * curCmpTailS2Num;
+            s1GCache.cmpS1GLastBlockCost = curCmpTailS2Num > 0U ? typeCost_[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK] :
+                                                                  typeCost_[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK];
+            s1GCache.cmpS1GNormalBlockCost = typeCost_[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK];
+        } else {
+            s1GCache.cmpS1GCost = typeCost_[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK] * curCmpNormalS2Num +
+                                  typeCost_[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK] * curCmpTailS2Num;
+            s1GCache.cmpS1GLastBlockCost = curCmpTailS2Num > 0U ? typeCost_[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK] :
+                                                                  typeCost_[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK];
+            s1GCache.cmpS1GNormalBlockCost = typeCost_[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK];
+        }
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcOriBlockRange(const Range<int64_t> &oriS2TokenRange,
+                                                        const BatchCache &batchCache, S1GCache &s1GCache)
+{
+    int64_t oriS2FirstToken = oriS2TokenRange.first;
+    int64_t oriS2LastToken = oriS2TokenRange.second;
+    s1GCache.oriS2Start = 0;
+    // ori 部分 s2 起止和 tailSize
+    if (oriS2FirstToken >= static_cast<int64_t>(batchCache.oriS2Size) || oriS2LastToken < 0 ||
+        oriS2LastToken < oriS2FirstToken) {
+        s1GCache.oriS2End = 0;
+        s1GCache.oriS2TailSize = 0;
+    } else {
+        oriS2FirstToken =
+            Clip(oriS2FirstToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.oriS2Size - 1U));
+        oriS2LastToken = Clip(oriS2LastToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.oriS2Size - 1U));
+        // oriS2LastToken 与 topk 取最小
+        uint32_t s1Idx = GetS1Idx(batchCache.s1Size, s1GCache.s1GIdx);
+        uint32_t bsStride = GetBsStride(s1GCache.bIdx, s1Idx);
+        uint32_t oriTopkSize = GetOriTopkLength(bsStride);
+        uint32_t actOriS2Size = isSparseOriKv_ ?
+                                    std::min(static_cast<uint32_t>(oriS2LastToken - oriS2FirstToken + 1), oriTopkSize) :
+                                    static_cast<uint32_t>(oriS2LastToken - oriS2FirstToken + 1);
+        s1GCache.oriS2End = actOriS2Size == 0 ? 0 : (actOriS2Size - 1) / s2BaseSize_ + 1U;
+        s1GCache.oriS2TailSize = actOriS2Size % s2BaseSize_;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcCmpBlockRange(const Range<int64_t> &cmpRevertS2TokenRange,
+                                                        const BatchCache &batchCache, S1GCache &s1GCache)
+{
+    int64_t cmpRevertS2FirstToken = cmpRevertS2TokenRange.first;
+    int64_t cmpRevertS2LastToken = cmpRevertS2TokenRange.second;
+    s1GCache.cmpS2Start = s1GCache.oriS2End;
+    // cmp 部分 s2 起止和 tailSize
+    if (cmpRevertS2FirstToken >= static_cast<int64_t>(batchCache.cmpRevertS2Size) || cmpRevertS2LastToken < 0 ||
+        cmpRevertS2LastToken < cmpRevertS2FirstToken) {
+        s1GCache.cmpS2End = s1GCache.cmpS2Start;
+        s1GCache.cmpS2TailSize = 0;
+    } else {
+        cmpRevertS2FirstToken =
+            Clip(cmpRevertS2FirstToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.cmpRevertS2Size - 1U));
+        cmpRevertS2LastToken =
+            Clip(cmpRevertS2LastToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.cmpRevertS2Size - 1U));
+        // 如果压缩后长度为0，则直接返回
+        if ((cmpRevertS2LastToken + 1) / cmpRatio_ == 0) {
+            s1GCache.cmpS2End = s1GCache.cmpS2Start;
+            s1GCache.cmpS2TailSize = 0;
+            return;
+        }
+        // 获取压缩后的 token 索引
+        uint64_t cmpS2FirstToken =
+            (cmpRevertS2FirstToken + 1) / cmpRatio_ == 0 ? 0 : (cmpRevertS2FirstToken + 1) / cmpRatio_ - 1U;
+        uint64_t cmpS2LastToken = (cmpRevertS2LastToken + 1) / cmpRatio_ - 1U;
+        // cmpS2LastToken 与 topk 取最小
+        uint32_t s1Idx = GetS1Idx(batchCache.s1Size, s1GCache.s1GIdx);
+        uint32_t bsStride = GetBsStride(s1GCache.bIdx, s1Idx);
+        uint32_t cmpTopkSize = GetCmpTopkLength(bsStride);
+        uint32_t actCmpS2Size = isSparseCmpKv_ ?
+                                    std::min(static_cast<uint32_t>(cmpS2LastToken - cmpS2FirstToken + 1), cmpTopkSize) :
+                                    static_cast<uint32_t>(cmpS2LastToken - cmpS2FirstToken + 1);
+        s1GCache.cmpS2End =
+            actCmpS2Size == 0 ? s1GCache.cmpS2Start : s1GCache.cmpS2Start + (actCmpS2Size - 1) / s2BaseSize_ + 1U;
+        s1GCache.cmpS2TailSize = actCmpS2Size % s2BaseSize_;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::GatherOriAndCmpCache(S1GCache &s1GCache)
+{
+    s1GCache.s2Start = 0;
+    if (s1GCache.cmpS1GBlock > 0) {
+        s1GCache.s1GLastBlockCost = s1GCache.cmpS1GLastBlockCost;
+        s1GCache.s2End = s1GCache.cmpS2End;
+    } else {
+        s1GCache.s1GLastBlockCost = s1GCache.oriS1GLastBlockCost;
+        s1GCache.s2End = s1GCache.oriS2End;
+    }
+    s1GCache.s1GBlock = s1GCache.oriS1GBlock + s1GCache.cmpS1GBlock;
+    s1GCache.s1GCost = s1GCache.oriS1GCost + s1GCache.cmpS1GCost;
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcS1GCache(uint32_t s1GIdx, const SplitContext &splitContext,
+                                                   const BatchCache &batchCache, S1GCache &s1GCache)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    // 如果s1G是空行，则直接返回
+    if (splitInfo.s1GBaseNum[batchCache.bIdx] == 0) {
+        s1GCache.s1GCost = 0;
+        s1GCache.s1GLastBlockCost = 0;
+        s1GCache.oriS1GNormalBlockCost = 0;
+        s1GCache.oriS1GLastBlockCost = 0;
+        s1GCache.cmpS1GNormalBlockCost = 0;
+        s1GCache.cmpS1GLastBlockCost = 0;
+        s1GCache.s1GBlock = 0;
+        s1GCache.s2Start = 0;
+        s1GCache.cmpS2Start = 0;
+        s1GCache.s2End = 0;
+        return;
+    }
+    s1GCache.bIdx = batchCache.bIdx;
+    s1GCache.s1GIdx = s1GIdx;
+    // 计算 ori_kv 有效负载起止
+    if (hasOriKv_) {
+        // 计算 ori_kv 的 s2Token 起止
+        auto oriS2TokenRange = CalcS2TokenRange(s1GIdx, batchCache, ORI_KV);
+        // 计算 ori_kv 的 s2Block 起止
+        CalcOriBlockRange(oriS2TokenRange, batchCache, s1GCache);
+    } else {
+        // ori_kv s2Token 起止初始化为0
+        s1GCache.oriS2Start = 0;
+        s1GCache.oriS2End = s1GCache.oriS2Start;
+        s1GCache.oriS2TailSize = 0;
+    }
+    // 计算 cmp_kv 有效负载起止
+    if (hasCmpKv_) {
+        // 计算 cmp_kv 的 s2Token 起止
+        auto cmpRevertS2TokenRange = CalcS2TokenRange(s1GIdx, batchCache, CMP_KV);
+        // 计算 cmp_kv 的 s2Block 起止
+        CalcCmpBlockRange(cmpRevertS2TokenRange, batchCache, s1GCache);
+    } else {
+        // cmp_kv s2Token 起止初始化为0
+        s1GCache.cmpS2Start = s1GCache.oriS2End;
+        s1GCache.cmpS2End = s1GCache.cmpS2Start;
+        s1GCache.cmpS2TailSize = 0;
+    }
+    // 计算基本块负载
+    CalcCostTable(mBaseSize_, s2BaseSize_, splitInfo.s1GTailSize[s1GCache.bIdx], s1GCache.oriS2TailSize,
+                  s1GCache.cmpS2TailSize);
+    // 计算 ori 和 cmp 部分的 cost 和 block 信息
+    CalcOriS1GCache(s1GCache, splitInfo);
+    CalcCmpS1GCache(s1GCache, splitInfo);
+    // 汇总 ori 和 cmp 部分的 cost 和 block 信息
+    GatherOriAndCmpCache(s1GCache);
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcBatchCost(uint32_t bIdx, const SplitContext &splitContext, CostInfo &costInfo)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+
+    costInfo.bN2CostOfEachBatch[bIdx] = 0;
+    costInfo.bN2BlockOfEachBatch[bIdx] = 0U;
+    costInfo.bN2LastBlockCostOfEachBatch[bIdx] = 0U;
+
+    if (GetS1SeqSize(bIdx) == 0U) {
+        return;
+    }
+    if (!hasOriKv_ && !hasCmpKv_) {
+        return;
+    } else if (!hasOriKv_) {
+        if (GetCmpS2SeqSize(bIdx) == 0U) {
+            return;
+        }
+    } else if (!hasCmpKv_) {
+        if (GetOriS2SeqSize(bIdx) == 0U) {
+            return;
+        }
+    } else {
+        if ((GetOriS2SeqSize(bIdx) == 0U) && GetCmpS2SeqSize(bIdx) == 0U) {
+            return;
+        }
+    }
+
+    BatchCache bCache;
+    S1GCache s1GCache;
+    CalcBatchCache(bIdx, splitContext, bCache);
+    for (uint32_t s1GIdx = 0; s1GIdx < splitInfo.s1GBaseNum[bIdx]; s1GIdx++) {
+        CalcS1GCache(s1GIdx, splitContext, bCache, s1GCache);
+        costInfo.bN2CostOfEachBatch[bIdx] += s1GCache.s1GCost;
+        costInfo.bN2BlockOfEachBatch[bIdx] += s1GCache.s1GBlock;
+        // 更新最大S1G行开销
+        if (s1GCache.s1GCost > costInfo.maxS1GCost) {
+            costInfo.maxS1GCost = s1GCache.s1GCost;
+        }
+        if (s1GCache.s1GBlock > 0) {
+            costInfo.bN2LastBlockCostOfEachBatch[bIdx] = s1GCache.s1GLastBlockCost;
+        }
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcCostInfo(SplitContext &splitContext)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    CostInfo &costInfo = splitContext.costInfo;
+
+    if (splitInfo.isKvSeqAllZero) {
+        costInfo.totalCost = 0;
+        costInfo.totalBlockNum = 0U;
+        return;
+    }
+
+    // 计算 batch 的负载并记录，用于按batch分配，需要按行计算起止点，统计块数、负载
+    for (uint32_t bIdx = 0; bIdx < batchSize_; bIdx++) {
+        CalcBatchCost(bIdx, splitContext, costInfo);
+        costInfo.totalCost += costInfo.bN2CostOfEachBatch[bIdx] * numHeadsKv_;
+        costInfo.totalBlockNum += costInfo.bN2BlockOfEachBatch[bIdx] * numHeadsKv_;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::UpdateCursor(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    const CostInfo &costInfo = splitContext.costInfo;
+
+    bool UpdateS1G = false;
+    bool UpdateBatch = false;
+
+    // Update S2
+    if (assignContext.curS2Idx >= assignContext.s1GCache.s2End) { // 边界assignInfo.s2End是取不到的开区间
+        assignContext.curS2Idx = 0U;
+        assignContext.curS1GIdx++;
+        UpdateS1G = true;
+    }
+
+    // Update S1G
+    if (assignContext.curS1GIdx >= splitInfo.s1GBaseNum[assignContext.curBIdx]) {
+        assignContext.curS1GIdx = 0U;
+        assignContext.curBN2Idx++;
+    }
+
+    // Update Batch
+    if (assignContext.curBN2Idx == batchSize_ * numHeadsKv_) { // 所有负载全部分配完，设置最后一个核的右开区间，返回
+        assignContext.curS1GIdx = 0U;
+        assignContext.curS2Idx = 0U;
+        assignContext.isFinished = true;
+        return;
+    }
+
+    if (assignContext.curBN2Idx / numHeadsKv_ != assignContext.curBIdx) {
+        assignContext.curBIdx = assignContext.curBN2Idx / numHeadsKv_;
+        assignContext.curS1GIdx = 0U;
+        UpdateBatch = true;
+        UpdateS1G = true;
+    }
+
+    // Update Cache
+    if (UpdateBatch) {
+        CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+        assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+        assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+    }
+    if (UpdateS1G) {
+        CalcS1GCache(assignContext.curS1GIdx, splitContext, assignContext.batchCache, assignContext.s1GCache);
+        assignContext.curS2Idx = (supportFd) ? assignContext.s1GCache.oriS2Start : 0;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::AssignByBatch(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+    const CostInfo &costInfo = splitContext.costInfo;
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    while (assignContext.bN2Cost == 0 ||
+           IsWithinTolerance(assignContext.coreCache.costLimit,
+                             costInfo.bN2LastBlockCostOfEachBatch[assignContext.curBIdx] / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + assignContext.bN2Cost)) {
+        assignContext.coreCache.cost += assignContext.bN2Cost;
+        assignContext.coreCache.block += assignContext.bN2Block;
+        assignContext.curBN2Idx++;
+        // to the end
+        if (assignContext.curBN2Idx == batchSize_ * numHeadsKv_) {
+            assignContext.curS1GIdx = 0U;
+            assignContext.curS2Idx = 0U;
+            assignContext.isFinished = true;
+            return;
+        }
+
+        // next batch
+        if (assignContext.curBN2Idx / numHeadsKv_ != assignContext.curBIdx) {
+            assignContext.curBIdx = assignContext.curBN2Idx / numHeadsKv_;
+            CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+        }
+
+        assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+        assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+        assignContext.curS1GIdx = 0U;
+        CalcS1GCache(assignContext.curS1GIdx, splitContext, assignContext.batchCache, assignContext.s1GCache);
+        assignContext.curS2Idx = assignContext.s1GCache.s2Start;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::AssignByRow(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+
+    while (IsWithinTolerance(assignContext.coreCache.costLimit,
+                             assignContext.s1GCache.s1GLastBlockCost / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + assignContext.s1GCache.s1GCost)) {
+        assignContext.coreCache.cost += assignContext.s1GCache.s1GCost;
+        assignContext.coreCache.block += assignContext.s1GCache.s1GBlock;
+        // 当前batch被分配一行出去，更新剩余负载
+        assignContext.bN2Cost = assignContext.bN2Cost > assignContext.s1GCache.s1GCost ?
+                                    assignContext.bN2Cost - assignContext.s1GCache.s1GCost :
+                                    0;
+        assignContext.bN2Block = assignContext.bN2Block > assignContext.s1GCache.s1GBlock ?
+                                     assignContext.bN2Block - assignContext.s1GCache.s1GBlock :
+                                     0U;
+        // 计算新一行的信息
+        do {
+            assignContext.curS1GIdx++;
+            CalcS1GCache(assignContext.curS1GIdx, splitContext, assignContext.batchCache, assignContext.s1GCache);
+        } while (assignContext.s1GCache.s1GBlock == 0);
+        assignContext.curS2Idx = assignContext.s1GCache.s2Start;
+    }
+}
+
+int64_t SparseFlashMlaMetadataCpuKernel::CalcCurBlockCost(const AssignContext &assignContext)
+{
+    int64_t curCost = 0;
+    if (assignContext.curS2Idx < assignContext.s1GCache.cmpS2Start) {
+        curCost = assignContext.s1GCache.oriS1GNormalBlockCost;
+        if (assignContext.curS2Idx == (assignContext.s1GCache.cmpS2Start - 1U)) {
+            curCost = assignContext.s1GCache.oriS1GLastBlockCost;
+        }
+    } else {
+        curCost = assignContext.s1GCache.cmpS1GNormalBlockCost;
+        if (assignContext.curS2Idx == (assignContext.s1GCache.s2End - 1U)) {
+            curCost = assignContext.s1GCache.cmpS1GLastBlockCost;
+        }
+    }
+    return curCost;
+}
+
+void SparseFlashMlaMetadataCpuKernel::AssignByBlock(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished || !supportFd) {
+        return;
+    }
+
+    int64_t curCost = CalcCurBlockCost(assignContext);
+
+    // (costLimit - curCostOnCore) * FA_TOLERANCE_RATIO > curCost；至少分配1块
+    while (IsWithinTolerance(assignContext.coreCache.costLimit, curCost / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + curCost)) {
+        assignContext.coreCache.cost += curCost;
+        assignContext.coreCache.block++;
+        assignContext.curS2Idx++;
+        // 当前batch被分配一块出去，更新剩余负载
+        assignContext.bN2Cost = assignContext.bN2Cost - curCost;
+        // 当前行被分配一块出去，更新剩余负载
+        assignContext.s1GCache.s1GCost = assignContext.s1GCache.s1GCost - curCost;
+        assignContext.bN2Block--;
+        assignContext.s1GCache.s1GBlock--;
+        curCost = CalcCurBlockCost(assignContext);
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::ForceAssign(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+
+    int64_t curCost = CalcCurBlockCost(assignContext);
+
+    assignContext.coreCache.cost += curCost;
+    assignContext.coreCache.block++;
+    assignContext.curS2Idx++;
+    // 当前batch被分配一块出去，更新剩余负载
+    assignContext.bN2Cost = assignContext.bN2Cost - curCost;
+    assignContext.bN2Block--;
+    // 当前行被分配一块出去，更新剩余负载
+    assignContext.s1GCache.s1GCost = assignContext.s1GCache.s1GCost - curCost;
+    assignContext.s1GCache.s1GBlock--;
+    UpdateCursor(splitContext, assignContext);
+}
+
+bool SparseFlashMlaMetadataCpuKernel::IsNeedRecordFDInfo(const AssignContext &assignContext,
+                                                         const SplitResult &splitRes)
+{
+    // 切分点大概率不会刚好在行尾，因此滞后处理归约信息的统计，到下一个切分点再判断是否需要归约
+    // 核0无需处理
+    if (assignContext.curCoreIdx == 0U) {
+        return false;
+    }
+    // 无跨核行，无需处理
+    if (assignContext.curKvSplitPart <= 1U) {
+        return false;
+    }
+    // 需要归约的行还未处理完
+    if (assignContext.curBN2Idx == splitRes.bN2End[assignContext.curCoreIdx - 1U] &&
+        assignContext.curS1GIdx == splitRes.gS1End[assignContext.curCoreIdx - 1U]) {
+        return false;
+    }
+    return true;
+}
+
+void SparseFlashMlaMetadataCpuKernel::RecordFDInfo(const SplitContext &splitContext, const AssignContext &assignContext,
+                                                   SplitResult &result)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    // 需要规约的行是上一个核的切分点所在位置
+    uint32_t splitBIdx = result.bN2End[assignContext.curCoreIdx - 1U] / numHeadsKv_;
+    uint32_t splitS1GIdx = result.gS1End[assignContext.curCoreIdx - 1U];
+    uint32_t s1Size = GetS1SeqSize(splitBIdx);
+
+    // 计算归约数据的FD均衡划分信息
+    uint32_t curFdS1gSize =
+        (splitS1GIdx == splitInfo.s1GBaseNum[splitBIdx] - 1U) ?
+            (static_cast<uint64_t>(s1Size) * groupSize_ - static_cast<uint64_t>(splitS1GIdx) * mBaseSize_) :
+            mBaseSize_;
+    // 记录
+    result.maxS2SplitNum = std::max(result.maxS2SplitNum, assignContext.curKvSplitPart);
+    // 若存在头归约，则切分点一定为上一个核结束的位置
+    result.fdRes.fdBN2Idx[result.numOfFdHead] = result.bN2End[assignContext.curCoreIdx - 1U];
+    result.fdRes.fdMIdx[result.numOfFdHead] = result.gS1End[assignContext.curCoreIdx - 1U];
+    result.fdRes.fdWorkspaceIdx[result.numOfFdHead] = assignContext.preFdDataNum;
+    result.fdRes.fdS2SplitNum[result.numOfFdHead] = assignContext.curKvSplitPart;
+    result.fdRes.fdMSize[result.numOfFdHead] = curFdS1gSize;
+    result.numOfFdHead++;
+}
+
+void SparseFlashMlaMetadataCpuKernel::AssignBlocksToCore(const SplitContext &splitContext, AssignContext &assignContext,
+                                                         SplitResult &result)
+{
+    const CostInfo &costInfo = splitContext.costInfo;
+    result.firstFdDataWorkspaceIdx[assignContext.curCoreIdx] =
+        assignContext.preFdDataNum + assignContext.curKvSplitPart - 1U;
+    int64_t avgCost = assignContext.unassignedCost / (aicCoreNum_ - assignContext.curCoreIdx);
+    assignContext.coreCache = {};
+    if (!supportFd) {
+        assignContext.coreCache.costLimit = std::max(avgCost, costInfo.maxS1GCost);
+    } else {
+        assignContext.coreCache.costLimit = avgCost;
+    }
+    // 1、按整batch分配
+    AssignByBatch(splitContext, assignContext);
+    // 2、按行分配
+    AssignByRow(splitContext, assignContext);
+    // 3、按块分配
+    AssignByBlock(splitContext, assignContext);
+    // 4、强制分配
+    if (assignContext.coreCache.block == 0 && supportFd) {
+        ForceAssign(splitContext, assignContext);
+    }
+    result.bN2End[assignContext.curCoreIdx] = assignContext.curBN2Idx;
+    result.gS1End[assignContext.curCoreIdx] = assignContext.curS1GIdx;
+    result.s2End[assignContext.curCoreIdx] = assignContext.curS2Idx;
+    result.maxCost = std::max(result.maxCost, assignContext.coreCache.cost);
+    assignContext.unassignedCost -= assignContext.coreCache.cost;
+    result.maxS2GBaseNum = std::max(assignContext.coreCache.block, result.maxS2GBaseNum);
+    // 对之前的归约信息进行记录并清理
+    if (IsNeedRecordFDInfo(assignContext, result)) {
+        RecordFDInfo(splitContext, assignContext, result);
+        assignContext.preFdDataNum += assignContext.curKvSplitPart;
+        assignContext.curKvSplitPart = 1U;
+    }
+    // 更新S2切分信息
+    if (assignContext.curS2Idx > assignContext.s1GCache.s2Start &&
+        assignContext.curS2Idx <= assignContext.s1GCache.s2End) {
+        assignContext.curKvSplitPart++;
+    }
+}
+
+void SparseFlashMlaMetadataCpuKernel::CalcSplitPlan(int64_t costLimit, const SplitContext &splitContext,
+                                                    SplitResult &result)
+{
+    const CostInfo &costInfo = splitContext.costInfo;
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    if (aicCoreNum_ == 0U) {
+        return;
+    }
+    result.maxCost = 0U;
+    result.usedCoreNum = 0U;
+
+    AssignContext assignContext{};
+    assignContext.curBIdx = 0U;
+    assignContext.curS1GIdx = 0U;
+    assignContext.unassignedCost = costInfo.totalCost;
+    assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+    assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+    CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+    CalcS1GCache(assignContext.curS1GIdx, splitContext, assignContext.batchCache, assignContext.s1GCache);
+    assignContext.curS2Idx = assignContext.s1GCache.s2Start;
+    // 负载分配
+    for (uint32_t i = 0; i < aicCoreNum_; ++i) {
+        if (result.maxCost > costLimit) {
+            return;
+        }
+        if (assignContext.isFinished || assignContext.unassignedCost <= 0) {
+            break;
+        }
+        assignContext.curCoreIdx = i;
+        AssignBlocksToCore(splitContext, assignContext, result);
+    }
+    result.usedCoreNum = assignContext.curCoreIdx + 1;
+}
+
+void SparseFlashMlaMetadataCpuKernel::SplitFD(SplitResult &splitRes)
+{
+    // 计算FD的总数据量
+    uint64_t totalFDLoad = 0;
+    for (uint32_t i = 0; i < splitRes.numOfFdHead; i++) {
+        totalFDLoad += splitRes.fdRes.fdS2SplitNum[i] * splitRes.fdRes.fdMSize[i];
+    }
+    // 计算当前最大冗余vec核数
+    uint32_t emptyVectorNum = aivCoreNum_ - splitRes.numOfFdHead;
+    // 计算每个核处理的load
+    uint64_t averageLoad = (totalFDLoad + aivCoreNum_ - 1U) / aivCoreNum_; // 向上取整，避免核负载为0
+    uint32_t curCoreIndex = 0;
+    for (uint32_t i = 0; i < splitRes.numOfFdHead; i++) {
+        // 冗余vec核数为0，此时规约任务无法进行更小的切分，只能1个vec核计算1个规约任务
+        if (emptyVectorNum == 0U) {
+            splitRes.fdRes.fdIdx[curCoreIndex] = i;
+            splitRes.fdRes.fdMStart[curCoreIndex] = 0U;
+            splitRes.fdRes.fdMNum[curCoreIndex] = splitRes.fdRes.fdMSize[i];
+            curCoreIndex++;
+            continue;
+        }
+        // 计算当前归约任务所用核数，向下取整，避免使用核数超出总核数
+        uint32_t curFDVectorNum = splitRes.fdRes.fdS2SplitNum[i] * splitRes.fdRes.fdMSize[i] / averageLoad;
+        curFDVectorNum = std::max(1U, curFDVectorNum);
+        // 计算当前归约任务每个核的行数，向上取整，避免行数为0
+        uint32_t curAveMSize = (splitRes.fdRes.fdMSize[i] + curFDVectorNum - 1U) / curFDVectorNum;
+        curFDVectorNum = (splitRes.fdRes.fdMSize[i] + curAveMSize - 1U) / curAveMSize;
+        // 需要使用的vec核数与当前剩余可用vec核数取最小
+        curFDVectorNum = std::min(curFDVectorNum, emptyVectorNum + 1U); // 1: Fd任务自身带一个核
+        // FD负载分配
+        for (uint32_t vid = 0; vid < curFDVectorNum; vid++) {
+            splitRes.fdRes.fdIdx[curCoreIndex] = i;
+            splitRes.fdRes.fdMStart[curCoreIndex] = vid * curAveMSize;
+            splitRes.fdRes.fdMNum[curCoreIndex] =
+                (vid < curFDVectorNum - 1) ? curAveMSize : (splitRes.fdRes.fdMSize[i] - vid * curAveMSize);
+            curCoreIndex++;
+        }
+        // 更新冗余vec核数
+        emptyVectorNum -= (curFDVectorNum - 1U); // 1: 空余核不包含FD自身的核，要-1
+    }
+    splitRes.fdRes.fdUsedVecNum = curCoreIndex;
+}
+
+bool SparseFlashMlaMetadataCpuKernel::BalanceSchedule(SplitResult &splitRes)
+{
+    SplitContext splitContext(batchSize_);
+
+    // 1、划分基本块，统计信息
+    CalcSplitInfo(splitContext);
+    // 全空case
+    if (splitContext.splitInfo.isKvSeqAllZero) {
+        splitRes.usedCoreNum = 1U;
+        splitRes.bN2End[0] = batchSize_ * numHeadsKv_;
+        splitRes.gS1End[0] = 0U;
+        splitRes.s2End[0] = 0U;
+        return true;
+    }
+    CalcCostInfo(splitContext);
+
+    // 2、获取每个核的分配方案
+    splitRes.maxCost = INT64_MAX;
+    splitRes.usedCoreNum = 1U;
+
+    CalcSplitPlan(splitRes.maxCost, splitContext, splitRes);
+    // 3、存在FD任务，对FD进行负载均衡分配
+    if (splitRes.numOfFdHead > 0U) {
+        SplitFD(splitRes);
+    }
+    splitRes.usedCoreNum = std::max(splitRes.usedCoreNum, 1U); // 至少使用1个core
+    return true;
+}
+
+bool SparseFlashMlaMetadataCpuKernel::GenMetadata(SplitResult &splitRes)
+{
+    optiling::detail::SmlaMetadata *metadataPtr = static_cast<optiling::detail::SmlaMetadata *>(metadata_->GetData());
+    *metadataPtr = {};
+    // FA Metadata Generate
+    if (isSplitG_) {
+        for (size_t i = 0; i < aicCoreNum_; i++) {
+            // 单核s2基本块最大数量
+            metadataPtr->faMetadata[2 * i][FA_S2_MAX_NUM] = splitRes.maxS2GBaseNum;
+            metadataPtr->faMetadata[2 * i + 1][FA_S2_MAX_NUM] = splitRes.maxS2GBaseNum;
+
+            if (i >= splitRes.usedCoreNum) {
+                metadataPtr->faMetadata[2 * i][FA_CORE_ENABLE_INDEX] = 0;     // AIC disenable
+                metadataPtr->faMetadata[2 * i + 1][FA_CORE_ENABLE_INDEX] = 0; // AIC disenable
+                continue;
+            }
+            metadataPtr->faMetadata[2 * i][FA_CORE_ENABLE_INDEX] = 1;     // AIC enable
+            metadataPtr->faMetadata[2 * i + 1][FA_CORE_ENABLE_INDEX] = 1; // AIC enable
+            // FA START
+            metadataPtr->faMetadata[2 * i][FA_BN2_START_INDEX] = i == 0 ? 0 : splitRes.bN2End[i - 1];
+            metadataPtr->faMetadata[2 * i][FA_M_START_INDEX] = i == 0 ? 0 : splitRes.gS1End[i - 1];
+            metadataPtr->faMetadata[2 * i][FA_S2_START_INDEX] = i == 0 ? 0 : splitRes.s2End[i - 1];
+
+            metadataPtr->faMetadata[2 * i + 1][FA_BN2_START_INDEX] = i == 0 ? 0 : splitRes.bN2End[i - 1];
+            metadataPtr->faMetadata[2 * i + 1][FA_M_START_INDEX] = i == 0 ? 0 : splitRes.gS1End[i - 1];
+            metadataPtr->faMetadata[2 * i + 1][FA_S2_START_INDEX] = i == 0 ? 0 : splitRes.s2End[i - 1];
+            // FA END
+            metadataPtr->faMetadata[2 * i][FA_BN2_END_INDEX] = splitRes.bN2End[i];
+            metadataPtr->faMetadata[2 * i][FA_M_END_INDEX] = splitRes.gS1End[i];
+            metadataPtr->faMetadata[2 * i][FA_S2_END_INDEX] = splitRes.s2End[i];
+
+            metadataPtr->faMetadata[2 * i + 1][FA_BN2_END_INDEX] = splitRes.bN2End[i];
+            metadataPtr->faMetadata[2 * i + 1][FA_M_END_INDEX] = splitRes.gS1End[i];
+            metadataPtr->faMetadata[2 * i + 1][FA_S2_END_INDEX] = splitRes.s2End[i];
+            // firstFdDataWorkspace
+            metadataPtr->faMetadata[2 * i][FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX] = splitRes.firstFdDataWorkspaceIdx[i];
+            metadataPtr->faMetadata[2 * i + 1][FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX] =
+                splitRes.firstFdDataWorkspaceIdx[i];
+        }
+    } else {
+        for (size_t i = 0; i < aicCoreNum_; ++i) {
+            if (i >= splitRes.usedCoreNum) {
+                metadataPtr->faMetadata[i][FA_CORE_ENABLE_INDEX] = 0; // AIC disenable
+                continue;
+            }
+            metadataPtr->faMetadata[i][FA_CORE_ENABLE_INDEX] = 1; // AIC enable
+            // FA START
+            metadataPtr->faMetadata[i][FA_BN2_START_INDEX] = i == 0 ? 0 : splitRes.bN2End[i - 1];
+            metadataPtr->faMetadata[i][FA_M_START_INDEX] = i == 0 ? 0 : splitRes.gS1End[i - 1];
+            metadataPtr->faMetadata[i][FA_S2_START_INDEX] = i == 0 ? 0 : splitRes.s2End[i - 1];
+            // FA END
+            metadataPtr->faMetadata[i][FA_BN2_END_INDEX] = splitRes.bN2End[i];
+            metadataPtr->faMetadata[i][FA_M_END_INDEX] = splitRes.gS1End[i];
+            metadataPtr->faMetadata[i][FA_S2_END_INDEX] = splitRes.s2End[i];
+            // firstFdDataWorkspace
+            metadataPtr->faMetadata[i][FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX] = splitRes.firstFdDataWorkspaceIdx[i];
+        }
+    }
+
+    // FD Metadata Generate
+    for (size_t i = 0; i < aivCoreNum_; ++i) {
+        if (i >= splitRes.fdRes.fdUsedVecNum) {
+            metadataPtr->fdMetadata[i][FD_CORE_ENABLE_INDEX] = 0; // AIV disenable
+            continue;
+        }
+        metadataPtr->fdMetadata[i][FD_CORE_ENABLE_INDEX] = 1; // AIV enable
+        uint32_t curFdIdx = splitRes.fdRes.fdIdx[i];
+        metadataPtr->fdMetadata[i][FD_BN2_IDX_INDEX] = splitRes.fdRes.fdBN2Idx[curFdIdx];
+        metadataPtr->fdMetadata[i][FD_M_IDX_INDEX] = splitRes.fdRes.fdMIdx[curFdIdx];
+        metadataPtr->fdMetadata[i][FD_WORKSPACE_IDX_INDEX] = splitRes.fdRes.fdWorkspaceIdx[curFdIdx];
+        metadataPtr->fdMetadata[i][FD_WORKSPACE_NUM_INDEX] = splitRes.fdRes.fdS2SplitNum[curFdIdx];
+        metadataPtr->fdMetadata[i][FD_M_START_INDEX] = splitRes.fdRes.fdMStart[i];
+        metadataPtr->fdMetadata[i][FD_M_NUM_INDEX] = splitRes.fdRes.fdMNum[i];
+    }
+    return true;
+}
+
+namespace {
+static const char *kernelType = "SparseFlashMlaMetadata";
+REGISTER_CPU_KERNEL(kernelType, SparseFlashMlaMetadataCpuKernel);
+} // namespace
+
+}; // namespace aicpu

--- a/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.h
+++ b/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.h
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file sparse_flash_mla_metadata_aicpu.h
+ * \brief
+ */
+
+#ifndef SPARSE_FLASH_MLA_METADATA_AICPU_H
+#define SPARSE_FLASH_MLA_METADATA_AICPU_H
+
+#include <array>
+#include <string>
+#include <vector>
+#include "cpu_context.h"
+#include "cpu_kernel.h"
+#include "cpu_tensor.h"
+#include "../../common/op_kernel/sparse_flash_mla_metadata.h"
+#include "../../common/op_kernel/aicpu_common.h"
+
+namespace aicpu {
+constexpr int64_t FA_TOLERANCE_RATIO = 2;
+constexpr uint32_t COST_WEIGHT_M = 6U;
+constexpr uint32_t COST_WEIGHT_S2 = 10U;
+constexpr bool ORI_KV = false;
+constexpr bool CMP_KV = true;
+constexpr uint32_t NO_MASK = 0;
+constexpr uint32_t HAS_MASK = 1;
+
+enum BlockType : uint32_t {
+    ORI_NORMAL_BLOCK = 0,
+    ORI_TAIL_BLOCK,
+    CMP_NORMAL_BLOCK,
+    CMP_TAIL_BLOCK,
+    BLOCK_MAX_TYPE
+};
+
+enum class SparseMode : uint8_t {
+    DEFAULT_MASK = 0,
+    ALL_MASK,
+    LEFT_UP_CAUSAL,
+    RIGHT_DOWN_CAUSAL,
+    BAND,
+    SPARSE_BUTT,
+};
+
+enum class ValidSocVersion {
+    ASCEND910 = 0,
+    ASCEND950
+};
+
+template<class T>
+using Range = std::pair<T, T>;
+
+template<class T>
+using BlockCost = std::array<std::array<T, static_cast<size_t>(BLOCK_MAX_TYPE)>, static_cast<size_t>(BLOCK_MAX_TYPE)>;
+
+template<typename T>
+T Clip(T value, T minValue, T maxValue)
+{
+    if (value < minValue) {
+        return minValue;
+    }
+    if (value > maxValue) {
+        return maxValue;
+    }
+    return value;
+}
+
+template<typename T>
+inline bool IsWithinTolerance(T limit, T tolerance, T value)
+{
+    return limit + tolerance >= value;
+}
+
+// 分核功能模块输出：FD信息，包含需要归约的数据索引及其分核信息
+struct FlashDecodeResult {
+    uint32_t fdUsedVecNum { 0U };             // 归约过程使用的vector数量
+    // 1、归约任务的索引信息
+    std::vector<uint32_t> fdBN2Idx {};          // 每个归约任务的BN2索引，脚标为归约任务的序号，最大为核数-1
+    std::vector<uint32_t> fdMIdx {};            // 每个归约任务的GS1索引，脚标为归约任务的序号
+    std::vector<uint32_t> fdWorkspaceIdx {};    // 每个归约任务在workspace中的存放位置
+    std::vector<uint32_t> fdS2SplitNum {};      // 每个归约任务的S2核间切分份数，脚标为归约任务的序号
+    std::vector<uint32_t> fdMSize {};           // 每个归约任务m轴大小，脚标为归约任务的序号
+    // 2、FD负载均衡阶段，归约任务的分核（vec）信息
+    std::vector<uint32_t> fdIdx {};             // FD负载均衡阶段，每个vector处理的归约任务对应ID
+    std::vector<uint32_t> fdMStart {};          // FD负载均衡阶段，每个vector处理的归约任务的m轴起点
+    std::vector<uint32_t> fdMNum {};            // FD负载均衡阶段，每个vector处理的归约任务的m轴行数
+
+    FlashDecodeResult(uint32_t aicNum, uint32_t aivNum)
+        : fdBN2Idx(aicNum),
+        fdMIdx(aicNum),
+        fdWorkspaceIdx(aicNum),
+        fdS2SplitNum(aicNum),
+        fdMSize(aicNum),
+        fdIdx(aivNum),
+        fdMStart(aivNum),
+        fdMNum(aivNum) {}
+};
+
+// 分核功能模块输出：FA阶段的核间分核信息
+struct SplitResult {
+    uint32_t usedCoreNum { 0U };        // 使用的核数量
+    std::vector<uint32_t> bN2End {};    // 每个核处理数据的BN2结束点
+    std::vector<uint32_t> gS1End {};    // 每个核处理数据的GS1结束点
+    std::vector<uint32_t> s2End {};     // 每个核处理数据的S2结束点
+    std::vector<uint32_t> firstFdDataWorkspaceIdx {};     // 每个核第一份归约任务的存放位置
+    int64_t maxCost { 0 };            // 慢核开销
+    uint32_t numOfFdHead { 0U };        // 归约任务数量
+    uint32_t maxS2SplitNum { 0U };      // 单个归约任务最大分核数量
+    uint32_t maxS2GBaseNum { 0U };      // 单个核最大s2基本块数量
+    FlashDecodeResult fdRes { 0U, 0U };     // FD信息
+
+    SplitResult(uint32_t aicNum, uint32_t aivNum)
+        : bN2End(aicNum),
+        gS1End(aicNum),
+        s2End(aicNum),
+        firstFdDataWorkspaceIdx(aicNum),
+        fdRes(aicNum, aivNum) {};
+};
+
+// 分核功能模块内部使用：记录切分信息
+struct SplitInfo {
+    std::vector<uint32_t> s1GBaseNum {};                   // S1G方向，切了多少个基本块
+    std::vector<uint32_t> oriS2BaseNum {};                    // oriS2方向，切了多少个基本块
+    std::vector<uint32_t> cmpS2BaseNum {};                    // cmpS2方向，切了多少个基本块
+    std::vector<uint32_t> s1GTailSize {};                  // S1G方向，尾块size
+    std::vector<uint32_t> oriS2TailSize {};                   // oriS2方向，尾块size
+    std::vector<uint32_t> cmpS2TailSize {};                   // cmpS2方向，尾块size
+    bool isKvSeqAllZero { true };
+
+    explicit SplitInfo(uint32_t batchSize)
+        : s1GBaseNum(batchSize),
+        oriS2BaseNum(batchSize),
+        cmpS2BaseNum(batchSize),
+        s1GTailSize(batchSize),
+        oriS2TailSize(batchSize),
+        cmpS2TailSize(batchSize) {}
+};
+
+// 分核功能模块内部使用：记录batch的开销信息
+struct CostInfo {
+    std::vector<int64_t> bN2CostOfEachBatch {};           // 整个batch的开销
+    std::vector<uint32_t> bN2BlockOfEachBatch {};          // 整个batch的开销
+    std::vector<int64_t> bN2LastBlockCostOfEachBatch {};  // batch最后一块的开销
+    uint32_t totalBlockNum { 0U };
+    int64_t totalCost { 0 };
+    int64_t maxS1GCost { 0 };  // 记录所有S1G行中的最大开销
+
+    explicit CostInfo(uint32_t batchSize)
+        : bN2CostOfEachBatch(batchSize),
+        bN2BlockOfEachBatch(batchSize),
+        bN2LastBlockCostOfEachBatch(batchSize) {}
+};
+
+// 分核功能模块内部使用：分核过程中，case基本信息的上下文信息，组合以减少接口传参数量
+struct SplitContext {
+    SplitInfo splitInfo { 0U };
+    CostInfo costInfo { 0U };
+
+    explicit SplitContext(uint32_t batchSize)
+        : splitInfo(batchSize),
+        costInfo(batchSize) {}
+};
+
+// 分核功能模块内部使用：记录batch相关的临时信息
+struct BatchCache {
+    uint32_t bIdx { 0U };
+    uint32_t s1Size { 0U };
+    uint32_t oriS2Size { 0U };
+    uint64_t cmpRevertS2Size { 0U };
+    int64_t oriPreTokenLeftUp { 0 };
+    int64_t oriNextTokenLeftUp { 0 };
+    int64_t cmpPreTokenLeftUp { 0 };
+    int64_t cmpNextTokenLeftUp { 0 };
+    BlockCost<int64_t> typeCost {};
+};
+
+// 分核功能模块内部使用：记录当前行（S1G）的临时信息
+struct S1GCache {
+    uint32_t bIdx { 0U };
+    uint32_t s1GIdx { 0U };
+    uint32_t s2Start { 0U };
+    uint32_t s2End { 0U };
+    uint32_t oriS2Start { 0U };
+    uint32_t oriS2End { 0U };
+    uint32_t cmpS2Start { 0U };  // win部分与cmp部分的切分点
+    uint32_t cmpS2End { 0U };
+    int64_t s1GCost { 0 };
+    int64_t s1GLastBlockCost { 0 };
+    uint32_t s1GBlock { 0U };
+    uint32_t oriS1GBlock { 0U };
+    int64_t oriS1GCost { 0 };
+    int64_t oriS1GLastBlockCost { 0 };
+    int64_t oriS1GNormalBlockCost { 0 };
+    uint32_t cmpS1GBlock { 0U };
+    int64_t cmpS1GCost { 0 };
+    int64_t cmpS1GLastBlockCost { 0 };
+    int64_t cmpS1GNormalBlockCost { 0 };
+    int64_t oriS2TailSize {0};
+    int64_t cmpS2TailSize {0};
+};
+
+// 分核功能模块内部使用：记录分配过程中，当前核的负载信息
+struct CoreCache {
+    int64_t costLimit { 0 };  // 负载上限
+    int64_t cost { 0 };       // 已分配负载
+    uint32_t block { 0U };      // 已分配块数
+};
+
+// 分核功能模块内部使用：记录分配过程中的上下文信息
+struct AssignContext {
+    uint32_t curBIdx { 0U };
+    uint32_t curBN2Idx { 0U };
+    uint32_t curS1GIdx { 0U };
+    uint32_t curS2Idx { 0U };
+    uint32_t curCoreIdx { 0U };
+    int64_t unassignedCost { 0 };
+    uint32_t curKvSplitPart { 1U };
+    uint32_t preFdDataNum { 0U };
+
+    int64_t bN2Cost { 0 };
+    uint32_t bN2Block { 0U };
+    bool isFinished { false };
+    BatchCache batchCache {};
+    S1GCache s1GCache {};
+    CoreCache coreCache {};
+};
+
+class SparseFlashMlaMetadataCpuKernel : public CpuKernel {
+public:
+    SparseFlashMlaMetadataCpuKernel() = default;
+    ~SparseFlashMlaMetadataCpuKernel() = default;
+    uint32_t Compute(CpuKernelContext &ctx) override;
+
+private:
+    bool Prepare(CpuKernelContext &ctx);
+    int32_t GetQueryBatchSize();
+    void CalcOriMaskMode();
+    void CalcCmpMaskMode();
+    ValidSocVersion ProcessSocVersion();
+    bool ParamsCheck();
+    int32_t GetSumOfQuerySeq();
+    bool ParamsInit();
+    bool BalanceSchedule(SplitResult &splitRes);
+    bool GenMetadata(SplitResult &splitRes);
+    // util
+    uint32_t GetS1SeqSize(uint32_t bIdx);
+    uint32_t GetOriS2SeqSize(uint32_t bIdx);
+    uint32_t GetCmpS2SeqSize(uint32_t bIdx);
+    uint64_t GetRevertS2Size(uint32_t bIdx);
+    uint32_t GetS1Idx(uint32_t s1Size, uint32_t s1GIdx);
+    uint32_t GetBsStride(uint32_t bIdx, uint32_t s1Idx);
+    uint32_t GetOriTopkLength(uint32_t bsStride);
+    uint32_t GetCmpTopkLength(uint32_t bsStride);
+    int64_t CalcOriPreTokenLeftUp(uint32_t s1Size, uint32_t s2Size);
+    int64_t CalcOriNextTokenLeftUp(uint32_t s1Size, uint32_t s2Size);
+    int64_t CalcCmpPreTokenLeftUp(uint32_t s1Size, uint64_t s2Size);
+    int64_t CalcCmpNextTokenLeftUp(uint32_t s1Size, uint64_t s2Size);
+    Range<int64_t> CalcS2TokenRange(uint32_t s1GIdx, const BatchCache &batchCache, bool isCmpKv);
+    int64_t OriCalcCost(uint32_t basicM, uint32_t basicS2);
+    int64_t CmpCalcCost(uint32_t basicM, uint32_t basicS2);
+    void CalcCostTable(uint32_t s1NormalSize, uint32_t s2NormalSize, uint32_t s1GTailSize, uint32_t oriS2TailSize,
+        uint32_t cmpS2TailSize);
+
+    // cache calculation
+    void CalcBatchCache(uint32_t bIdx, const SplitContext &splitContext, BatchCache &batchCache);
+    void CalcOriBlockRange(const Range<int64_t> &oriS2TokenRange, const BatchCache &batchCache, S1GCache &s1GCache);
+    void CalcCmpBlockRange(const Range<int64_t> &cmpS2TokenRange, const BatchCache &batchCache, S1GCache &s1GCache);
+    void CalcOriS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo);
+    void CalcCmpS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo);
+    void GatherOriAndCmpCache(S1GCache &s1GCache);
+    void CalcS1GCache(uint32_t s1GIdx, const SplitContext &splitContext, const BatchCache &batchCache,
+        S1GCache &s1GCache);
+
+    // preprocess
+    void CalcSplitInfo(SplitContext &splitContext);
+    void CalcBatchCost(uint32_t bIdx, const SplitContext &splitContext, CostInfo &costInfo);
+    void CalcCostInfo(SplitContext &splitContext);
+
+    // assign
+    void UpdateCursor(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignByBatch(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignByRow(const SplitContext &splitContext, AssignContext &assignContext);
+    int64_t CalcCurBlockCost(const AssignContext &assignContext);
+    void AssignByBlock(const SplitContext &splitContext, AssignContext &assignContext);
+    void ForceAssign(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignBlocksToCore(const SplitContext &splitContext, AssignContext &assignContext, SplitResult &result);
+
+    // FD
+    bool IsNeedRecordFDInfo(const AssignContext &assignContext, const SplitResult &splitRes);
+    void RecordFDInfo(const SplitContext &splitContext, const AssignContext &assignContext, SplitResult &result);
+
+    // main
+    void SplitFD(SplitResult &splitRes);
+    void CalcSplitPlan(int64_t costLimit, const SplitContext &splitContext, SplitResult &result);
+
+private:
+    // input
+    Tensor *cuSeqlensQ_ = nullptr;
+    Tensor *cuSeqlensOriKv_ = nullptr;
+    Tensor *cuSeqlensCmpKv_ = nullptr;
+    Tensor *sequsedQ_ = nullptr;
+    Tensor *sequsedOriKv_ = nullptr;
+    Tensor *sequsedCmpKv_ = nullptr;
+    Tensor *cmpResidualKv_ = nullptr;
+    Tensor *oriTopkLength_ = nullptr;
+    Tensor *cmpTopkLength_ = nullptr;
+
+    // output
+    Tensor *metadata_ = nullptr;
+
+    // attributes
+    int32_t batchSize_ = 0;
+    int32_t maxSeqlenQ_ = 0;
+    int32_t numHeadsQ_ = 0;
+    int32_t maxSeqlenOriKv_ = 0;
+    int32_t maxSeqlenCmpKv_ = 0;
+    int32_t numHeadsKv_ = 1;
+    int32_t headDim_ = 0;
+    int32_t oriTopK_ = 0;
+    int32_t cmpTopK_ = 0;
+    int32_t cmpRatio_ = 1;
+    int32_t oriMaskMode_ = static_cast<int32_t>(SparseMode::BAND);
+    int32_t cmpMaskMode_ = static_cast<int32_t>(SparseMode::RIGHT_DOWN_CAUSAL);
+    int64_t oriWinLeft_ = 127;
+    int64_t oriWinRight_ = 0;
+    std::string layoutQ_ = "BSND";
+    std::string layoutKv_ = "PA_BBND";
+    bool hasOriKv_ = true;
+    bool hasCmpKv_ = true;
+    uint32_t aicCoreNum_ = optiling::AIC_CORE_MAX_NUM;
+    uint32_t aivCoreNum_ = optiling::AIV_CORE_MAX_NUM;
+
+    // attr
+    std::string socVersion_ = "Ascend950";
+    int64_t oriPreToken_ = 0;
+    int64_t oriNextToken_ = 0;
+    int64_t cmpPreToken_ = 0;
+    int64_t cmpNextToken_ = 0;
+    uint32_t groupSize_ = 0;
+    uint32_t mBaseSize_ = 0;
+    uint32_t s2BaseSize_ = 128U;
+    bool isS1G_ = true;
+    bool supportFd = false;
+    uint32_t oriAttentionMode_ = HAS_MASK;
+    uint32_t cmpAttentionMode_ = HAS_MASK;
+    BlockCost<int64_t> typeCost_ = {};
+    bool isSplitG_ = false;
+    bool isSparseOriKv_ = false;
+    bool isSparseCmpKv_ = false;
+
+private:
+    enum class ParamId : uint32_t {
+    // input
+    cuSeqlensQ = 0,
+    cuSeqlensOriKv = 1,
+    cuSeqlensCmpKv = 2,
+    sequsedQ = 3,
+    sequsedOriKv = 4,
+    sequsedCmpKv = 5,
+    cmpResidualKv = 6,
+    oriTopkLength = 7,
+    cmpTopkLength = 8,
+    // output
+    metaData = 0,
+    };
+};
+} // namespace aicpu
+
+#endif

--- a/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.json
+++ b/csrc/attention/sparse_flash_mla_metadata/op_kernel_aicpu/sparse_flash_mla_metadata_aicpu.json
@@ -1,0 +1,15 @@
+{
+    "SparseFlashMlaMetadata":{
+        "opInfo":{
+            "computeCost":"100",
+            "engine":"DNN_VM_AICPU",
+            "flagAsync":"False",
+            "flagPartial":"False",
+            "functionName":"RunCpuKernel",
+            "kernelSo":"libtransformer_aicpu_kernels.so",
+            "opKernelLib":"CUSTAICPUKernel",
+            "userDefined":"True",
+            "workspaceSize":"100"
+        }
+    }
+}

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -215,6 +215,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "vllm_quant_lightning_indexer_metadata"
         "quant_lightning_indexer_v2"
         "quant_lightning_indexer_v2_metadata"
+        "sparse_flash_mla_metadata"
         "kv_quant_sparse_attn_sharedkv"
         "kv_quant_sparse_attn_sharedkv_metadata"
         "hc_post"

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -1230,6 +1230,79 @@ auto get_valid_tensor = [](const c10::optional<at::Tensor> &tensor_opt, at::Devi
     return tensor_opt.has_value() ? tensor_opt : torch::empty({0}, torch::dtype(torch::kInt32).device(device));
 };
 
+at::Tensor npu_sparse_flash_mla_metadata_npu(
+    int64_t num_heads_q,
+    int64_t num_heads_kv,
+    int64_t head_dim,
+    const c10::optional<at::Tensor> &cu_seqlens_q,
+    const c10::optional<at::Tensor> &cu_seqlens_ori_kv,
+    const c10::optional<at::Tensor> &cu_seqlens_cmp_kv,
+    const c10::optional<at::Tensor> &seqused_q,
+    const c10::optional<at::Tensor> &seqused_ori_kv,
+    const c10::optional<at::Tensor> &seqused_cmp_kv,
+    const c10::optional<at::Tensor> &cmp_residual_kv,
+    const c10::optional<at::Tensor> &ori_topk_length,
+    const c10::optional<at::Tensor> &cmp_topk_length,
+    int64_t batch_size,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_ori_kv,
+    int64_t max_seqlen_cmp_kv,
+    int64_t ori_topk,
+    int64_t cmp_topk,
+    int64_t cmp_ratio,
+    int64_t ori_mask_mode,
+    int64_t cmp_mask_mode,
+    int64_t ori_win_left,
+    int64_t ori_win_right,
+    c10::string_view layout_q,
+    c10::string_view layout_kv,
+    bool has_ori_kv,
+    bool has_cmp_kv,
+    c10::string_view device)
+{
+    constexpr int64_t OUTPUT_SIZE = 1024;
+    at::Device output_device = at::Device(std::string(device));
+    if (cu_seqlens_q.has_value()) {
+        output_device = cu_seqlens_q.value().device();
+    } else if (cu_seqlens_ori_kv.has_value()) {
+        output_device = cu_seqlens_ori_kv.value().device();
+    } else if (cu_seqlens_cmp_kv.has_value()) {
+        output_device = cu_seqlens_cmp_kv.value().device();
+    } else if (seqused_q.has_value()) {
+        output_device = seqused_q.value().device();
+    } else if (seqused_ori_kv.has_value()) {
+        output_device = seqused_ori_kv.value().device();
+    } else if (seqused_cmp_kv.has_value()) {
+        output_device = seqused_cmp_kv.value().device();
+    }
+    at::Tensor output = torch::empty({OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(output_device));
+
+    auto cu_seqlens_q_val = get_valid_tensor(cu_seqlens_q, output_device);
+    auto cu_seqlens_ori_kv_val = get_valid_tensor(cu_seqlens_ori_kv, output_device);
+    auto cu_seqlens_cmp_kv_val = get_valid_tensor(cu_seqlens_cmp_kv, output_device);
+    auto seqused_q_val = get_valid_tensor(seqused_q, output_device);
+    auto seqused_ori_kv_val = get_valid_tensor(seqused_ori_kv, output_device);
+    auto seqused_cmp_kv_val = get_valid_tensor(seqused_cmp_kv, output_device);
+    auto cmp_residual_kv_val = get_valid_tensor(cmp_residual_kv, output_device);
+    auto ori_topk_length_val = get_valid_tensor(ori_topk_length, output_device);
+    auto cmp_topk_length_val = get_valid_tensor(cmp_topk_length, output_device);
+
+    std::string layout_q_str = std::string(layout_q);
+    std::string layout_kv_str = std::string(layout_kv);
+    char *layout_q_ptr = const_cast<char *>(layout_q_str.c_str());
+    char *layout_kv_ptr = const_cast<char *>(layout_kv_str.c_str());
+
+    EXEC_NPU_CMD(aclnnSparseFlashMlaMetadata, cu_seqlens_q_val, cu_seqlens_ori_kv_val,
+                    cu_seqlens_cmp_kv_val, seqused_q_val, seqused_ori_kv_val,
+                    seqused_cmp_kv_val, cmp_residual_kv_val, ori_topk_length_val,
+                    cmp_topk_length_val, num_heads_q, num_heads_kv, head_dim,
+                    batch_size, max_seqlen_q, max_seqlen_ori_kv, max_seqlen_cmp_kv,
+                    ori_topk, cmp_topk, cmp_ratio, ori_mask_mode, cmp_mask_mode,
+                    ori_win_left, ori_win_right, layout_q_ptr, layout_kv_ptr,
+                    has_ori_kv, has_cmp_kv, output);
+    return output;
+}
+
 at::Tensor npu_sparse_attn_sharedkv_metadata_npu(
     int64_t num_heads_q,
     int64_t num_heads_kv,
@@ -3250,6 +3323,40 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         ") -> (Tensor sparse_indices, Tensor sparse_values)"
         );
     ops.impl("npu_quant_lightning_indexer_v2", torch::kPrivateUse1, &vllm_ascend::npu_quant_lightning_indexer_v2_npu);
+
+    ops.def(
+        "npu_sparse_flash_mla_metadata("
+            "int num_heads_q, "
+            "int num_heads_kv, "
+            "int head_dim, "
+            "Tensor? cu_seqlens_q=None, "
+            "Tensor? cu_seqlens_ori_kv=None, "
+            "Tensor? cu_seqlens_cmp_kv=None, "
+            "Tensor? seqused_q=None, "
+            "Tensor? seqused_ori_kv=None, "
+            "Tensor? seqused_cmp_kv=None, "
+            "Tensor? cmp_residual_kv=None, "
+            "Tensor? ori_topk_length=None, "
+            "Tensor? cmp_topk_length=None, "
+            "int batch_size=0, "
+            "int max_seqlen_q=0, "
+            "int max_seqlen_ori_kv=0, "
+            "int max_seqlen_cmp_kv=0, "
+            "int ori_topk=0, "
+            "int cmp_topk=0, "
+            "int cmp_ratio=4, "
+            "int ori_mask_mode=4, "
+            "int cmp_mask_mode=3, "
+            "int ori_win_left=128, "
+            "int ori_win_right=0, "
+            "str layout_q=\"BSND\", "
+            "str layout_kv=\"PA_ND\", "
+            "bool has_ori_kv=True, "
+            "bool has_cmp_kv=True, "
+            "str device=\"npu\""
+        ") -> (Tensor metadata)"
+        );
+    ops.impl("npu_sparse_flash_mla_metadata", torch::kPrivateUse1, &vllm_ascend::npu_sparse_flash_mla_metadata_npu);
 
     ops.def(
         "npu_sparse_attn_sharedkv("

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1018,6 +1018,62 @@ std::tuple<at::Tensor, at::Tensor> npu_sparse_attn_sharedkv_meta(const at::Tenso
     return output;
 }
 
+at::Tensor npu_sparse_flash_mla_metadata_meta(
+    int64_t num_heads_q,
+    int64_t num_heads_kv,
+    int64_t head_dim,
+    const c10::optional<at::Tensor> &cu_seqlens_q,
+    const c10::optional<at::Tensor> &cu_seqlens_ori_kv,
+    const c10::optional<at::Tensor> &cu_seqlens_cmp_kv,
+    const c10::optional<at::Tensor> &seqused_q,
+    const c10::optional<at::Tensor> &seqused_ori_kv,
+    const c10::optional<at::Tensor> &seqused_cmp_kv,
+    const c10::optional<at::Tensor> &cmp_residual_kv,
+    const c10::optional<at::Tensor> &ori_topk_length,
+    const c10::optional<at::Tensor> &cmp_topk_length,
+    int64_t batch_size,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_ori_kv,
+    int64_t max_seqlen_cmp_kv,
+    int64_t ori_topk,
+    int64_t cmp_topk,
+    int64_t cmp_ratio,
+    int64_t ori_mask_mode,
+    int64_t cmp_mask_mode,
+    int64_t ori_win_left,
+    int64_t ori_win_right,
+    c10::string_view layout_q,
+    c10::string_view layout_kv,
+    bool has_ori_kv,
+    bool has_cmp_kv,
+    const c10::string_view device)
+{
+    constexpr int64_t OUTPUT_SIZE = 1024;
+    at::Tensor output;
+    if (cu_seqlens_q.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(cu_seqlens_q.value().device()));
+    } else if (cu_seqlens_ori_kv.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(cu_seqlens_ori_kv.value().device()));
+    } else if (cu_seqlens_cmp_kv.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(cu_seqlens_cmp_kv.value().device()));
+    } else if (seqused_q.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(seqused_q.value().device()));
+    } else if (seqused_ori_kv.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(seqused_ori_kv.value().device()));
+    } else if (seqused_cmp_kv.has_value()) {
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(seqused_cmp_kv.value().device()));
+    } else {
+        auto deviceOri = at::Device(std::string(device));
+        std::string device_str = "meta";
+        if (deviceOri.has_index()) {
+            device_str += ":";
+            device_str += std::to_string(deviceOri.index());
+        }
+        output = at::empty_symint(c10::SymDimVector{OUTPUT_SIZE}, torch::dtype(torch::kInt32).device(at::Device(device_str)));
+    }
+    return output;
+}
+
 at::Tensor npu_sparse_attn_sharedkv_metadata_meta(
     int64_t num_heads_q,
     int64_t num_heads_kv,
@@ -2138,6 +2194,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_vllm_quant_lightning_indexer_metadata", &vllm_ascend::meta::npu_vllm_quant_lightning_indexer_metadata_meta);
     ops.impl("npu_quant_lightning_indexer_v2", &vllm_ascend::meta::npu_quant_lightning_indexer_v2_meta);
     ops.impl("npu_quant_lightning_indexer_v2_metadata", &vllm_ascend::meta::npu_quant_lightning_indexer_v2_metadata_meta);
+    ops.impl("npu_sparse_flash_mla_metadata", &vllm_ascend::meta::npu_sparse_flash_mla_metadata_meta);
     ops.impl("npu_sparse_attn_sharedkv", &vllm_ascend::meta::npu_sparse_attn_sharedkv_meta);
     ops.impl("npu_sparse_attn_sharedkv_metadata", &vllm_ascend::meta::npu_sparse_attn_sharedkv_metadata_meta);
     ops.impl("npu_hc_post", &vllm_ascend::meta::npu_hc_post_meta);

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_flash_mla_metadata.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_flash_mla_metadata.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Standalone output and input-validation contracts for the A5 metadata op."""
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from tests.ut.ops.helpers.c_ascend_loader import ensure_c_ascend_loaded
+from vllm_ascend.device.hardware_profile import DeviceAdaptorFamily, get_current_hardware_profile
+
+
+@pytest.fixture
+def metadata_op():
+    if get_current_hardware_profile().device_adaptor_family != DeviceAdaptorFamily.FP8_OPTIMIZED:
+        pytest.skip("SparseFlashMlaMetadata requires A5")
+    ensure_c_ascend_loaded(required_op="npu_sparse_flash_mla_metadata")
+    return torch.ops._C_ascend.npu_sparse_flash_mla_metadata
+
+
+def _inputs(selected_count):
+    return dict(
+        num_heads_q=4,
+        num_heads_kv=1,
+        head_dim=512,
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32, device="npu"),
+        seqused_ori_kv=torch.tensor([selected_count], dtype=torch.int32, device="npu"),
+        ori_topk_length=torch.tensor([[selected_count]], dtype=torch.int32, device="npu"),
+        batch_size=1,
+        max_seqlen_q=1,
+        max_seqlen_ori_kv=selected_count,
+        max_seqlen_cmp_kv=0,
+        ori_topk=2051,
+        cmp_topk=0,
+        cmp_ratio=1,
+        ori_mask_mode=3,
+        cmp_mask_mode=3,
+        ori_win_left=0,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_BBND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device="npu",
+    )
+
+
+@pytest.mark.parametrize("selected_count", [1, 128, 2048])
+@torch.inference_mode()
+def test_metadata_output_contract(metadata_op, selected_count):
+    output = metadata_op(**_inputs(selected_count))
+    torch.npu.synchronize()
+    assert output.shape == (1024,)
+    assert output.dtype == torch.int32
+    assert output.device.type == "npu"
+
+
+@torch.inference_mode()
+def test_metadata_rejects_unsupported_head_dimension(metadata_op):
+    inputs = _inputs(128)
+    inputs["head_dim"] = 511
+    with pytest.raises(RuntimeError):
+        metadata_op(**inputs)
+        torch.npu.synchronize()

--- a/tests/ut/ops/helpers/c_ascend_loader.py
+++ b/tests/ut/ops/helpers/c_ascend_loader.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Load the ``_C_ascend`` torch extension for tests that call the ops.
+
+``vllm_ascend`` loads ``vllm_ascend_C`` lazily (``enable_custom_op`` is only
+invoked during engine startup), so a plain ``import vllm_ascend`` does NOT
+register ``torch.ops._C_ascend``. Tests that call the compiled ops must load
+the extension explicitly.
+
+This module itself only imports torch; the vllm_ascend import happens inside
+the function so pure-torch reference tests stay dependency-free.
+"""
+
+from __future__ import annotations
+
+
+def ensure_c_ascend_loaded(required_op: str) -> None:
+    """Load ``vllm_ascend_C`` and register ``torch.ops._C_ascend``.
+
+    Uses the same bootstrap path as the engine (``enable_custom_op``). When
+    the engine gate skips the import (Ascend 950 / batch-invariant mode), the
+    extension is still imported directly so the compiled ops remain testable.
+    """
+    from vllm_ascend.utils import bootstrap_custom_op_env, enable_custom_op
+
+    if not enable_custom_op():
+        bootstrap_custom_op_env()
+        import vllm_ascend.vllm_ascend_C  # noqa: F401
+
+    import torch
+
+    if not hasattr(torch.ops, "_C_ascend") or not hasattr(torch.ops._C_ascend, required_op):
+        raise RuntimeError(
+            f"torch.ops._C_ascend.{required_op} is not registered. Rebuild the "
+            "torch extension (COMPILE_CUSTOM_KERNELS=1 pip install -e . "
+            "--no-build-isolation) and verify with "
+            "'python -c \"import vllm_ascend.vllm_ascend_C\"'."
+        )


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Add `npu_sparse_flash_mla_metadata` for A5 sparse MLA attention. Include the shared metadata ABI, input validation, host/AICPU implementation, ACLNN and PyTorch bindings, build registration, and examples.

The attention consumer is tracked in #16242. This PR contains the metadata operator only: 25 files, +4264/-0 lines, one signed-off commit on main. The larger change keeps the operator, ABI, build support, and tests together; model integration and other pending PRs are excluded.

### Does this PR introduce _any_ user-facing change?

Yes. A new custom operator generates metadata consumed by the sparse flash MLA operator on A5. No model or serving configuration is enabled by this PR alone.

### How was this patch tested?

- Python AST/Ruff, C++ clang-format, and `git diff --check` passed for the relevant changes.
- Added A5 tests for output shape/dtype/device, selected-count boundaries, and rejection of an unsupported head dimension:

  ```bash
  pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_flash_mla_metadata.py
  ```

- A5 device execution is pending. CPU integration tests are not a substitute for this operator's hardware validation.
- The full format suite is not yet green: metadata shape-lint findings remain.

Draft while these validation and lint items are completed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
