### PR TITLE
[Feature][Attention] Support NoPE in the shared SFA backend

### DIFF
--- a/tests/ut/attention/test_sfa_nope_forward.py
+++ b/tests/ut/attention/test_sfa_nope_forward.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.config.compilation import CUDAGraphMode
+
+import vllm_ascend.attention.sfa_v1 as sparse_mla
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, AscendSFAMetadata
+
+
+class _Linear:
+    def __init__(self, weight: torch.Tensor) -> None:
+        self.weight = weight
+        self.calls: list[tuple[torch.Tensor, dict]] = []
+
+    def __call__(self, x: torch.Tensor, **kwargs):
+        self.calls.append((x.clone(), kwargs))
+        return (x @ self.weight,)
+
+
+class _RecordingIndexer:
+    head_dim: int
+    enable_sparse_li_c8: bool
+
+    def __init__(self, indices: torch.Tensor) -> None:
+        self.indices = indices
+        self.call: tuple | None = None
+        self.k_cache = SimpleNamespace(prefix="model.layers.0.self_attn.indexer.k_cache")
+
+    def __call__(self, hidden, q_c, cos, sin, k_hidden, metadata, compute_topk):
+        self.call = (hidden.clone(), q_c.clone(), cos, sin, k_hidden.clone(), metadata, compute_topk)
+        return self.indices
+
+
+def _rms_norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    return x * torch.rsqrt(x.square().mean(dim=-1, keepdim=True) + eps)
+
+
+def _reference_sparse_attention(**kwargs):
+    query = kwargs["query"]
+    cache = kwargs["key"]
+    indices = kwargs["sparse_indices"].squeeze(1)
+    block_table = kwargs["block_table"]
+    query_ends = kwargs["actual_seq_lengths_query"]
+
+    assert kwargs["value"] is cache
+    assert kwargs["sparse_block_size"] == 1
+    assert kwargs["layout_query"] == "TND"
+    assert kwargs["layout_kv"] == "PA_BSND"
+    assert kwargs["sparse_mode"] == 3
+    assert kwargs["attention_mode"] == 2
+    assert kwargs["return_softmax_lse"] is False
+    assert kwargs["actual_seq_lengths_query"].dtype == torch.int32
+    assert kwargs["actual_seq_lengths_kv"].dtype == torch.int32
+    assert kwargs["query_rope"] is None
+    assert kwargs["key_rope"] is None
+
+    outputs = []
+    for token_idx, token_indices in enumerate(indices):
+        if token_idx >= int(query_ends[-1]):
+            outputs.append(torch.zeros_like(query[token_idx]))
+            continue
+        request_idx = int(torch.searchsorted(query_ends, token_idx, right=True))
+        physical_blocks = block_table[request_idx, token_indices.to(torch.int64)]
+        selected = cache[physical_blocks, 0, 0]
+        scores = torch.einsum("hd,kd->hk", query[token_idx], selected)
+        probs = torch.softmax(scores * kwargs["scale_value"], dim=-1)
+        outputs.append(torch.einsum("hk,kd->hd", probs, selected))
+    latent_output = torch.stack(outputs)
+    unused = latent_output.new_empty(0)
+    return latent_output, unused, unused
+
+
+@pytest.mark.parametrize("graph_mode", [False, True])
+@pytest.mark.parametrize("empty_rope_handle", [False, True])
+def test_sparse_mla_full_forward_uses_real_rows_and_latent_values(graph_mode, empty_rope_handle) -> None:
+    torch.manual_seed(7)
+    num_tokens = 3
+    padded_tokens = 4
+    hidden_dim = 5
+    num_heads = 2
+    q_nope_dim = 4
+    latent_dim = 8
+    value_dim = 3
+    output_dim = 4
+
+    hidden_states = torch.randn(padded_tokens, hidden_dim)
+    fused_weight = torch.randn(hidden_dim, latent_dim * 2)
+    q_weight = torch.randn(latent_dim, num_heads * q_nope_dim) * 0.25
+    uk_weight = torch.randn(num_heads, q_nope_dim, latent_dim) * 0.25
+    uv_weight = torch.randn(num_heads, latent_dim, value_dim) * 0.25
+    gate_weight = torch.randn(hidden_dim, num_heads * value_dim)
+    output_weight = torch.randn(num_heads * value_dim, output_dim)
+
+    block_table = torch.tensor([[0, 1, 2], [3, 4, -1]], dtype=torch.int32)
+    slot_mapping = torch.tensor([1, 2, 4, -1], dtype=torch.int64)
+    positions = torch.tensor([1, 2, 1, 0], dtype=torch.int64)
+    indices = torch.tensor([[[0, 1]], [[0, 2]], [[0, 1]]], dtype=torch.int32)
+    if graph_mode:
+        indices = torch.cat((indices, torch.full_like(indices[:1], -1)))
+    initial_cache = torch.randn(5, 1, 1, latent_dim)
+    kv_cache: tuple[torch.Tensor, ...] = (initial_cache.clone(),)
+    if empty_rope_handle:
+        kv_cache = (*kv_cache, torch.empty(5, 1, 1, 0))
+    metadata = AscendSFAMetadata(
+        num_input_tokens=padded_tokens,
+        cos=None,
+        sin=None,
+        seq_lens_cpu=torch.tensor([3, 2], dtype=torch.int32),
+        cum_query_lens=torch.tensor([2, 3], dtype=torch.int32),
+        num_actual_tokens=num_tokens,
+        # One two-token prefill and one one-token decode share this TND call.
+        num_prefills=2,
+        max_query_len=2,
+        max_seq_len=3,
+        seq_lens=torch.tensor([3, 2], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+        block_table=block_table,
+        block_size=1,
+        slot_mapping=slot_mapping,
+        positions=positions,
+    )
+
+    fused_qkv = _Linear(fused_weight)
+    gate_proj = _Linear(gate_weight)
+    output_proj = _Linear(output_weight)
+    indexer = _RecordingIndexer(indices)
+    indexer_metadata = SimpleNamespace(
+        block_table=torch.tensor([[7, 6], [4, 5]], dtype=torch.int32),
+        slot_mapping=torch.full_like(slot_mapping, -1),
+        seq_lens=torch.zeros(2, dtype=torch.int32),
+        seq_lens_cpu=torch.zeros(2, dtype=torch.int32),
+        positions=positions,
+        block_size=1,
+        tokens_per_state=4,
+        cum_query_lens=metadata.query_start_loc[1:],
+        raw_seq_lens=metadata.seq_lens,
+        num_actual_tokens=num_tokens,
+    )
+
+    indexer.head_dim = latent_dim
+    indexer.enable_sparse_li_c8 = False
+    config = SimpleNamespace(kv_transfer_config=None, model_config=SimpleNamespace(hf_config=SimpleNamespace()))
+    ascend_config = SimpleNamespace(enable_sparse_sfa_c8=False, enable_mlapo=False)
+    with (
+        patch.object(sparse_mla, "get_current_vllm_config", return_value=config),
+        patch.object(sparse_mla, "get_ascend_config", return_value=ascend_config),
+        patch.object(sparse_mla, "get_tensor_model_parallel_world_size", return_value=1),
+        patch.object(sparse_mla, "enable_sp", return_value=False),
+    ):
+        impl = AscendSFAImpl(
+            q_lora_rank=latent_dim,
+            kv_lora_rank=latent_dim,
+            num_heads=num_heads,
+            head_size=latent_dim,
+            v_head_dim=value_dim,
+            scale=0.25,
+            qk_rope_head_dim=0,
+            qk_nope_head_dim=q_nope_dim,
+            qk_head_dim=q_nope_dim,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            kv_a_layernorm=_rms_norm,
+            layer_name="model.layers.0.self_attn",
+            fused_qkv_a_proj=fused_qkv,
+            q_a_layernorm=_rms_norm,
+            q_b_proj=_Linear(q_weight),
+            kv_b_proj=None,
+            indexer=indexer,
+            g_proj=gate_proj,
+            o_proj=output_proj,
+        )
+    impl.W_UK_T, impl.W_UV = uk_weight, uv_weight
+    assert not impl.supports_dense_mha_prefill
+    output = torch.full((padded_tokens, output_dim), 123.0)
+
+    with (
+        patch.object(
+            sparse_mla,
+            "get_forward_context",
+            return_value=SimpleNamespace(
+                cudagraph_runtime_mode=CUDAGraphMode.FULL if graph_mode else CUDAGraphMode.NONE,
+                attn_metadata={indexer.k_cache.prefix: indexer_metadata},
+            ),
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "npu_sparse_flash_attention",
+            side_effect=_reference_sparse_attention,
+            create=True,
+        ) as sparse_attention,
+        patch.object(sparse_mla, "record_attention_compute_start"),
+        patch.object(sparse_mla, "wait_for_kv_layer_from_connector"),
+        patch.object(sparse_mla, "notify_kv_cache_written"),
+        patch.object(sparse_mla, "maybe_save_kv_layer_to_connector"),
+        patch.object(sparse_mla, "torch_npu", SimpleNamespace()),
+    ):
+        actual = AscendSFAImpl.forward(
+            impl,
+            "model.layers.0.self_attn",
+            hidden_states,
+            kv_cache,
+            metadata,
+            output=output,
+        )
+
+    real_hidden = hidden_states[:num_tokens]
+    expected_qkv = real_hidden @ fused_weight
+    expected_q_c = _rms_norm(expected_qkv[:, :latent_dim])
+    expected_kv = _rms_norm(expected_qkv[:, latent_dim:])
+    expected_cache = initial_cache.clone()
+    expected_cache[slot_mapping[:num_tokens], 0, 0] = expected_kv
+    expected_q_nope = (expected_q_c @ q_weight).view(-1, num_heads, q_nope_dim)
+    expected_query = torch.einsum("thd,hdl->thl", expected_q_nope, uk_weight)
+    expected_latent = _reference_sparse_attention(
+        query=expected_query,
+        key=expected_cache,
+        value=expected_cache,
+        sparse_indices=indices[:num_tokens],
+        scale_value=impl.scale,
+        sparse_block_size=1,
+        block_table=block_table,
+        actual_seq_lengths_query=metadata.query_start_loc[1:].to(torch.int32),
+        actual_seq_lengths_kv=metadata.seq_lens.to(torch.int32),
+        query_rope=None,
+        key_rope=None,
+        layout_query="TND",
+        layout_kv="PA_BSND",
+        sparse_mode=3,
+        attention_mode=2,
+        return_softmax_lse=False,
+    )[0]
+    expected_values = torch.einsum("thl,hlv->thv", expected_latent, uv_weight).reshape(
+        num_tokens, num_heads * value_dim
+    )
+    expected_values *= torch.sigmoid(real_hidden @ gate_weight)
+    expected_o_input = torch.zeros(padded_tokens, num_heads * value_dim)
+    expected_o_input[:num_tokens] = expected_values
+    expected_output = expected_o_input @ output_weight
+
+    assert actual is output
+    torch.testing.assert_close(actual, expected_output)
+    torch.testing.assert_close(actual[num_tokens:], torch.zeros(1, output_dim))
+    torch.testing.assert_close(kv_cache[0], expected_cache)
+    assert fused_qkv.calls[0][0].shape[0] == (padded_tokens if graph_mode else num_tokens)
+    assert indexer.call is not None
+    torch.testing.assert_close(indexer.call[0][:num_tokens], real_hidden)
+    torch.testing.assert_close(indexer.call[1][:num_tokens], expected_q_c)
+    assert indexer.call[2:4] == (None, None)
+    torch.testing.assert_close(indexer.call[4][:num_tokens], real_hidden)
+    assert indexer.call[5] is indexer_metadata
+    assert indexer.call[6] is True
+    assert output_proj.calls[0][1] == {}
+
+    kwargs = sparse_attention.call_args.kwargs
+    torch.testing.assert_close(kwargs["query"][:num_tokens], expected_query)
+    torch.testing.assert_close(kwargs["key"], expected_cache)
+    torch.testing.assert_close(kwargs["actual_seq_lengths_query"], torch.tensor([2, 3], dtype=torch.int32))
+    torch.testing.assert_close(kwargs["actual_seq_lengths_kv"], torch.tensor([3, 2], dtype=torch.int32))
+    assert kwargs["query"].shape[-1] == latent_dim
+    assert latent_dim != value_dim
+    assert expected_values.shape[-1] == num_heads * value_dim
+    assert metadata.smla_metadata is None

--- a/tests/ut/attention/test_sfa_nope_metadata.py
+++ b/tests/ut/attention/test_sfa_nope_metadata.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
+
+import vllm_ascend.attention.sfa_v1 as sfa
+import vllm_ascend.attention.sfa_v1 as sparse_mla
+from vllm_ascend.device.hardware_profile import DeviceAdaptorFamily
+
+
+def _builder(block_size, a5, monkeypatch, rope_dim=0):
+    indexer = SimpleNamespace(
+        topk_output_width=17,
+        get_topk_lengths=lambda positions: torch.where(positions == 0, 1, 7),
+    )
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            max_model_len=4096,
+            get_head_size=lambda: 512,
+            hf_text_config=SimpleNamespace(num_attention_heads=4, kv_lora_rank=512),
+        ),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+        scheduler_config=SimpleNamespace(max_num_seqs=2, max_num_batched_tokens=4),
+        speculative_config=None,
+        compilation_config=SimpleNamespace(
+            static_forward_context={
+                "layer": SimpleNamespace(qk_rope_head_dim=rope_dim, impl=SimpleNamespace(indexer=indexer))
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        sparse_mla,
+        "get_current_hardware_profile",
+        lambda: SimpleNamespace(device_adaptor_family=DeviceAdaptorFamily.FP8_OPTIMIZED if a5 else None),
+    )
+    monkeypatch.setattr(sfa, "get_ascend_config", lambda: SimpleNamespace(c8_reshape_optim_enabled=False))
+    monkeypatch.setattr(sfa, "select_common_block_size", lambda *args: 128)
+    monkeypatch.setattr(
+        sfa, "AttentionMaskBuilder", lambda device: SimpleNamespace(get_attention_mask=lambda *args: None)
+    )
+    monkeypatch.setattr(
+        sfa, "get_cos_and_sin_mla", lambda *args, **kwargs: pytest.fail("NoPE must not build rotary tables")
+    )
+
+    def base_init(self, spec, names, cfg, device, metadata_cls, supports_dcp):
+        self.kv_cache_spec, self.vllm_config, self.device = spec, cfg, device
+        self.model_config, self.metadata_cls = cfg.model_config, metadata_cls
+
+    with patch.object(MLACommonMetadataBuilder, "__init__", base_init):
+        return sfa.AscendSFAMetadataBuilder(
+            SimpleNamespace(block_size=block_size), ["layer"], config, torch.device("cpu")
+        )
+
+
+def _common(block_size):
+    split = block_size // 128
+    pages = torch.tensor([[7, 2], [5, -1]], dtype=torch.int32)
+    expanded = (pages.unsqueeze(-1) * split + torch.arange(split, dtype=torch.int32)).reshape(2, -1)
+    expanded[1, split:] = -1
+    return SimpleNamespace(
+        num_reqs=2,
+        num_actual_tokens=3,
+        num_input_tokens=4,
+        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([block_size + 2, 1], dtype=torch.int32),
+        _seq_lens_cpu=None,
+        seq_lens_cpu=None,
+        slot_mapping=torch.tensor([2 * block_size, 2 * block_size + 1, 5 * block_size, -1]),
+        positions=torch.tensor([block_size, block_size + 1, 0, 0]),
+        block_table_tensor=expanded,
+        max_query_len=2,
+        max_seq_len=block_size + 2,
+        group_len=None,
+        group_key_idx=None,
+        group_key_cache_idx=None,
+        attn_state=sfa.AscendAttentionState.ChunkedPrefill,
+        causal=True,
+    )
+
+
+@pytest.mark.parametrize("block_size", [128, 384, 2304])
+@pytest.mark.parametrize("a5", [False, True])
+def test_shared_sfa_nope_metadata_pages_lengths_and_draft_buffers(monkeypatch, block_size, a5):
+    builder = _builder(block_size, a5, monkeypatch)
+    seen = []
+
+    def plan(**kwargs):
+        seen.append(kwargs["ori_topk_length"].clone())
+        return torch.full((1024,), len(seen), dtype=torch.int32)
+
+    monkeypatch.setattr(sparse_mla, "sparse_flash_mla_metadata", plan)
+    common = _common(block_size)
+    first = builder.build(0, common)
+    assert type(first) is sfa.AscendSFAMetadata
+    assert first.cos is None and first.sin is None and first.seq_lens_cpu is None
+    assert first.num_prefills == 1 and first.num_decode_tokens == 1
+    uses_storage_pages = a5 or block_size <= 1024
+    expected_table = (
+        torch.tensor([[7, 2], [5, -1]], dtype=torch.int32) if uses_storage_pages else common.block_table_tensor
+    )
+    torch.testing.assert_close(first.block_table, expected_table)
+    assert first.block_size == (block_size if uses_storage_pages else 128)
+    address = first.block_table.data_ptr()
+    second = builder.build(0, common)
+    assert second.block_table.data_ptr() == address
+    draft = builder.build_for_drafting(common, 1)
+    assert draft.block_table.data_ptr() != address
+    if a5:
+        torch.testing.assert_close(
+            seen[0],
+            torch.tensor([[7], [7], [1], [0]], dtype=torch.int32),
+        )
+        assert second.smla_metadata.data_ptr() == first.smla_metadata.data_ptr()
+        assert draft.smla_metadata.data_ptr() != first.smla_metadata.data_ptr()
+        assert draft.smla_topk_length.data_ptr() != first.smla_topk_length.data_ptr()
+    else:
+        assert first.smla_metadata is None and not seen
+    common.block_table_tensor[0, : builder.nope_states[None].split] = 3 * builder.nope_states[
+        None
+    ].split + torch.arange(builder.nope_states[None].split)
+    builder.build(0, common)
+    page_multiplier = 1 if uses_storage_pages else builder.nope_states[None].split
+    assert first.block_table[0, 0] == 3 * page_multiplier
+    assert draft.block_table[0, 0] == 7 * page_multiplier
+
+
+@pytest.mark.parametrize("block_size,page_padding_bytes", [(384, 95232), (2304, 0)])
+def test_a3_sparse_mla_preserves_storage_addresses(monkeypatch, block_size, page_padding_bytes):
+    builder = _builder(block_size, False, monkeypatch)
+    metadata = builder.build(0, _common(block_size))
+    cache = torch.arange(8 * block_size * 8, dtype=torch.float32).reshape(8, block_size, 1, 8)
+    if page_padding_bytes:
+        backing = torch.empty(8, block_size * 8 + page_padding_bytes // cache.element_size())
+        padded_cache = backing[:, : block_size * 8].view_as(cache)
+        padded_cache.copy_(cache)
+        cache = padded_cache
+        assert not cache.is_contiguous()
+    query = torch.ones(3, 2, 8)
+    indices = torch.tensor(
+        [
+            [[0, 127, 128, block_size - 1, block_size]],
+            [[0, 128, block_size - 1, block_size, block_size + 1]],
+            [[0, -1, -1, -1, -1]],
+        ]
+    )
+    pages = torch.tensor([[7, 2], [5, -1]])
+
+    def op(**kwargs):
+        viewed = kwargs["key"]
+        assert viewed is kwargs["value"]
+        kernel_block_size = 128 if block_size > 1024 else block_size
+        assert viewed.shape == (8 * (block_size // kernel_block_size), kernel_block_size, 1, 8)
+        assert viewed.data_ptr() == cache.data_ptr()
+        for token, request in enumerate([0, 0, 1]):
+            positions = indices[token, 0]
+            positions = positions[positions >= 0]
+            kernel_pages = kwargs["block_table"][request, positions // kernel_block_size]
+            storage_pages = pages[request, positions // block_size]
+            actual = viewed[kernel_pages, positions % kernel_block_size]
+            expected = cache[storage_pages, positions % block_size]
+            torch.testing.assert_close(actual, expected)
+        return (query,)
+
+    monkeypatch.setattr(torch.ops._C_ascend, "npu_sparse_flash_attention", op, raising=False)
+    torch.testing.assert_close(sparse_mla.sparse_mla(query, cache, indices.int(), metadata, 0.5), query)
+
+
+def test_rope_sfa_keeps_rotary_tables_and_kernel_pages(monkeypatch):
+    builder = _builder(384, False, monkeypatch, rope_dim=64)
+    common = _common(384)
+    common.seq_lens_cpu = common.seq_lens.clone()
+    cos, sin = torch.randn(4, 64), torch.randn(4, 64)
+    with patch.object(sfa, "get_cos_and_sin_mla", return_value=(cos, sin)) as rotary:
+        metadata = builder.build(0, common)
+    rotary.assert_called_once()
+    torch.testing.assert_close(rotary.call_args.args[0], common.positions)
+    assert rotary.call_args.kwargs == {"use_cache": True}
+    assert metadata.cos.data_ptr() == cos.data_ptr()
+    assert metadata.sin.data_ptr() == sin.data_ptr()
+    assert metadata.block_table.data_ptr() == common.block_table_tensor.data_ptr()
+    assert not builder.nope_states and metadata.smla_metadata is None
+
+
+@pytest.mark.parametrize("sfa_c8,li_c8", [(False, False), (True, False), (False, True), (True, True)])
+def test_rope_sfa_preserves_cache_composition_and_device_dispatch(sfa_c8, li_c8):
+    impl = object.__new__(sfa.AscendSFAImpl)
+    impl.qk_rope_head_dim = 64
+    impl.layer_name = "model.layers.0.self_attn"
+    impl.has_indexer = True
+    impl.enable_sparse_sfa_c8, impl.enable_sparse_li_c8 = sfa_c8, li_c8
+    main = tuple(torch.empty(1) for _ in range(1 if sfa_c8 else 2))
+    indexer = tuple(torch.empty(1) for _ in range(2 if li_c8 else 1))
+    impl.indexer = SimpleNamespace(k_cache=SimpleNamespace(kv_cache=indexer), num_cache_tensors=len(indexer))
+    composed = impl._compose_sfa_kv_cache(main)
+    assert all(actual is expected for actual, expected in zip(composed, (*main, *indexer), strict=True))
+    inputs = [object() for _ in range(6)]
+    q, rope, indices, metadata, query_lens, seq_lens = inputs
+    with patch.object(sfa.DeviceOperator, "execute_sparse_flash_attention_process") as dispatch:
+        result = impl._execute_sparse_flash_attention_process(
+            q, rope, composed, indices, metadata, query_lens, seq_lens
+        )
+    assert result is dispatch.return_value
+    dispatch.assert_called_once_with(impl, q, rope, composed, indices, metadata, query_lens, seq_lens, block_table=None)
+
+
+@pytest.mark.parametrize("a5", [False, True])
+def test_nope_operator_masks_unwritten_graph_rows(monkeypatch, a5):
+    query = torch.ones(3, 2, 128)
+    cache = torch.zeros(2, 128, 1, 128)
+    metadata = SimpleNamespace(
+        smla_metadata=torch.empty(1024, dtype=torch.int32) if a5 else None,
+        smla_topk_length=torch.tensor([[1], [1], [0]], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+        block_table=torch.tensor([[0], [1]], dtype=torch.int32),
+        block_size=128,
+    )
+
+    def op(*args, **kwargs):
+        result = query.clone()
+        result[2] = float("nan")
+        return (result,)
+
+    if a5:
+        monkeypatch.setattr(sparse_mla, "sparse_flash_mla", op)
+    else:
+        monkeypatch.setattr(torch.ops._C_ascend, "npu_sparse_flash_attention", op, raising=False)
+    output = sparse_mla.sparse_mla(query, cache, torch.tensor([[[0]], [[0]], [[-1]]], dtype=torch.int32), metadata, 0.5)
+    torch.testing.assert_close(output[:2], query[:2])
+    assert (output[2] == 0).all()
+
+
+def test_a5_smla_uses_original_cache_sorted_indices_and_stable_metadata(monkeypatch):
+    buffer = torch.empty(sparse_mla.SMLA_METADATA_SIZE, dtype=torch.int32)
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([8, 4], dtype=torch.int32),
+        max_query_len=1,
+        max_seq_len=8,
+        block_table=torch.tensor([[2], [1]], dtype=torch.int32),
+        smla_metadata=None,
+        smla_topk_length=torch.full((2, 1), 3, dtype=torch.int32),
+    )
+
+    def build(**kwargs):
+        assert isinstance(kwargs["max_seqlen_q"], int) and isinstance(kwargs["max_seqlen_ori_kv"], int)
+        assert kwargs["has_ori_kv"] and not kwargs["has_cmp_kv"]
+        assert kwargs["ori_topk_length"] is metadata.smla_topk_length
+        return torch.full_like(buffer, metadata.max_seq_len)
+
+    monkeypatch.setattr(sparse_mla, "sparse_flash_mla_metadata", build)
+    sparse_mla.build_smla_metadata(metadata, buffer, 2, 128, 7)
+    address = metadata.smla_metadata.data_ptr()
+    metadata.max_seq_len = 12
+    sparse_mla.build_smla_metadata(metadata, buffer, 2, 128, 7)
+    assert metadata.smla_metadata.data_ptr() == address
+    assert (metadata.smla_metadata == 12).all()
+    query = torch.ones(2, 2, 128, dtype=torch.bfloat16)
+    cache = torch.zeros(3, 8, 1, 128, dtype=torch.bfloat16)
+    indices = torch.tensor([[[7, 6, -1, 0]], [[2, -1, 1, 0]]], dtype=torch.int32)
+
+    def smla(q, **kwargs):
+        assert kwargs["ori_kv"] is cache
+        assert kwargs["sinks"] is None
+        assert kwargs.get("cmp_kv") is None
+        assert kwargs["metadata"] is buffer
+        assert kwargs["layout_kv"] == "PA_BBND" and kwargs["topk_value_mode"] == 1
+        torch.testing.assert_close(
+            kwargs["ori_sparse_indices"], torch.tensor([[[0, 6, 7, -1]], [[0, 1, 2, -1]]], dtype=torch.int32)
+        )
+        torch.testing.assert_close(kwargs["ori_topk_length"], metadata.smla_topk_length)
+        return q + 1, torch.empty(0)
+
+    monkeypatch.setattr(sparse_mla, "sparse_flash_mla", smla)
+    torch.testing.assert_close(sparse_mla.sparse_mla(query, cache, indices, metadata, 0.5), query + 1)

--- a/tests/ut/attention/test_sfa_o_proj_weight_switch.py
+++ b/tests/ut/attention/test_sfa_o_proj_weight_switch.py
@@ -197,6 +197,7 @@ class TestAscendSFAOProjWeightSwitch(TestBase):
         impl.q_lora_rank = 8
         impl.kv_lora_rank = 4
         impl.qk_rope_head_dim = 2
+        impl.g_proj = None
         impl.layer_name = "layers.0.attn"
 
         q_c = MagicMock()

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -240,6 +240,7 @@ class TestAscendSFACacheComposition(TestBase):
                 enable_li_c8=enable_li_c8,
             ):
                 impl = AscendSFAImpl.__new__(AscendSFAImpl)
+                impl.qk_rope_head_dim = 64
                 impl.layer_name = "model.layers.0.self_attn.attn"
                 impl.has_indexer = True
                 impl.enable_sparse_sfa_c8 = enable_sfa_c8

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -107,6 +107,13 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
 
     accept_output_buffer: bool = True
 
+    @property
+    def topk_output_width(self) -> int:
+        return self.topk_tokens
+
+    def get_topk_lengths(self, positions: torch.Tensor) -> torch.Tensor:
+        return (positions + 1).clamp(min=0, max=self.topk_tokens)
+
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None
     k_hadamard: torch.Tensor | None = None

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -6,10 +6,12 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import torch
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,  # type: ignore
     AttentionCGSupport,
@@ -21,6 +23,7 @@ from vllm.v1.worker.utils import select_common_block_size
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.sparse_flash_mla import sparse_flash_mla, sparse_flash_mla_metadata
 from vllm_ascend.attention.utils import (
     MLAPO_MAX_SUPPORTED_TOKENS,
     SFA_QSFA_TILE_SIZE,
@@ -29,12 +32,13 @@ from vllm_ascend.attention.utils import (
     get_sfa_qsfa_packed_head_dim,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
+    scatter_paged_cache,
     trans_rope_weight,
     transdata,
     wait_for_kv_layer_from_connector,
 )
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.device.hardware_profile import DeviceAdaptorFamily, HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import (
     record_attention_compute_start,
 )
@@ -61,6 +65,167 @@ if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
     from vllm_ascend.worker.npu_input_batch import NPUInputBatch
+
+
+# NoPE sparse MLA operator helpers.
+SMLA_METADATA_SIZE = 1024
+SPARSE_ATTENTION_MAX_BLOCK_SIZE = 1024
+
+
+def build_smla_metadata(metadata, buffer, num_heads, head_dim, topk):
+    generated = sparse_flash_mla_metadata(
+        num_heads_q=num_heads,
+        num_heads_kv=1,
+        head_dim=head_dim,
+        cu_seqlens_q=metadata.query_start_loc,
+        seqused_ori_kv=metadata.seq_lens,
+        ori_topk_length=metadata.smla_topk_length,
+        batch_size=metadata.seq_lens.numel(),
+        # These are scheduler CPU scalars. Passing device max() results here
+        # would force a host synchronization for each metadata build.
+        max_seqlen_q=metadata.max_query_len,
+        max_seqlen_ori_kv=metadata.max_seq_len,
+        max_seqlen_cmp_kv=0,
+        ori_topk=topk,
+        cmp_topk=0,
+        cmp_ratio=1,
+        ori_mask_mode=3,
+        cmp_mask_mode=3,
+        ori_win_left=0,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_BBND",
+        has_ori_kv=True,
+        has_cmp_kv=False,
+        device=str(metadata.seq_lens.device),
+    )
+    buffer.copy_(generated)
+    metadata.smla_metadata = buffer
+
+
+def sparse_mla(query, cache, indices, metadata, scale):
+    """Attend to original latent KV, using the platform's NoPE operator."""
+    if metadata.smla_metadata is not None:
+        # The A5 DMA merges adjacent columns. Preserve the selected set while
+        # sorting token positions and moving invalid padding to the end.
+        sentinel = torch.iinfo(torch.int32).max
+        sorted_indices = torch.where(indices >= 0, indices, sentinel).sort(dim=-1).values
+        sorted_indices = torch.where(sorted_indices == sentinel, -1, sorted_indices)
+        result = sparse_flash_mla(
+            query.contiguous(),
+            ori_kv=cache,
+            ori_sparse_indices=sorted_indices,
+            ori_block_table=metadata.block_table,
+            cu_seqlens_q=metadata.query_start_loc,
+            seqused_ori_kv=metadata.seq_lens,
+            ori_topk_length=metadata.smla_topk_length[: query.shape[0]],
+            sinks=None,
+            metadata=metadata.smla_metadata,
+            softmax_scale=scale,
+            cmp_ratio=1,
+            ori_mask_mode=3,
+            cmp_mask_mode=3,
+            ori_win_left=0,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_BBND",
+            topk_value_mode=1,
+            return_softmax_lse=False,
+        )
+    else:
+        # Large, contiguous hybrid storage pages need a C128 view to meet
+        # the A2/A3 limit. Keep supported page-strided layouts unchanged.
+        if cache.shape[1] != metadata.block_size:
+            cache = cache.view(-1, metadata.block_size, *cache.shape[2:])
+        result = torch.ops._C_ascend.npu_sparse_flash_attention(
+            query=query.contiguous(),
+            key=cache,
+            value=cache,
+            sparse_indices=indices,
+            scale_value=scale,
+            sparse_block_size=1,
+            block_table=metadata.block_table,
+            actual_seq_lengths_query=metadata.query_start_loc[1:].to(torch.int32),
+            actual_seq_lengths_kv=metadata.seq_lens.to(torch.int32),
+            query_rope=None,
+            key_rope=None,
+            layout_query="TND",
+            layout_kv="PA_BSND",
+            sparse_mode=3,
+            attention_mode=2,
+            return_softmax_lse=False,
+        )
+    output = result[0]
+    # Kernels may leave graph-capacity rows unwritten. Mask on device before
+    # value/output projections so NaNs in padding cannot escape the layer.
+    valid = torch.arange(query.shape[0], device=query.device) < metadata.query_start_loc[-1]
+    return output.masked_fill(~valid[:, None, None], 0)
+
+
+class SparseMLAMetadataState:
+    """Persistent operator buffers for NoPE within the shared SFA builder.
+
+    Indexers supply their visible index counts. Pool construction and scoring
+    remain entirely outside attention metadata and operator dispatch.
+    """
+
+    def __init__(self, kv_cache_spec, vllm_config, device, indexer, kernel_block_size=128):
+        block_size = kv_cache_spec.block_size
+        if block_size <= 0 or block_size % kernel_block_size:
+            raise ValueError("Sparse MLA block size must be a positive multiple of the SFA kernel block size.")
+        self.split = block_size // kernel_block_size
+        self.use_smla = get_current_hardware_profile().device_adaptor_family == DeviceAdaptorFamily.FP8_OPTIMIZED
+        self.block_size = block_size
+        if not self.use_smla and block_size > SPARSE_ATTENTION_MAX_BLOCK_SIZE:
+            self.block_size = kernel_block_size
+        self.table_stride = self.block_size // kernel_block_size
+        table_width = cdiv(vllm_config.model_config.max_model_len, block_size) * (block_size // self.block_size)
+        self.block_table_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_seqs,
+            table_width,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.indexer = indexer
+        if self.use_smla:
+            if indexer is None:
+                raise ValueError("A5 NoPE sparse MLA requires an indexer to supply visible top-k lengths.")
+            config = vllm_config.model_config.hf_text_config
+            self.num_heads = config.num_attention_heads // vllm_config.parallel_config.tensor_parallel_size
+            self.head_dim = config.kv_lora_rank
+            self.metadata_buffer = torch.empty(SMLA_METADATA_SIZE, dtype=torch.int32, device=device)
+            self.length_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                1,
+                dtype=torch.int32,
+                device=device,
+            )
+
+    def prepare(self, metadata):
+        expanded = metadata.block_table
+        if expanded.shape[1] % self.split:
+            raise ValueError("Sparse MLA received a partially expanded SFA block table.")
+        width = expanded.shape[1] // self.table_stride
+        if width > self.block_table_buffer.shape[1]:
+            raise ValueError("Sparse MLA block table exceeds its persistent buffer.")
+        table = self.block_table_buffer[: expanded.shape[0], :width]
+        torch.div(expanded[:, :: self.table_stride], self.table_stride, rounding_mode="floor", out=table)
+        metadata.block_table = table
+        metadata.block_size = self.block_size
+        if self.use_smla:
+            positions = metadata.positions
+            if positions.numel() > self.length_buffer.shape[0]:
+                raise ValueError("Sparse MLA token count exceeds its persistent top-k buffer.")
+            lengths = self.length_buffer[: positions.numel()]
+            counts = self.indexer.get_topk_lengths(positions)
+            valid = torch.arange(positions.numel(), device=positions.device) < metadata.query_start_loc[-1]
+            lengths[:, 0].copy_(counts.masked_fill(~valid, 0))
+            metadata.smla_topk_length = lengths
+            build_smla_metadata(
+                metadata, self.metadata_buffer, self.num_heads, self.head_dim, self.indexer.topk_output_width
+            )
+        return metadata
+
 
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
@@ -156,11 +321,11 @@ class AscendSFAMetadata:
     num_actual_tokens: int  # Number of tokens excluding padding.
     slot_mapping: torch.Tensor
     seq_lens: torch.Tensor
-    seq_lens_cpu: torch.Tensor
+    seq_lens_cpu: torch.Tensor | None
     cum_query_lens: torch.Tensor
     block_table: torch.Tensor
-    sin: torch.Tensor
-    cos: torch.Tensor
+    sin: torch.Tensor | None
+    cos: torch.Tensor | None
 
     # For logging.
     num_input_tokens: int = 0  # Number of tokens including padding.
@@ -182,6 +347,12 @@ class AscendSFAMetadata:
     # by AscendSFAKVOffloadMetadataBuilder.
     req_ids_tensor: torch.Tensor | None = None
     token_to_req: torch.Tensor | None = None
+    positions: torch.Tensor | None = None
+    query_start_loc: torch.Tensor | None = None
+    max_query_len: int = 0
+    max_seq_len: int = 0
+    smla_metadata: torch.Tensor | None = None
+    smla_topk_length: torch.Tensor | None = None
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
@@ -224,6 +395,13 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFABackend])
+
+        layer = vllm_config.compilation_config.static_forward_context[layer_names[0]]
+        self.nope = layer.qk_rope_head_dim == 0
+        self.nope_states: dict[int | None, SparseMLAMetadataState] = {}
+        self.nope_indexer = None
+        if self.nope:
+            self.nope_indexer = layer.impl.indexer
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
@@ -341,10 +519,17 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             seq_lens_cpu = common_attn_metadata._seq_lens_cpu[:num_reqs]
         elif common_attn_metadata.seq_lens_cpu is not None:
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu[:num_reqs]
+        elif self.nope:
+            # MTP accepted counts are device-resident. NoPE operators use
+            # device lengths and scheduler upper bounds, so need no CPU copy.
+            seq_lens_cpu = None
         else:
             seq_lens_cpu = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
 
-        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=(draft_index is None))
+        if self.nope:
+            cos, sin = None, None
+        else:
+            cos, sin = get_cos_and_sin_mla(input_positions, use_cache=(draft_index is None))
 
         cos, sin, slot_mapping, parallel_metadata = self._prepare_parallel_metadata(
             common_attn_metadata,
@@ -365,7 +550,7 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 block_size,
             )
 
-        return self.metadata_cls(  # type: ignore
+        metadata = self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=num_actual_tokens,
             cum_query_lens=cum_query_lens,
@@ -377,14 +562,33 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             attn_mask=self.attn_mask_builder.get_attention_mask(common_attn_metadata.causal, self.model_config),
             attn_state=common_attn_metadata.attn_state,
             block_table=block_table,
-            sin=sin[:num_input_tokens],
-            cos=cos[:num_input_tokens],
+            sin=None if sin is None else sin[:num_input_tokens],
+            cos=None if cos is None else cos[:num_input_tokens],
+            positions=input_positions,
+            query_start_loc=common_attn_metadata.query_start_loc[: num_reqs + 1],
+            max_query_len=common_attn_metadata.max_query_len,
+            max_seq_len=common_attn_metadata.max_seq_len,
             block_size=block_size,
             group_len=common_attn_metadata.group_len,
             group_key_idx=common_attn_metadata.group_key_idx,
             group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
             **parallel_metadata,
         )
+        if self.nope:
+            query_lens = (
+                common_attn_metadata.query_start_loc_cpu[1 : num_reqs + 1]
+                - common_attn_metadata.query_start_loc_cpu[:num_reqs]
+            )
+            is_prefilling = query_lens > getattr(common_attn_metadata, "decode_token_per_req", 1)
+            metadata.num_prefills = int(is_prefilling.sum())
+            metadata.num_decodes = num_reqs - metadata.num_prefills
+            metadata.num_decode_tokens = int(query_lens[~is_prefilling].sum())
+            if draft_index not in self.nope_states:
+                self.nope_states[draft_index] = SparseMLAMetadataState(
+                    self.kv_cache_spec, self.vllm_config, self.device, self.nope_indexer, self.kernel_block_size
+                )
+            self.nope_states[draft_index].prepare(metadata)
+        return metadata
 
     def build_for_cudagraph_capture(
         self,
@@ -451,6 +655,11 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.kv_b_proj = kwargs["kv_b_proj"]
         self.o_proj = kwargs["o_proj"]
         self.indexer = kwargs["indexer"]
+        self.g_proj = kwargs.get("g_proj")
+        # NoPE sparse layers use the same SFA template and native prefill;
+        # they do not need an upstream dense-MHA prefill backend.
+        if self.qk_rope_head_dim == 0:
+            self.supports_dense_mha_prefill = False
         self.kv_a_proj_with_mqa = kwargs.get("kv_a_proj_with_mqa")
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
         self.q_a_layernorm = kwargs.get("q_a_layernorm")
@@ -504,6 +713,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         # The user-facing switches control these layouts independently. LI C8
         # applies only to layers that own an indexer cache.
         self.enable_sparse_sfa_c8 = ascend_config.enable_sparse_sfa_c8
+        if self.qk_rope_head_dim == 0 and self.enable_sparse_sfa_c8:
+            raise NotImplementedError("NoPE SFA currently requires an unquantized latent KV cache.")
         self.enable_sparse_li_c8 = self.has_indexer and self.indexer.enable_sparse_li_c8
         if self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8:
             if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
@@ -635,6 +846,8 @@ class AscendSFAImpl(MLAAttentionImpl):
 
     def _get_fused_type_unsupported_reasons(self, pp_type: PreprocessType) -> list[str]:
         reasons = []
+        if self.qk_rope_head_dim == 0:
+            reasons.append("NoPE SFA currently uses native preprocessing; fused NoPE contracts are not enabled.")
         if self.kv_a_layernorm is None or self.q_a_layernorm is None:
             reasons.append("Fused preprocessing requires q_a_layernorm and kv_a_layernorm.")
         if self.fused_qkv_a_proj is None:
@@ -820,6 +1033,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         slots: torch.Tensor,
         attn_metadata: M,
     ):
+        if self.qk_rope_head_dim == 0:
+            assert self.kv_a_layernorm is not None
+            values = self.kv_a_layernorm(kv_no_split.reshape(-1, self.kv_lora_rank))
+            cache = kv_cache[0]
+            scatter_paged_cache(cache, slots[: values.shape[0]].long(), values.to(cache.dtype), cache.shape[1])
+            return None, None
         B = kv_no_split.shape[0]
         N = self.num_kv_heads
         S = 1
@@ -1109,6 +1328,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         actual_seq_lengths_key,
         block_table=None,
     ):
+        if self.qk_rope_head_dim == 0:
+            return sparse_mla(ql_nope, kv_cache[0], topk_indices, attn_metadata, self.scale)
         return DeviceOperator.execute_sparse_flash_attention_process(
             self,
             ql_nope,
@@ -1250,7 +1471,20 @@ class AscendSFAImpl(MLAAttentionImpl):
         # separate cache specs, while the current kernel path still expects the
         # legacy combined tuple layout.
         main_cache = kv_cache
-        if main_cache is None or not self.has_indexer:
+        if main_cache is None:
+            return None
+        if self.qk_rope_head_dim == 0:
+            # The page-strided allocator may retain an empty RoPE view for
+            # the common MLA layout. It owns no storage and is not an input
+            # to the NoPE operator.
+            if len(main_cache) == 2 and main_cache[1].numel() == 0:
+                return (main_cache[0],)
+            if len(main_cache) != 1:
+                raise RuntimeError("NoPE SFA requires one latent KV cache tensor.")
+            # The indexer owns and consumes its own cache. No LightningIndexer
+            # cache layout is imposed on this attention operator.
+            return main_cache
+        if not self.has_indexer:
             return main_cache
 
         # Sparse KV offload registers the main MLA cache as a 6-tuple
@@ -1319,6 +1553,15 @@ class AscendSFAImpl(MLAAttentionImpl):
             # Profiling run.
             return output.fill_(0)
 
+        if self.qk_rope_head_dim == 0:
+            num_tokens = min(hidden_states.shape[0], attn_metadata.slot_mapping.shape[0])
+            if get_forward_context().cudagraph_runtime_mode != CUDAGraphMode.FULL:
+                num_tokens = min(num_tokens, attn_metadata.num_actual_tokens)
+            if num_tokens == 0:
+                return output.zero_()
+            hidden_states = hidden_states[:num_tokens]
+        gate_hidden_states = hidden_states if self.g_proj is not None else None
+
         composed_kv_cache = self._compose_sfa_kv_cache(kv_cache)
         assert composed_kv_cache is not None
         kv_cache = composed_kv_cache
@@ -1329,7 +1572,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         indexer_attn_metadata = self._get_indexer_attn_metadata()
 
         # Inputs and outputs may be padded for CUDA graphs
-        num_input_tokens = attn_metadata.num_input_tokens
+        num_input_tokens = hidden_states.shape[0] if self.qk_rope_head_dim == 0 else attn_metadata.num_input_tokens
         parallel_context = self._get_parallel_forward_context(
             attn_metadata,
             num_input_tokens,
@@ -1414,7 +1657,8 @@ class AscendSFAImpl(MLAAttentionImpl):
             )
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
-            q_pe = self.rope_single(q_pe, cos, sin)
+            if self.qk_rope_head_dim:
+                q_pe = self.rope_single(q_pe, cos, sin)
             self._record_query_gather_context(
                 ql_nope,
                 q_pe,
@@ -1492,6 +1736,13 @@ class AscendSFAImpl(MLAAttentionImpl):
         )
 
         attn_output = self._v_up_proj(attn_output)
+        if gate_hidden_states is not None:
+            assert self.g_proj is not None
+            attn_output.mul_(torch.sigmoid(self.g_proj(gate_hidden_states.contiguous())[0]))
+        if self.qk_rope_head_dim == 0 and attn_output.shape[0] < output.shape[0]:
+            padded = attn_output.new_zeros((output.shape[0], attn_output.shape[1]))
+            padded[: attn_output.shape[0]] = attn_output
+            attn_output = padded
 
         output = self._finalize_o_proj(
             attn_output,

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -80,6 +80,37 @@ def get_sfa_qsfa_packed_head_dim(
     return kv_lora_rank + qk_rope_head_dim * get_dtype_size(torch.bfloat16) + scale_metadata_bytes
 
 
+def scatter_paged_cache(
+    cache: torch.Tensor,
+    slots: torch.Tensor,
+    values: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Write unique valid slots, preserving padded rows during graph replay."""
+    if cache.shape[1] != block_size:
+        raise ValueError(f"Cache block size mismatch: metadata={block_size}, tensor={cache.shape[1]}.")
+    values = values.reshape(values.shape[0], *cache.shape[2:])
+    valid = (slots >= 0) & (slots < cache.shape[0] * block_size)
+    safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
+    block_ids = torch.div(safe_slots, block_size, rounding_mode="floor")
+    block_offsets = torch.remainder(safe_slots, block_size)
+    row_mask = valid.view(-1, *([1] * (values.ndim - 1)))
+
+    # Invalid rows use a fixed sentinel; restore its original value unless
+    # slot zero is itself a valid write. All operations retain static shapes.
+    old_zero = cache[0, 0].clone()
+    safe_values = torch.where(row_mask, values, old_zero.unsqueeze(0))
+    writes_zero = valid & (slots == 0)
+    zero_value = torch.where(
+        writes_zero.view(-1, *([1] * (values.ndim - 1))),
+        values,
+        torch.zeros_like(values),
+    ).sum(dim=0)
+    expected_zero = torch.where(writes_zero.any(), zero_value, old_zero)
+    cache[block_ids, block_offsets] = safe_values
+    cache[0, 0].copy_(expected_zero)
+
+
 @dataclass
 class PagedAttentionGraphParam:
     """Mark PA params when PA and FIA share one graph replay list."""

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -79,6 +79,14 @@ class IndexerWrapper(nn.Module):
     def num_cache_tensors(self) -> int:
         return self.impl.num_cache_tensors
 
+    @property
+    def topk_output_width(self) -> int:
+        return self.impl.topk_output_width
+
+    def get_topk_lengths(self, positions: torch.Tensor) -> torch.Tensor:
+        """Return model-defined visible index counts for attention planning."""
+        return self.impl.get_topk_lengths(positions)
+
     def process_weights_after_loading(self) -> None:
         self.impl.process_weights_after_loading()
 


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Extend the shared SFA backend to execute sparse MLA without RoPE. Add NoPE preprocessing and forward execution, physical-page cache addressing, graph-stable metadata buffers, and indexer-provided visible top-k lengths. Keep cache ownership with the indexer and mask unwritten graph-padding rows before output projections.

Reuse the existing hardware-specific operators:

- A2/A3: `npu_sparse_flash_attention` with NoPE support from #16241, now merged.
- A5: the DeepSeek-V4 sparse MLA interface in `vllm_ascend/attention/sparse_flash_mla.py`, backed by the CANN `cann_ops_transformer` operators.

This PR contains shared attention integration. GLM KeyPool model routing is handled separately in #16253.

### Does this PR introduce _any_ user-facing change?

Yes. The shared SFA backend supports NoPE attention on A2/A3 and A5 when the corresponding operators are available. Existing RoPE behavior and cache allocation/grouping are preserved.

### How was this patch tested?

- The following files passed in a CPU integration run with 319 total passing tests, covering metadata/addressing, operator dispatch, NoPE forward behavior, and existing SFA regressions:

  ```bash
  pytest -q \
    tests/ut/attention/test_sfa_nope_metadata.py \
    tests/ut/attention/test_sfa_nope_forward.py \
    tests/ut/attention/test_sfa_v1.py
  ```

- A focused rerun of the same three files on A3 passed 60 tests.
- GitHub CI passed pre-commit, CPU unit tests, selected device tests, and the CI gate on the current head.

The focused unit tests use mocked operator calls and do not establish native numerical accuracy. A5 native operator validation remains outstanding.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
