### PR TITLE
[Feature][Ops] Support NoPE in sparse flash attention on A2/A3

### DIFF
--- a/csrc/attention/sparse_flash_attention/op_host/sparse_flash_attention_tiling.cpp
+++ b/csrc/attention/sparse_flash_attention/op_host/sparse_flash_attention_tiling.cpp
@@ -370,6 +370,7 @@ void SFAMlaTiling::FillTilingBaseParamsMla()
     tilingData_.baseParams.set_returnSoftmaxLse(sfaInfo_->returnSoftmaxLse);
     tilingData_.baseParams.set_isActualLenDimsNull(sfaInfo_->actualQSeqLenFlag ? 0U : 1U);
     tilingData_.baseParams.set_isActualLenDimsKVNull(sfaInfo_->actualSeqLenFlag ? 0U : 1U);
+    tilingData_.baseParams.set_ropeHeadDim(sfaInfo_->ropeHeadDim);
 }
 
 // for flash decode
@@ -464,6 +465,9 @@ void SFAMlaTiling::GetWorkspaceSize()
         workspaceSize_ += preLoadNum * mBaseSize_ * actCoreNum * nUpdateElemSize;
         workspaceSize_ += preLoadNum * mBaseSize_ * actCoreNum * softmaxSumElemSize;
         // topk BlkSize == 1场景, 需要额外空间缓存离散聚合的值
+        // kvMergeGm_ is sized for the maximal rope=64 form so its stride
+        // matches the kernel-side 512*576 layout. With rope=0 the rope segment
+        // stays unused; the stride is unchanged so host and kernel agree.
         //              bufNum  s2Base   D   dRope  sizeOf(half)
         // 4:bufNum  512:s2Base  512:D  64:dRope  2:sizeOf(half)
         workspaceSize_ += 4 * 512 * (512 + 64) * 2 * actCoreNum;
@@ -801,6 +805,13 @@ ge::graphStatus SFATilingCheck::CheckRopeExistence()
     OP_CHECK_IF((opParamInfo_.queryRope.tensor == nullptr && opParamInfo_.keyRope.tensor != nullptr),
         OP_LOGE(opName_, "QueryRope is null, but keyRope exists, they should be both null or exist."),
         return ge::GRAPH_FAILED);
+    if (opParamInfo_.queryRope.tensor == nullptr && opParamInfo_.keyRope.tensor == nullptr) {
+        if (isA5_) {
+            OP_LOGE(opName_, "In A5 situation, queryRope and keyRope should not be null.");
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
+    }
     OP_CHECK_IF(opParamInfo_.keyRope.desc == nullptr || opParamInfo_.queryRope.desc == nullptr,
         OP_LOGE(opName_, "In Mla situation, desc of keyRope and queryRope should not be null"),
         return ge::GRAPH_FAILED);
@@ -937,8 +948,12 @@ void SFATilingCheck::SetSFAShapeCompare()
     keyShapeCmp_ = opParamInfo_.key.shape->GetStorageShape();
     valueShapeCmp_ = opParamInfo_.value.shape->GetStorageShape();
     attenOutShapeCmp_ = opParamInfo_.attenOut.shape->GetStorageShape();
-    queryRopeShapeCmp_ = opParamInfo_.queryRope.tensor->GetStorageShape();
-    keyRopeShapeCmp_ = opParamInfo_.keyRope.tensor->GetStorageShape();
+    if (opParamInfo_.queryRope.tensor != nullptr) {
+        queryRopeShapeCmp_ = opParamInfo_.queryRope.tensor->GetStorageShape();
+    }
+    if (opParamInfo_.keyRope.tensor != nullptr) {
+        keyRopeShapeCmp_ = opParamInfo_.keyRope.tensor->GetStorageShape();
+    }
     softmaxMaxShapeCmp_ = opParamInfo_.softmaxMax.shape->GetStorageShape();
     softmaxSumShapeCmp_ = opParamInfo_.softmaxSum.shape->GetStorageShape();
 }
@@ -1098,6 +1113,9 @@ ge::graphStatus SFATilingCheck::CheckSoftmaxSum()
 
 ge::graphStatus SFATilingCheck::CheckQRope()
 {
+    if (opParamInfo_.queryRope.tensor == nullptr) {
+        return ge::GRAPH_SUCCESS;
+    }
     if (ge::GRAPH_SUCCESS != CheckDTypeConsistency(opParamInfo_.queryRope.desc->GetDataType(),
         inputQType_, QUERY_ROPE_NAME) ||
         ge::GRAPH_SUCCESS != CheckQRopeShape()) {
@@ -1194,6 +1212,13 @@ ge::graphStatus SFATilingCheck::CheckVAndKRopeShape()
 
 ge::graphStatus SFATilingCheck::CheckVAndKRope()
 {
+    if (opParamInfo_.keyRope.tensor == nullptr) {
+        if (ge::GRAPH_SUCCESS != CheckDTypeConsistency(opParamInfo_.value.desc->GetDataType(),
+            inputKvType_, VALUE_NAME)) {
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
+    }
     if (ge::GRAPH_SUCCESS != CheckDTypeConsistency(opParamInfo_.value.desc->GetDataType(),
         inputKvType_, VALUE_NAME) ||
         ge::GRAPH_SUCCESS != CheckDTypeConsistency(opParamInfo_.keyRope.desc->GetDataType(),
@@ -1349,9 +1374,15 @@ ge::graphStatus SFATilingCheck::CheckFeatureMlaNoQuantShape() const
         OP_LOGE(opName_, "qk_head_dim[%u] should be equal to v_head_dim[%u]", qkHeadDim_, vHeadDim_),
         return ge::GRAPH_FAILED);
 
-    OP_CHECK_IF(ropeHeadDim_ != 64,
-        OP_LOGE(opName_, "rope_head_dim should be 64, but got %u", ropeHeadDim_),
-        return ge::GRAPH_FAILED);
+    if (isA5_) {
+        OP_CHECK_IF(ropeHeadDim_ != 64,
+            OP_LOGE(opName_, "rope_head_dim should be 64, but got %u", ropeHeadDim_),
+            return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(ropeHeadDim_ != 0 && ropeHeadDim_ != 64,
+            OP_LOGE(opName_, "rope_head_dim should be 0 or 64 for A2/A3, but got %u", ropeHeadDim_),
+            return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -1534,11 +1565,12 @@ ge::graphStatus SFAInfoParser::CheckRequiredInOutExistence() const
                return ge::GRAPH_FAILED);
     OP_CHECK_IF(opParamInfo_.softmaxSum.desc == nullptr, OP_LOGE(opName_, "Desc of tensor softmaxSum is nullptr"),
                return ge::GRAPH_FAILED);
-    OP_CHECK_IF(opParamInfo_.queryRope.tensor == nullptr, OP_LOGE(opName_, "Shape of queryRope is nullptr"),
-               return ge::GRAPH_FAILED);
-    OP_CHECK_IF(opParamInfo_.queryRope.desc == nullptr, OP_LOGE(opName_, "Desc of queryRope is nullptr"),
-               return ge::GRAPH_FAILED);
-
+    if (isA5_) {
+        OP_CHECK_IF(opParamInfo_.queryRope.tensor == nullptr, OP_LOGE(opName_, "Shape of queryRope is nullptr"),
+                return ge::GRAPH_FAILED);
+        OP_CHECK_IF(opParamInfo_.queryRope.desc == nullptr, OP_LOGE(opName_, "Desc of queryRope is nullptr"),
+                return ge::GRAPH_FAILED);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -1869,6 +1901,10 @@ ge::graphStatus SFAInfoParser::GetValueHeadDim()
 
 ge::graphStatus SFAInfoParser::GetRopeHeadDim()
 {
+    if (opParamInfo_.queryRope.tensor == nullptr) {
+        ropeHeadDim_ = 0;
+        return ge::GRAPH_SUCCESS;
+    }
     if (queryShape_.GetDimNum() != queryRopeShape_.GetDimNum()) {
         OP_LOGE(opName_, "The dimensions of query and query_rope should be equal, but query has dimension %zu while query_rope has dimension %zu.",
                 queryShape_.GetDimNum(), queryRopeShape_.GetDimNum());
@@ -1935,7 +1971,9 @@ void SFAInfoParser::SetSFAShape()
     keyShape_ = opParamInfo_.key.shape->GetStorageShape();
     valueShape_ = opParamInfo_.value.shape->GetStorageShape();
     sparseIndicesShape_ = opParamInfo_.sparseIndices.shape->GetStorageShape();
-    queryRopeShape_ = opParamInfo_.queryRope.tensor->GetStorageShape();
+    if (opParamInfo_.queryRope.tensor != nullptr) {
+        queryRopeShape_ = opParamInfo_.queryRope.tensor->GetStorageShape();
+    }
 }
 
 ge::graphStatus SFAInfoParser::GetGSize()

--- a/csrc/attention/sparse_flash_attention/op_host/sparse_flash_attention_tiling.h
+++ b/csrc/attention/sparse_flash_attention/op_host/sparse_flash_attention_tiling.h
@@ -168,6 +168,7 @@ TILING_DATA_FIELD_DEF(int64_t, sparseBlockSize)
 TILING_DATA_FIELD_DEF(uint32_t, sparseBlockCount)
 TILING_DATA_FIELD_DEF(uint32_t, isActualLenDimsNull)
 TILING_DATA_FIELD_DEF(uint32_t, isActualLenDimsKVNull)
+TILING_DATA_FIELD_DEF(uint32_t, ropeHeadDim)
 END_TILING_DATA_DEF
 REGISTER_TILING_DATA_CLASS(SparseFlashAttentionBaseParamsMlaOp, SparseFlashAttentionBaseParamsMla)
 

--- a/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_kernel_mla.h
+++ b/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_kernel_mla.h
@@ -217,7 +217,7 @@ template <typename SFAT> __aicore__ inline void SparseFlashAttentionMla<SFAT>::I
     constInfo.s2BaseSize = tilingData->innerSplitParams.s2BaseSize;
     constInfo.kvHeadNum = kvHeadNum;
     constInfo.headDim = headDim;
-    constInfo.headDimRope = headDimRope;
+    constInfo.headDimRope = tilingData->baseParams.ropeHeadDim;
     constInfo.sparseBlockSize = tilingData->baseParams.sparseBlockSize;
     constInfo.sparseBlockCount = tilingData->baseParams.sparseBlockCount;
     constInfo.sparseMode = tilingData->baseParams.sparseMode;
@@ -400,7 +400,7 @@ template <typename SFAT> __aicore__ inline void SparseFlashAttentionMla<SFAT>::U
 template <typename SFAT>
 __aicore__ inline void SparseFlashAttentionMla<SFAT>::UpdateInner(uint32_t &s2End, uint32_t &curS2End,
                                                                                   uint32_t s1Idx, bool isEnd)
-{ 
+{
     uint32_t s1BaseSize = 1;
     int64_t s1Offset = s1BaseSize * s1Idx;
     int64_t s2LastToken = Min(s1Offset + tempLoopInfo.nextTokensPerBatch + s1BaseSize,tempLoopInfo.curActualSeqLenOri);
@@ -415,7 +415,7 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::Init(__gm__ uint8_t *query
                        __gm__ uint8_t *sparseIndices, __gm__ uint8_t *actualSeqLengthsQ,
                        __gm__ uint8_t *actualSeqLengths, __gm__ uint8_t *blockTable,
                        __gm__ uint8_t *queryRope, __gm__ uint8_t *keyRope,
-                       __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxMax, __gm__ uint8_t *softmaxSum, 
+                       __gm__ uint8_t *attentionOut, __gm__ uint8_t *softmaxMax, __gm__ uint8_t *softmaxSum,
                        __gm__ uint8_t *workspace, const SparseFlashAttentionTilingDataMla *__restrict tiling,
                        __gm__ uint8_t *gmTiling, TPipe *tPipe)
 {
@@ -443,8 +443,10 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::Init(__gm__ uint8_t *query
     queryGm.SetGlobalBuffer((__gm__ Q_T *)query);
     keyGm.SetGlobalBuffer((__gm__ KV_T *)keyPtr);
     valueGm.SetGlobalBuffer((__gm__ KV_T *)valuePtr);
-    qRopeGm.SetGlobalBuffer((__gm__ Q_ROPE_T *)queryRope);
-    kRopeGm.SetGlobalBuffer((__gm__ K_ROPE_T *)keyRope);
+    if (constInfo.headDimRope > 0) {
+        qRopeGm.SetGlobalBuffer((__gm__ Q_ROPE_T *)queryRope);
+        kRopeGm.SetGlobalBuffer((__gm__ K_ROPE_T *)keyRope);
+    }
 
     attentionOutGm.SetGlobalBuffer((__gm__ OUT_T *)attentionOut);
     softmaxMaxGm.SetGlobalBuffer((__gm__ T *)softmaxMax);
@@ -553,7 +555,7 @@ template <typename SFAT> __aicore__ inline void SparseFlashAttentionMla<SFAT>::I
     bool setStart=false;
 	targetBaseNum = (currCoreIdx + 1) * avgBaseNum;  // 计算当前的目标权重
     uint32_t targetStartBaseNum = targetBaseNum-avgBaseNum;
-    for (uint32_t bN2Idx = 0; bN2Idx < constInfo.batchSize * constInfo.kvHeadNum; bN2Idx++) { 
+    for (uint32_t bN2Idx = 0; bN2Idx < constInfo.batchSize * constInfo.kvHeadNum; bN2Idx++) {
         uint32_t bIdx = bN2Idx / constInfo.kvHeadNum;
 		actBatchS1 = GetBalanceActualSeqLengths(actualSeqLengthsQGm, bIdx);
         for (uint32_t s1GIdx = 0; s1GIdx < actBatchS1; s1GIdx++) {
@@ -628,8 +630,8 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::CalcParams(uint32_t loop, 
     info.isBmm2Output = false;
 
     info.actS1Size = tempLoopInfo.actS1Size;
-    
-    
+
+
     info.actMBaseSize = constInfo.mBaseSize;
     uint32_t remainedGS1Size = tempLoopInfo.actS1Size * constInfo.gSize - tempLoopInfo.gS1Idx;
     if (remainedGS1Size <= constInfo.mBaseSize && remainedGS1Size > 0) {
@@ -673,13 +675,17 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::CalcParams(uint32_t loop, 
     info.tndBIdxOffsetForKV = actualSeqKVPrefixSum * constInfo.kvHeadNum * headDim;
 
     if (info.isFirstSInnerLoop) {
-        uint64_t tndBIdxRopeOffsetForQ = actualSeqQPrefixSum * constInfo.qHeadNum * headDimRope;
         tensorACoreOffset = info.tndBIdxOffsetForQ + info.gS1Idx * headDim;
-        tensorARopeCoreOffset = tndBIdxRopeOffsetForQ + info.gS1Idx * headDimRope;
-        
-        uint64_t tndBIdxRopeOffsetForK = actualSeqKVPrefixSum * constInfo.kvHeadNum * headDimRope;
         tensorBCoreOffset = info.tndBIdxOffsetForKV + info.n2Idx * headDim;
-        tensorBRopeCoreOffset = tndBIdxRopeOffsetForK + info.n2Idx * headDimRope;
+        if (constInfo.headDimRope > 0) {
+            uint64_t tndBIdxRopeOffsetForQ = actualSeqQPrefixSum * constInfo.qHeadNum * constInfo.headDimRope;
+            tensorARopeCoreOffset = tndBIdxRopeOffsetForQ + info.gS1Idx * constInfo.headDimRope;
+            uint64_t tndBIdxRopeOffsetForK = actualSeqKVPrefixSum * constInfo.kvHeadNum * constInfo.headDimRope;
+            tensorBRopeCoreOffset = tndBIdxRopeOffsetForK + info.n2Idx * constInfo.headDimRope;
+        } else {
+            tensorARopeCoreOffset = 0;
+            tensorBRopeCoreOffset = 0;
+        }
         if (constInfo.sparseMode == 3) {
             threshold = static_cast<int64_t>(tempLoopInfo.nextTokensPerBatch) + info.gS1Idx / constInfo.gSize + 1;
         } else {
@@ -927,7 +933,7 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::GetAxisStartIdx(uint32_t b
     uint32_t s1GPrevBaseNum = (actualSeqQPrev * constInfo.gSize + constInfo.mBaseSize - 1) / constInfo.mBaseSize;
     constInfo.bN2Start = bN2EndPrev;
     constInfo.gS1Start = s1GEndPrev;
-    
+
     constInfo.s2Start = 0;
     if (s1GEndPrev >= s1GPrevBaseNum - 1) { // 上个核把S1G处理完了
         constInfo.gS1Start = 0;
@@ -944,7 +950,7 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::CalcSinnerTopKBegin(RunInf
     if constexpr (TEMPLATE_MODE == V_TEMPLATE) {
         return;
     }
-    
+
     uint64_t thresholdSparseCount = (info.threshold + constInfo.sparseBlockSize - 1) / constInfo.sparseBlockSize;
     uint64_t validCount = (constInfo.sparseBlockCount > thresholdSparseCount) ? thresholdSparseCount : constInfo.sparseBlockCount;
 
@@ -974,7 +980,7 @@ __aicore__ inline void SparseFlashAttentionMla<SFAT>::CalcSinnerTopKBegin(RunInf
         info.curOffsetInSparseBlock = 0;
         firstVaildFlag = true;
     }
-    
+
     for (uint64_t topkIdx = curTopKIdx + 1; topkIdx < validCount; topkIdx++) {
         int32_t sparseIndices = topKGm.GetValue(info.topKBaseOffset + topkIdx);
         if (sparseIndices == -1) {

--- a/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_cube_mla.h
+++ b/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_cube_mla.h
@@ -73,7 +73,7 @@ template <typename T, SFA_LAYOUT SRC_LAYOUT>
 __aicore__ inline void DataCopyPA(LocalTensor<T> &dstTensor,  //l1
                                   GlobalTensor<T> &srcTensor, //gm
                                   GlobalTensor<int32_t> &blockTableGm,
-                                  const PAShape &shape,       // blockSize, headNum, headDim                           
+                                  const PAShape &shape,       // blockSize, headNum, headDim
                                   const Position &startPos)   // bacthIdx nIdx curSeqIdx
 {
     uint32_t copyFinishRowCnt = 0;
@@ -106,7 +106,7 @@ __aicore__ inline void DataCopyPA(LocalTensor<T> &dstTensor,  //l1
         LocalTensor<T> tmpDstTensor = dstTensor[copyFinishRowCnt * blockElementCnt];
         GlobalTensor<T> tmpSrcTensor = srcTensor[offset];
 
-        DataCopyGmNDToL1<T>(tmpDstTensor, tmpSrcTensor, copyRowCnt, shape.copyRowNumAlign, dValue, srcDValue);                     
+        DataCopyGmNDToL1<T>(tmpDstTensor, tmpSrcTensor, copyRowCnt, shape.copyRowNumAlign, dValue, srcDValue);
         copyFinishRowCnt += copyRowCnt;
         curS2Idx += copyRowCnt;
     }
@@ -249,6 +249,7 @@ private:
                                                uint32_t copyTotalRowCntAlign, uint32_t copyStartRowCnt,
                                                uint32_t nActCopyRowCount, uint32_t copyStartColumnCount,
                                                uint32_t copyColumnCount);
+    __aicore__ inline void ComputeMm1NoRope(const RunInfo &info, const MSplitInfo mSplitInfo);
     __aicore__ inline void LoadDataMm1A(LocalTensor<KV_T> &aL0Tensor, LocalTensor<KV_T> &aL1Tensor, uint32_t idx,
                                         uint32_t kSplitSize, uint32_t mSize, uint32_t kSize);
     __aicore__ inline void LoadDataMm1B(LocalTensor<KV_T> &bL0Tensor, LocalTensor<KV_T> &bL1Tensor, uint32_t idx,
@@ -540,7 +541,7 @@ __aicore__ inline void SFAMatmulService<SFAT>::CalcTopKBlockInfo(
             if (sparseIndices == -1) {
                 break;
             }
-            
+
             uint64_t blockBegin = sparseIndices * constInfo.sparseBlockSize;
             if (blockBegin >= info.threshold) {
                 continue;
@@ -557,6 +558,189 @@ __aicore__ inline void SFAMatmulService<SFAT>::CalcTopKBlockInfo(
     }
 }
 
+// rope=0 only: the K axis holds just the 512-wide nope part, split as 256x2 in L1 and 128x2 in L0.
+template <typename SFAT>
+__aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1NoRope(const RunInfo &info, const MSplitInfo mSplitInfo)
+{
+    uint32_t mSize = mSplitInfo.nBufferDealM;
+    uint32_t mL1Size = M_SPLIT_SIZE;
+    uint32_t mL1SizeAlign = SFAAlign(M_SPLIT_SIZE, 16U);
+    uint32_t mL1Loops = (mSize + M_SPLIT_SIZE - 1) / M_SPLIT_SIZE;
+
+    uint32_t nSize = info.actualSingleProcessSInnerSize;
+    uint32_t nL1Size = N_SPLIT_SIZE;
+    uint32_t nL1SizeAlign = SFAAlign(N_SPLIT_SIZE, 16U);
+    uint32_t nL1Loops = (nSize + N_SPLIT_SIZE - 1) / N_SPLIT_SIZE;
+
+    const uint32_t kSize = constInfo.headDim; // 512
+    const uint32_t kL1Size = kSize >> 1;      // 256: the K axis is split into two L1 segments
+    const uint32_t kL1Loops = 2;
+    const uint32_t kL0Size = 128;
+    const uint32_t kL0Loops = kL1Size / kL0Size; // 256/128 = 2
+
+    LocalTensor<KV_T> bL1Tensor;
+    uint32_t ka = 0;
+
+    uint32_t curTopKIdx = info.curTopKIdx;
+    uint64_t curOffsetInSparseBlock = info.curOffsetInSparseBlock;
+    uint32_t copyRowCnt = 0;
+    int64_t idInTopK = topKGm.GetValue(info.topKBaseOffset + curTopKIdx);
+
+    uint32_t curTopKIdxTmp = 0;
+    uint64_t curOffsetInSparseBlockTmp = 0;
+    uint32_t copyRowCntTmp = 0;
+    int64_t idInTopKTmp = 0;
+
+    for (uint32_t nL1 = 0; nL1 < nL1Loops; nL1++) {
+        if (nL1 == (nL1Loops - 1)) {
+            nL1Size = nSize - (nL1Loops - 1) * N_SPLIT_SIZE;
+            nL1SizeAlign = SFAAlign(nL1Size, 16U);
+        }
+        curTopKIdxTmp = curTopKIdx;
+        curOffsetInSparseBlockTmp = curOffsetInSparseBlock;
+        copyRowCntTmp = copyRowCnt;
+        idInTopKTmp = idInTopK;
+
+        for (uint32_t kL1 = 0; kL1 < kL1Loops; kL1++) {
+            kvL1BufIter++;
+            uint32_t kb = kvL1BufIter % 3;
+            WaitFlag<HardEvent::MTE1_MTE2>(mte21KVIds[kb]);
+            bL1Tensor = l1KVTensor[kb * L1_BLOCK_OFFSET];
+
+            uint32_t curSeqIdx = info.s2BatchOffset + nL1 * N_SPLIT_SIZE;
+            uint32_t copyFinishRowCnt = 0;
+            curTopKIdx = curTopKIdxTmp;
+            curOffsetInSparseBlock = curOffsetInSparseBlockTmp;
+            copyRowCnt = copyRowCntTmp;
+            idInTopK = idInTopKTmp;
+            if constexpr (TEMPLATE_MODE == V_TEMPLATE) {
+                // The nope segment of kvMergeGm_ keeps the N_WORKSPACE_SIZE*576 stride used on the write side.
+                Nd2NzParams nd2nzPara;
+                nd2nzPara.ndNum = 1;
+                nd2nzPara.nValue = nL1Size;
+                nd2nzPara.dValue = kL1Size;
+                nd2nzPara.srcDValue = constInfo.headDim;
+                nd2nzPara.dstNzC0Stride = nL1SizeAlign;
+                nd2nzPara.dstNzNStride = 1;
+                nd2nzPara.srcNdMatrixStride = 0;
+                nd2nzPara.dstNzMatrixStride = 0;
+                DataCopy(bL1Tensor,
+                         kvMergeGm_[info.loop % 4 * N_WORKSPACE_SIZE * 576 + kL1 * kL1Size +
+                                    nL1 * N_SPLIT_SIZE * constInfo.headDim],
+                         nd2nzPara);
+            } else {
+                while (copyFinishRowCnt < nL1Size) {
+                    CalcTopKBlockInfo(info, curTopKIdx, curOffsetInSparseBlock, curSeqIdx, copyRowCnt, idInTopK);
+                    if (copyFinishRowCnt + copyRowCnt > nL1Size) {
+                        copyRowCnt = nL1Size - copyFinishRowCnt;
+                    }
+                    if constexpr (PAGE_ATTENTION) {
+                        Position startPos;
+                        startPos.bIdx = info.bIdx;
+                        startPos.n2Idx = info.n2Idx;
+                        startPos.s2Idx = idInTopK * constInfo.sparseBlockSize + curOffsetInSparseBlock;
+                        startPos.dIdx = kL1 * kL1Size;
+                        PAShape shape;
+                        shape.blockSize = kvCacheBlockSize;
+                        shape.headNum = constInfo.kvHeadNum;
+                        shape.headDim = constInfo.headDim;
+                        shape.actHeadDim = kL1Size;
+                        shape.maxblockNumPerBatch = maxBlockNumPerBatch;
+                        shape.copyRowNum = copyRowCnt;
+                        shape.copyRowNumAlign = nL1SizeAlign;
+                        LocalTensor<KV_T> kTensor = bL1Tensor[copyFinishRowCnt * 16];
+                        DataCopyPA<KV_T, KV_LAYOUT_T>(kTensor, keyGm, blockTableGm, shape, startPos);
+                    } else {
+                        uint64_t keyOffset = info.tensorBOffset;
+                        if constexpr (KV_LAYOUT_T == SFA_LAYOUT::BSND || KV_LAYOUT_T == SFA_LAYOUT::TND) {
+                            keyOffset += (idInTopK * constInfo.sparseBlockSize + curOffsetInSparseBlock) *
+                                         constInfo.kvHeadNum * constInfo.headDim;
+                        } else {
+                            keyOffset += (idInTopK * constInfo.sparseBlockSize + curOffsetInSparseBlock) *
+                                         constInfo.headDim;
+                        }
+                        CopyInMm1BToL1(bL1Tensor, keyOffset + kL1 * kL1Size, nL1SizeAlign, copyFinishRowCnt,
+                                       copyRowCnt, kL1Size);
+                    }
+                    copyFinishRowCnt += copyRowCnt;
+                    curSeqIdx += copyRowCnt;
+                }
+            }
+            SetFlag<HardEvent::MTE2_MTE1>(mte21KVIds[kb]);
+            WaitFlag<HardEvent::MTE2_MTE1>(mte21KVIds[kb]);
+            mL1Size = M_SPLIT_SIZE;
+            mL1SizeAlign = SFAAlign(M_SPLIT_SIZE, 16U);
+            for (uint32_t mL1 = 0; mL1 < mL1Loops; mL1++) {
+                if (mL1 == (mL1Loops - 1)) {
+                    mL1Size = mSize - (mL1Loops - 1) * M_SPLIT_SIZE;
+                    mL1SizeAlign = SFAAlign(mL1Size, 16U);
+                }
+                uint32_t mIdx = qpL1BufIter + mL1;
+                ka = GetQPL1RealIdx(mIdx, kL1);
+                LocalTensor<Q_T> aL1Tensor = l1QPTensor[ka * L1_BLOCK_OFFSET];
+                if (nL1 == 0) {
+                    WaitFlag<HardEvent::MTE1_MTE2>(mte21QPIds[ka]);
+                    // Without rope the two K segments are separate blocks: no cross-block merge, hence no aL1PaddingSize.
+                    CopyInMm1AToL1(aL1Tensor, info, mSplitInfo.nBufferStartM + mL1 * M_SPLIT_SIZE, mL1Size,
+                                   kL1Size, kL1 * kL1Size);
+                    SetFlag<HardEvent::MTE2_MTE1>(mte21QPIds[ka]);
+                    WaitFlag<HardEvent::MTE2_MTE1>(mte21QPIds[ka]);
+                }
+                LocalTensor cL0Tensor =
+                    cL0TensorPingPong[(cL0BufIter % 2) * (L0C_PP_SIZE / sizeof(MM_OUT_T))];
+                for (uint32_t kL0 = 0; kL0 < kL0Loops; kL0++) {
+                    WaitFlag<HardEvent::M_MTE1>(Mte1MmABEventId(abL0BufIter % 2));
+                    LocalTensor<KV_T> aL0Tensor = aL0TensorPingPong[(abL0BufIter % 2) * (L0A_PP_SIZE / sizeof(KV_T))];
+                    LoadDataMm1A(aL0Tensor, aL1Tensor, kL0, kL0Size, mL1SizeAlign, kL0Size);
+                    LocalTensor<KV_T> bL0Tensor = bL0TensorPingPong[(abL0BufIter % 2) * (L0B_PP_SIZE / sizeof(KV_T))];
+                    LoadDataMm1B(bL0Tensor, bL1Tensor, kL0, kL0Size, kL0Size, nL1SizeAlign);
+                    SetFlag<HardEvent::MTE1_M>(Mte1MmABEventId(abL0BufIter % 2));
+                    WaitFlag<HardEvent::MTE1_M>(Mte1MmABEventId(abL0BufIter % 2));
+
+                    MmadParams mmadParams;
+                    mmadParams.m = mL1SizeAlign;
+                    mmadParams.n = nL1SizeAlign;
+                    mmadParams.k = kL0Size;
+                    mmadParams.cmatrixInitVal = (kL1 == 0 && kL0 == 0);
+                    mmadParams.cmatrixSource = false;
+                    mmadParams.unitFlag = (kL1 == (kL1Loops - 1) && kL0 == (kL0Loops - 1)) ? 0b11 : 0b10;
+                    Mmad(cL0Tensor, aL0Tensor, bL0Tensor, mmadParams);
+
+                    if ((mmadParams.m / 16) * (mmadParams.n / 16) < 10) {
+                        PipeBarrier<PIPE_M>();
+                    }
+                    SetFlag<HardEvent::M_MTE1>(Mte1MmABEventId(abL0BufIter % 2));
+                    abL0BufIter++;
+                }
+                if (nL1 == (nL1Loops - 1)) {
+                    SetFlag<HardEvent::MTE1_MTE2>(mte21QPIds[ka]);
+                }
+                if (kL1 == (kL1Loops - 1)) { // last kL1 iteration: move the accumulated K out
+                    FixpipeParamsV220 fixParams;
+                    fixParams.nSize = nL1SizeAlign;
+                    fixParams.mSize = mL1SizeAlign;
+                    fixParams.srcStride = mL1SizeAlign;
+                    fixParams.dstStride = info.actualSingleProcessSInnerSizeAlign;
+                    fixParams.unitFlag = 0b11;
+                    fixParams.ndNum = 1;
+                    Fixpipe(mm1ResGm[(info.loop % (constInfo.preLoadNum)) * constInfo.mmResUbSize + nL1 * N_SPLIT_SIZE +
+                                     (mSplitInfo.nBufferStartM + mL1 * M_SPLIT_SIZE) *
+                                         info.actualSingleProcessSInnerSizeAlign],
+                            cL0Tensor, fixParams);
+                }
+                if (mL1Loops == 2) {
+                    cL0BufIter++;
+                }
+            }
+            SetFlag<HardEvent::MTE1_MTE2>(mte21KVIds[kb]);
+        }
+        if (mL1Loops == 1) {
+            cL0BufIter++;
+        }
+    }
+    qpL1BufIter += mL1Loops;
+}
+
 template <typename SFAT>
 __aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1(const RunInfo &info, const MSplitInfo mSplitInfo)
 {
@@ -571,6 +755,12 @@ __aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1(const RunInfo &info, c
     uint32_t nL1SizeAlign = SFAAlign(N_SPLIT_SIZE, 16U);
     uint32_t nL1Loops = (nSize + N_SPLIT_SIZE - 1) / N_SPLIT_SIZE;
 
+    // rope=0 uses a dedicated path: the K axis holds only the 512-wide nope part, so no nope/rope interleave.
+    if (constInfo.headDimRope == 0) {
+        ComputeMm1NoRope(info, mSplitInfo);
+        return;
+    }
+
     uint32_t kSize = 576;
     uint32_t kL1Size = 288;
     uint32_t kL1Loops = 2; // 2 : 576/288, mla专用 这里不考虑d泛化
@@ -583,7 +773,7 @@ __aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1(const RunInfo &info, c
     LocalTensor<KV_T> kTensor;
     // ka表示左矩阵4buf选择哪一块buf, kb表示右矩阵3buf选择哪一块buf
     uint32_t ka = 0, kb = 0;
-    
+
     uint32_t curTopKIdx = info.curTopKIdx;
     uint64_t curOffsetInSparseBlock = info.curOffsetInSparseBlock; //sparse Block块内偏移
     uint32_t copyRowCnt = 0;
@@ -613,7 +803,7 @@ __aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1(const RunInfo &info, c
             // 从k当中取当前的块
             bL1Tensor = l1KVTensor[kb * L1_BLOCK_OFFSET];
                 // mm1拷贝主流程
- 
+
                 uint32_t curSeqIdx = info.s2BatchOffset + nL1 * N_SPLIT_SIZE;
                 uint32_t copyFinishRowCnt = 0;
                 curTopKIdx = curTopKIdxTmp;
@@ -624,8 +814,8 @@ __aicore__ inline void SFAMatmulService<SFAT>::ComputeMm1(const RunInfo &info, c
                     if (kL1 == 0) {
                         Nd2NzParams nd2nzPara;
                         nd2nzPara.ndNum = 1;
-                        nd2nzPara.nValue = nL1Size;                 // 行数
-                        nd2nzPara.dValue = constInfo.headDim >> 1;  // constInfo.headDim;
+                        nd2nzPara.nValue = nL1Size;
+                        nd2nzPara.dValue = constInfo.headDim >> 1;
                         nd2nzPara.srcDValue = constInfo.headDim;
                         nd2nzPara.dstNzC0Stride = nL1SizeAlign;
                         nd2nzPara.dstNzNStride = 1;

--- a/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_vector_mla.h
+++ b/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_vector_mla.h
@@ -93,7 +93,7 @@ public:
     __aicore__ inline void ProcessAmlaNupdate(const RunInfo &info, const MSplitInfo &mSplitInfo);
     __aicore__ inline void ComputeLogSumExpAndCopyToGm(const RunInfo &info, const MSplitInfo &mSplitInfo,
                                                        LocalTensor<T> &softmaxSumUb, LocalTensor<T> &softmaxMaxUb);
-    __aicore__ inline void CopyFALseToGm(const RunInfo &info, const MSplitInfo &mSplitInfo, 
+    __aicore__ inline void CopyFALseToGm(const RunInfo &info, const MSplitInfo &mSplitInfo,
                                         LocalTensor<T> &softmaxSumUb, LocalTensor<T> &softmaxMaxUb);
     __aicore__ inline void SetBmm2FirstSInnerBias(const RunInfo &info, const MSplitInfo &mSplitInfo);
     // ================================Vecotr2==========================================
@@ -331,7 +331,7 @@ template <typename SFAT> __aicore__ inline void SFAVectorService<SFAT>::InitSoft
 }
 
 template <typename SFAT>
-__aicore__ inline void SFAVectorService<SFAT>::CopyFALseToGm(const RunInfo &info, const MSplitInfo &mSplitInfo, 
+__aicore__ inline void SFAVectorService<SFAT>::CopyFALseToGm(const RunInfo &info, const MSplitInfo &mSplitInfo,
                                         LocalTensor<T> &softmaxSumUb, LocalTensor<T> &softmaxMaxUb)
 
 {
@@ -345,13 +345,13 @@ __aicore__ inline void SFAVectorService<SFAT>::CopyFALseToGm(const RunInfo &info
     if constexpr (LAYOUT_T == SFA_LAYOUT::TND) { //lse layout为N2 T G
         uint64_t actualSeqQTotal = (info.bIdx <= 0) ? 0 : actualSeqLengthsQGm.GetValue(constInfo.batchSize - 1);
         uint64_t actualSeqQPrefixSum = (info.bIdx <= 0) ? 0 : actualSeqLengthsQGm.GetValue(info.bIdx - 1);
-        offset += info.n2Idx * actualSeqQTotal * constInfo.gSize + 
-                  (actualSeqQPrefixSum + info.gS1Idx / constInfo.gSize) * constInfo.gSize + 
+        offset += info.n2Idx * actualSeqQTotal * constInfo.gSize +
+                  (actualSeqQPrefixSum + info.gS1Idx / constInfo.gSize) * constInfo.gSize +
                   mSplitInfo.nBufferStartM + mSplitInfo.vecStartM;
     } else {
-        offset += info.bIdx * constInfo.kvHeadNum * constInfo.qSeqSize * constInfo.gSize + 
-                  info.n2Idx * constInfo.qSeqSize * constInfo.gSize + 
-                  info.gS1Idx / constInfo.gSize * constInfo.gSize + 
+        offset += info.bIdx * constInfo.kvHeadNum * constInfo.qSeqSize * constInfo.gSize +
+                  info.n2Idx * constInfo.qSeqSize * constInfo.gSize +
+                  info.gS1Idx / constInfo.gSize * constInfo.gSize +
                   mSplitInfo.nBufferStartM + mSplitInfo.vecStartM;
     }
 
@@ -696,7 +696,7 @@ template <typename SFAT>
 __aicore__ inline void SFAVectorService<SFAT>::SetBmm2FirstSInnerBias(const RunInfo &info, const MSplitInfo &mSplitInfo)
 {
     uint32_t mSplitSize = 16U;
-    uint64_t baseoffset = (info.bn2IdxInCurCore % constInfo.preLoadNum) * constInfo.bmm2ResUbSize + 
+    uint64_t baseoffset = (info.bn2IdxInCurCore % constInfo.preLoadNum) * constInfo.bmm2ResUbSize +
                             (mSplitInfo.nBufferStartM + mSplitInfo.vecStartM) * constInfo.headDim;
     WaitFlag<AscendC::HardEvent::MTE3_V>(SYNC_OUTPUT_BUF1_FLAG);
     LocalTensor<int32_t> tmpTensor = outputBuff1.Get<int32_t>();
@@ -745,7 +745,7 @@ __aicore__ inline void SFAVectorService<SFAT>::ProcessAmlaNupdate(const RunInfo 
         // (m,1)单次brcb扩充成(m,8), 重复16次, 扩充为(m,128)
         for (uint32_t i = 0; i < dGroupSize / elementPerBlock; i++) {
             Brcb(tmpQue[i * elementPerBlock],
-                 nUpdateTensor[loop * mSplitSize], 
+                 nUpdateTensor[loop * mSplitSize],
                  static_cast<uint8_t>((processMSize + elementPerBlock - 1) / elementPerBlock),
                  {static_cast<uint16_t>(dGroupSize / elementPerBlock), // 单次迭代内，目的操作数不同datablock间地址步长,单位为datablock
                   static_cast<uint16_t>(dGroupSize)});                 // 相邻迭代间，目的操作数相同datablock地址步长
@@ -861,6 +861,9 @@ __aicore__ inline int64_t SFAVectorService<SFAT>::GetKeyRopeGmOffset(int64_t rea
         return -1;
     }
     int64_t realKeyRopeGmOffset = 0;
+    if (constInfo.headDimRope == 0) {
+        return 0;
+    }
     realKeyRopeGmOffset = (runInfo.tensorBRopeOffset +
                            realS2Idx * constInfo.kvHeadNum * constInfo.headDimRope) /
                            constInfo.headDimRope;
@@ -885,10 +888,11 @@ SFAVectorService<SFAT>::CopyInSingleKv(int64_t &mte2Size, int64_t mte3Size, int6
     DataCopyPadExtParams<KV_T> padParams;
     DataCopyPad(kvMergUb_[mergeMte3Idx % 2 * 32 * 512 + (mte2Size - mte3Size) * constInfo.headDim],
                 keyGm_[keyBNBOffset * constInfo.headDim], intriParams, padParams);
-    intriParams.blockLen = validS2Count * constInfo.headDimRope * sizeof(KV_T);
-
-    DataCopyPad(ropeMergUb_[mergeMte3Idx % 2 * 32 * 64 + (mte2Size - mte3Size) * constInfo.headDimRope],
-                keyRopeGm_[keyBNBOffset * constInfo.headDimRope], intriParams, padParams);
+    if (constInfo.headDimRope > 0) {
+        intriParams.blockLen = validS2Count * constInfo.headDimRope * sizeof(KV_T);
+        DataCopyPad(ropeMergUb_[mergeMte3Idx % 2 * 32 * 64 + (mte2Size - mte3Size) * constInfo.headDimRope],
+                    keyRopeGm_[keyBNBOffset * constInfo.headDimRope], intriParams, padParams);
+    }
     mte2Size += validS2Count;
 }
 
@@ -924,7 +928,7 @@ __aicore__ inline void SFAVectorService<SFAT>::CopyInKv(int64_t &mte2Size, int64
                             (keyRopeOffset2 - keyRopeOffset1)) - constInfo.sparseBlockSize) *
                              constInfo.headDimRope * sizeof(KV_T);
     }
-    
+
     if (unlikely(keySrcStride >= INT32_MAX || keySrcStride < 0 ||
         (!PAGE_ATTENTION && (keyRopeSrcStride >= INT32_MAX || keyRopeSrcStride < 0)) ||
         realS2Idx1 + constInfo.sparseBlockSize >= s2IdLimit ||
@@ -947,11 +951,13 @@ __aicore__ inline void SFAVectorService<SFAT>::CopyInKv(int64_t &mte2Size, int64
         DataCopyPad(kvMergUb_[mergeMte3Idx % 2 * 32 * 512 + (mte2Size - mte3Size) * constInfo.headDim],
                     keyGm_[startGmOffset * constInfo.headDim], intriParams, padParams);
 
-        intriParams.blockLen = constInfo.sparseBlockSize * constInfo.headDimRope * sizeof(KV_T);
-        intriParams.dstStride = 0;
-        intriParams.srcStride = keyRopeSrcStride;
-        DataCopyPad(ropeMergUb_[mergeMte3Idx % 2 * 32 * 64 + (mte2Size - mte3Size) * constInfo.headDimRope],
-                    keyRopeGm_[startGmOffset * constInfo.headDimRope], intriParams, padParams);
+        if (constInfo.headDimRope > 0) {
+            intriParams.blockLen = constInfo.sparseBlockSize * constInfo.headDimRope * sizeof(KV_T);
+            intriParams.dstStride = 0;
+            intriParams.srcStride = keyRopeSrcStride;
+            DataCopyPad(ropeMergUb_[mergeMte3Idx % 2 * 32 * 64 + (mte2Size - mte3Size) * constInfo.headDimRope],
+                        keyRopeGm_[startGmOffset * constInfo.headDimRope], intriParams, padParams);
+        }
         mte2Size += ((keyOffset1 > -1) + (keyOffset2 > -1)) * constInfo.sparseBlockSize;
     }
 }
@@ -976,9 +982,11 @@ __aicore__ inline void SFAVectorService<SFAT>::CopyOutMrgeResult(int64_t mte2Siz
     DataCopyPad(kvMergeGm_[runInfo.loop % 4 * 512 * 576 + (s2GmStartOffset + mte3Size)*constInfo.headDim],
                 kvMergUb_[mergeMte3Idx % 2 * 32 * 512], dataCopyParams);
 
-    dataCopyParams.blockLen = constInfo.headDimRope * sizeof(KV_T);
-    DataCopyPad(kvMergeGm_[runInfo.loop % 4 * 512 * 576 + 512 * 512 + (s2GmStartOffset + mte3Size) *
-                constInfo.headDimRope], ropeMergUb_[mergeMte3Idx % 2 * 32 * 64], dataCopyParams);
+    if (constInfo.headDimRope > 0) {
+        dataCopyParams.blockLen = constInfo.headDimRope * sizeof(KV_T);
+        DataCopyPad(kvMergeGm_[runInfo.loop % 4 * 512 * 576 + 512 * 512 + (s2GmStartOffset + mte3Size) *
+                    constInfo.headDimRope], ropeMergUb_[mergeMte3Idx % 2 * 32 * 64], dataCopyParams);
+    }
 }
 
 // b s1 k
@@ -1051,11 +1059,13 @@ __aicore__ inline void SFAVectorService<SFAT>::MergeKv(const RunInfo &runInfo)
             DataCopyPad(kvMergeGm_[runInfo.loop % MERGE_CACHE_GM_BUF_NUM * 512 * 576 + s2GmOffset * constInfo.headDim],
                         kvMergUb_, dataCopyParams);
         }
-        dataCopyParams.blockLen = constInfo.headDimRope * sizeof(KV_T);
-        for (int64_t s2GmOffset = s2GmStartOffset + mte2Size; s2GmOffset < s2GmLimit; s2GmOffset++) {
-            DataCopyPad(kvMergeGm_[runInfo.loop % MERGE_CACHE_GM_BUF_NUM * 512 * 576 + 512 * constInfo.headDim +
-                                   s2GmOffset * constInfo.headDimRope],
-                        kvMergUb_, dataCopyParams);
+        if (constInfo.headDimRope > 0) {
+            dataCopyParams.blockLen = constInfo.headDimRope * sizeof(KV_T);
+            for (int64_t s2GmOffset = s2GmStartOffset + mte2Size; s2GmOffset < s2GmLimit; s2GmOffset++) {
+                DataCopyPad(kvMergeGm_[runInfo.loop % MERGE_CACHE_GM_BUF_NUM * 512 * 576 + 512 * constInfo.headDim +
+                                       s2GmOffset * constInfo.headDimRope],
+                            kvMergUb_, dataCopyParams);
+            }
         }
         SetFlag<AscendC::HardEvent::MTE3_MTE2>(mergeMte3Idx & 1);
         mergeMte3Idx++;
@@ -1116,7 +1126,7 @@ __aicore__ inline void SFAVectorService<SFAT>::ProcessVec1L(const RunInfo &info)
             }
             if (info.tndIsS2SplitCore) {
                 if constexpr (FLASH_DECODE) {
-                    
+
                     ComputeLogSumExpAndCopyToGm(info, mSplitInfo, sumTensor, maxTensor);
                 }
             }
@@ -1250,7 +1260,7 @@ SFAVectorService<SFAT>::Bmm2DataCopyOutTrans(const RunInfo &info, LocalTensor<OU
     dataCopyParams.blockLen = actualColumnCount * sizeof(OUT_T);
     dataCopyParams.srcStride = (columnCount - actualColumnCount) / (BYTE_BLOCK / sizeof(OUT_T));
     dataCopyParams.dstStride = 0;
-    DataCopyPad(attentionOutGm[info.attenOutOffset + wsMStart * actualColumnCount], attenOutUb, dataCopyParams);    
+    DataCopyPad(attentionOutGm[info.attenOutOffset + wsMStart * actualColumnCount], attenOutUb, dataCopyParams);
     return;
 }
 
@@ -1308,7 +1318,7 @@ SFAVectorService<SFAT>::DealBmm2ResBaseBlock(const RunInfo &info, const MSplitIn
 
     SetFlag<AscendC::HardEvent::MTE2_V>(SYNC_INPUT_BUF1_FLAG);
     WaitFlag<AscendC::HardEvent::MTE2_V>(SYNC_INPUT_BUF1_FLAG);
-    
+
     // 将绝对值大于1e10的数置为0
     LocalTensor<T> bmm2ResUb = tmpBuff1.Get<T>();
     bmm2ResUb.SetSize(vec2ComputeSize);


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Support sparse MLA attention without RoPE inputs on A2/A3, as used by GLM-5.3-Flash. Update host tiling and the cube/vector kernel paths to handle a zero RoPE dimension, keeping the existing RoPE path available.

This PR contains only the sparse-flash-attention operator change: 5 files, +309/-64 lines, one signed-off commit on main. Model integration and other pending PRs are excluded.

### Does this PR introduce _any_ user-facing change?

Yes. The existing sparse flash attention operator accepts the NoPE query/key layout on A2/A3. No serving configuration or dependency-version change is introduced.

### How was this patch tested?

- Python AST/Ruff, C++ clang-format, and `git diff --check` passed for the relevant changes.
- The operator changes were included in an integrated A3 native-extension build. This is not a standalone numerical validation of this branch.
- Added code comments only: the NoPE path is documented in English, no functional change beyond the operator update above.

Standalone NPU numerical validation is still pending.

- The A3 cache build failed during CMake's Torch import because backend autoload initialized torch_npu/Triton in the build container. The build environment issue and an A3 rebuild remain pending. A2 and 310P cache builds passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
