### PR TITLE
[BugFix][Docker] Pass RUSTUP_DIST_SERVER/RUSTUP_UPDATE_ROOT build-args to build_rust.sh

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -33,12 +33,7 @@ on:
         required: false
         type: string
         default: 'release'
-        description: "Build type: 'daily' or 'release'. Daily uses swr.cn-north-4 and quay.io base image."
-      quay_daily_username:
-        required: false
-        type: string
-        default: ''
-        description: "Quay username for daily base image pull"
+        description: "Build type: 'daily' or 'release'. Daily uses swr.cn-north-12 base image."
       cann_version:
         required: false
         type: string
@@ -50,17 +45,11 @@ on:
         default: 'auto'
         description: "Base image date (YYYYMMDD). 'auto' to auto-detect latest available, or specify a custom date."
     secrets:
-      HW_USERNAME:
+      SWR_USERNAME:
         required: false
-      HW_TOKEN:
-        required: false
-      HW_USERNAME_DAILY:
-        required: false
-      HW_TOKEN_DAILY:
+      SWR_PASSWORD:
         required: false
       GITEE_TOKEN:
-        required: false
-      QUAY_DAILY_PASSWORD:
         required: false
 
 jobs:
@@ -98,30 +87,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.vllm_ascend_branch }}
 
-      - name: Login to Huawei Cloud SWR (Release)
+      - name: Login to SWR north-12
         id: login-swr
-        if: ${{ inputs.build_type != 'daily' || (inputs.build_type == 'daily' && matrix.os == 'ubuntu' && matrix.arch_name == 'arm64') }}
         env:
-          HW_USERNAME: ${{ secrets.HW_USERNAME }}
-          HW_TOKEN: ${{ secrets.HW_TOKEN }}
+          SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+          SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          echo "$HW_TOKEN" | docker login -u "$HW_USERNAME" --password-stdin swr.cn-southwest-2.myhuaweicloud.com
-
-      - name: Login to Huawei Cloud SWR (Daily)
-        id: login-swr-daily
-        if: ${{ inputs.build_type == 'daily' }}
-        env:
-          HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-          HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
-        run: |
-          docker login -u cn-north-4@"$HW_USERNAME_DAILY" -p "$HW_TOKEN_DAILY" swr.cn-north-4.myhuaweicloud.com
-
-      - name: Login to Quay.io (for daily base image pull)
-        if: ${{ inputs.build_type == 'daily' }}
-        env:
-          QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
-        run: |
-          docker login -u "${{ inputs.quay_daily_username }}" -p "$QUAY_DAILY_PASSWORD" quay.io
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
 
       - name: Build nightly-${{ inputs.target }} image
         id: build
@@ -133,13 +105,13 @@ jobs:
           BRANCH_TAG="${BRANCH_TAG//\//-}"
 
           if [ "${{ inputs.build_type }}" = "daily" ]; then
-            SWR_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend-temp"
+            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
+            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
             TAG_PREFIX="daily"
-            BASE_IMAGE="quay.io/atlas_inference/vllm-ascend"
+            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
           else
-            SWR_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend-temp"
+            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
+            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp"
             TAG_PREFIX="nightly-ci"
             BASE_IMAGE=""
           fi
@@ -152,14 +124,14 @@ jobs:
           fi
           if [ "${{ inputs.build_type }}" = "daily" ]; then
             # Resolve the base image date: 'auto' backtracks day-by-day from today to find
-            # the latest date for which the quay base image exists; otherwise use the
+            # the latest date for which the SWR base image exists; otherwise use the
             # user-supplied date (YYYYMMDD).
             if [ "${{ inputs.base_image_date }}" = "auto" ] || [ -z "${{ inputs.base_image_date }}" ]; then
               DATE=""
               for i in $(seq 0 30); do
                 CANDIDATE_DATE=$(date -d "$i days ago" +'%Y%m%d')
                 CANDIDATE_TAG="nightly-${BRANCH_TAG}${OS_MARK}-cann${CANN_VERSION_LOWER}-${CANDIDATE_DATE}"
-                if docker manifest inspect "quay.io/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
+                if docker manifest inspect "swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
                   DATE="$CANDIDATE_DATE"
                   echo "Found base image date: $DATE (tag: $CANDIDATE_TAG)"
                   break
@@ -220,14 +192,14 @@ jobs:
             echo "push_registry=${SWR_REGISTRY}"
           fi
 
-          if [ "${{ github.repository_owner }}" = "vllm-project" ] && [ "${{ steps.login-swr.outcome == 'success' || steps.login-swr-daily.outcome == 'success' }}" = "true" ]; then
+          if [ "${{ github.repository_owner }}" = "vllm-project" ] && [ "${{ steps.login-swr.outcome == 'success' }}" = "true" ]; then
             echo "swr_logged_in=true"
           else
             echo "swr_logged_in=false"
           fi
 
       - name: Push image to SWR
-        if: ${{ github.repository_owner == 'vllm-project' && (steps.login-swr.conclusion == 'success' || steps.login-swr-daily.conclusion == 'success') }}
+        if: ${{ github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
         run: |
           PUSH_REGISTRY="${{ steps.build.outputs.push_registry }}"
           FULL_TAG="${{ steps.build.outputs.full_tag }}"
@@ -246,7 +218,7 @@ jobs:
         run: |
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
-          RELEASE_SWR_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
+          RELEASE_SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
           RELEASE_TAG="nightly-ci-${BRANCH_TAG}-${{ inputs.target }}"
           # Release copy uses a stable tag without arch info (single-arch arm64 image)
           RELEASE_IMAGE="${RELEASE_SWR_REGISTRY}:${RELEASE_TAG}"
@@ -262,19 +234,19 @@ jobs:
     # only when BOTH arch images exist. Owner gate keeps it disabled in upstream forks.
     if: ${{ always() && github.repository_owner == 'vllm-project' && inputs.build_type == 'daily' }}
     steps:
-      - name: Login to Huawei Cloud SWR (Daily)
+      - name: Login to SWR north-12
         env:
-          HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-          HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+          SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+          SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          docker login -u cn-north-4@"$HW_USERNAME_DAILY" -p "$HW_TOKEN_DAILY" swr.cn-north-4.myhuaweicloud.com
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
 
       - name: Create multi-arch manifest
         run: |
           # Registry and tag are recomputed here (not from matrix outputs) so merge still
           # works even when the last-completed matrix instance failed to push.
-          MAIN_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend"
-          TEMP_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend-temp"
+          MAIN_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
+          TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
 
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -33,7 +33,12 @@ on:
         required: false
         type: string
         default: 'release'
-        description: "Build type: 'daily' or 'release'. Daily uses swr.cn-north-12 base image."
+        description: "Build type: 'daily' or 'release'. Daily uses swr_registry base image."
+      swr_registry:
+        required: false
+        type: string
+        default: 'swr.cn-north-12.myhuaweicloud.com'
+        description: 'SWR registry domain'
       cann_version:
         required: false
         type: string
@@ -87,13 +92,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.vllm_ascend_branch }}
 
-      - name: Login to SWR north-12
+      - name: Login to SWR
         id: login-swr
         env:
           SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
           SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin ${{ inputs.swr_registry }}
 
       - name: Build nightly-${{ inputs.target }} image
         id: build
@@ -105,13 +110,13 @@ jobs:
           BRANCH_TAG="${BRANCH_TAG//\//-}"
 
           if [ "${{ inputs.build_type }}" = "daily" ]; then
-            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
+            SWR_REGISTRY="${{ inputs.swr_registry }}/atlas_inference/vllm-ascend"
+            SWR_TEMP_REGISTRY="${{ inputs.swr_registry }}/atlas_inference/vllm-atlas-temp"
             TAG_PREFIX="daily"
-            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
+            BASE_IMAGE="${{ inputs.swr_registry }}/atlas_inference/vllm-ascend"
           else
-            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp"
+            SWR_REGISTRY="${{ inputs.swr_registry }}/ascend/vllm-ascend"
+            SWR_TEMP_REGISTRY="${{ inputs.swr_registry }}/atlas_ci/vllm-atlas-temp"
             TAG_PREFIX="nightly-ci"
             BASE_IMAGE=""
           fi
@@ -131,7 +136,7 @@ jobs:
               for i in $(seq 0 30); do
                 CANDIDATE_DATE=$(date -d "$i days ago" +'%Y%m%d')
                 CANDIDATE_TAG="nightly-${BRANCH_TAG}${OS_MARK}-cann${CANN_VERSION_LOWER}-${CANDIDATE_DATE}"
-                if docker manifest inspect "swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
+                if docker manifest inspect "${{ inputs.swr_registry }}/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
                   DATE="$CANDIDATE_DATE"
                   echo "Found base image date: $DATE (tag: $CANDIDATE_TAG)"
                   break
@@ -218,7 +223,7 @@ jobs:
         run: |
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
-          RELEASE_SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
+          RELEASE_SWR_REGISTRY="${{ inputs.swr_registry }}/ascend/vllm-ascend"
           RELEASE_TAG="nightly-ci-${BRANCH_TAG}-${{ inputs.target }}"
           # Release copy uses a stable tag without arch info (single-arch arm64 image)
           RELEASE_IMAGE="${RELEASE_SWR_REGISTRY}:${RELEASE_TAG}"
@@ -234,19 +239,19 @@ jobs:
     # only when BOTH arch images exist. Owner gate keeps it disabled in upstream forks.
     if: ${{ always() && github.repository_owner == 'vllm-project' && inputs.build_type == 'daily' }}
     steps:
-      - name: Login to SWR north-12
+      - name: Login to SWR
         env:
           SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
           SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin ${{ inputs.swr_registry }}
 
       - name: Create multi-arch manifest
         run: |
           # Registry and tag are recomputed here (not from matrix outputs) so merge still
           # works even when the last-completed matrix instance failed to push.
-          MAIN_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
-          TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
+          MAIN_REGISTRY="${{ inputs.swr_registry }}/atlas_inference/vllm-ascend"
+          TEMP_REGISTRY="${{ inputs.swr_registry }}/atlas_inference/vllm-atlas-temp"
 
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -54,6 +54,21 @@ on:
         type: boolean
         default: false
         description: "If true, login to SWR and push built images. Set to false for PR verification builds."
+      cann_swr_url:
+        required: false
+        type: string
+        default: 'swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann'
+        description: "CANN base image URL (SWR registry) for the job container"
+      cann_image_version:
+        required: false
+        type: string
+        default: '9.1.0'
+        description: "CANN version for the job container image tag"
+      soc:
+        required: false
+        type: string
+        default: '910b'
+        description: "Ascend SoC type for the job container image tag (e.g. 910b, a3, 310p, 950)"
     secrets:
       SWR_USERNAME:
         required: false
@@ -81,6 +96,10 @@ jobs:
     needs: generate-matrix
     name: Build nightly-${{ inputs.target }}-${{ matrix.os }}-${{ matrix.arch_name }}
     runs-on: ${{ matrix.arch_runner }}
+    container:
+      image: ${{ format('{0}:{1}-{2}-ubuntu22.04-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc) }}
+      env:
+        SOC: ${{ inputs.soc }}
     strategy:
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     outputs:

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -49,6 +49,11 @@ on:
         type: string
         default: 'auto'
         description: "Base image date (YYYYMMDD). 'auto' to auto-detect latest available, or specify a custom date."
+      should_push:
+        required: false
+        type: boolean
+        default: false
+        description: "If true, login to SWR and push built images. Set to false for PR verification builds."
     secrets:
       SWR_USERNAME:
         required: false
@@ -94,6 +99,7 @@ jobs:
 
       - name: Login to SWR
         id: login-swr
+        if: ${{ inputs.should_push }}
         env:
           SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
           SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
@@ -204,7 +210,7 @@ jobs:
           fi
 
       - name: Push image to SWR
-        if: ${{ github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
+        if: ${{ inputs.should_push && github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
         run: |
           PUSH_REGISTRY="${{ steps.build.outputs.push_registry }}"
           FULL_TAG="${{ steps.build.outputs.full_tag }}"
@@ -219,7 +225,7 @@ jobs:
           fi
 
       - name: Push ubuntu arm64 image to release SWR (no arch tag)
-        if: ${{ inputs.build_type == 'daily' && matrix.os == 'ubuntu' && matrix.arch_name == 'arm64' && github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
+        if: ${{ inputs.should_push && inputs.build_type == 'daily' && matrix.os == 'ubuntu' && matrix.arch_name == 'arm64' && github.repository_owner == 'vllm-project' && steps.login-swr.conclusion == 'success' }}
         run: |
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
@@ -237,7 +243,7 @@ jobs:
     needs: build
     # Run even if some matrix instances failed. Each OS variant is merged independently,
     # only when BOTH arch images exist. Owner gate keeps it disabled in upstream forks.
-    if: ${{ always() && github.repository_owner == 'vllm-project' && inputs.build_type == 'daily' }}
+    if: ${{ inputs.should_push && always() && github.repository_owner == 'vllm-project' && inputs.build_type == 'daily' }}
     steps:
       - name: Login to SWR
         env:

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -325,7 +325,7 @@ jobs:
         file: ${{ inputs.dockerfile || 'Dockerfile' }}
         # only trigger when tag, branch/main push
         push: ${{ inputs.should_push }}
-        outputs: type=image,name=${{ inputs.swr_temp_repo }},push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }}
+        outputs: type=image,name=${{ inputs.swr_temp_repo }},push-by-digest=true,name-canonical=true,push=${{ inputs.should_push }},oci-mediatypes=false
         # Image builds can compile inside Docker and therefore keep a fallback;
         # NPU test jobs use fail-on-cache-miss instead.
         build-args: |
@@ -377,16 +377,12 @@ jobs:
         fi
         echo "Creating temp tag: ${{ env.swr_temp_repo }}:$TAG"
 
-        # Install skopeo if not present (image is Ubuntu-based).
-        if ! command -v skopeo >/dev/null 2>&1; then
-          apt-get update -qq && apt-get install -y -qq skopeo
-        fi
-        CREDS="${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}"
-        skopeo copy \
-          --src-creds "$CREDS" \
-          --dest-creds "$CREDS" \
-          "docker://${{ inputs.swr_temp_repo }}@${{ steps.build.outputs.digest }}" \
-          "docker://${{ inputs.swr_temp_repo }}:$TAG"
+        # Copy the digest to a temp tag to prevent GC. The build uses
+        # oci-mediatypes=false so the image is Docker v2s2, and this produces
+        # a Docker manifest list which SWR accepts (no skopeo/sudo needed).
+        docker buildx imagetools create \
+          -t "${{ inputs.swr_temp_repo }}:$TAG" \
+          "${{ inputs.swr_temp_repo }}@${{ steps.build.outputs.digest }}"
 
     - name: Export digest
       run: |
@@ -545,11 +541,6 @@ jobs:
 
           DIGEST_DIR="${{ runner.temp }}/digests"
 
-          # Install skopeo if not present.
-          if ! command -v skopeo >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq skopeo
-          fi
-
           echo "Digests:"
           ls -la "$DIGEST_DIR"
           echo "Current tags:"
@@ -566,50 +557,41 @@ jobs:
             fi
             echo "Creating tag $tag"
 
-            # Some registries (e.g. SWR) reject OCI image index produced by
-            # "docker buildx imagetools create". To work around this,
-            # copy each single-arch digest to the destination with a per-arch
-            # temp tag, converting to Docker v2 schema2 format via skopeo, then
-            # create a Docker manifest list which all registries accept.
-            DIGEST_REFS=""
+            # The build step outputs Docker v2 schema2 images (oci-mediatypes=false),
+            # so "docker buildx imagetools create" produces a Docker manifest list
+            # (application/vnd.docker.distribution.manifest.list.v2+json) which SWR
+            # accepts, instead of an OCI image index (application/vnd.oci.image.index.v1+json).
+            DIGESTS=""
             for digest_file in "$DIGEST_DIR"/*; do
               digest=$(basename "$digest_file")
-              short_digest=$(echo "$digest" | cut -c1-12)
-              ARCH_TAG="${tag}-t${short_digest}"
-              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
-              skopeo copy \
-                --format v2s2 \
-                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
-                "docker://${ARCH_TAG}"
-              DIGEST_REFS="$DIGEST_REFS $ARCH_TAG"
+              DIGESTS="$DIGESTS $SOURCE_IMAGE@sha256:$digest"
             done
 
             # shellcheck disable=SC2086
-            docker manifest create "$tag" $DIGEST_REFS
-            docker manifest push "$tag"
-
-            # Clean up per-arch temp tags
-            for digest_ref in $DIGEST_REFS; do
-              echo "  Cleaning up $digest_ref"
-              skopeo delete "docker://$digest_ref" || true
-            done
+            docker buildx imagetools create \
+              -t "$tag" \
+              $DIGESTS
           done
 
       - name: Clean up temp tags
         if: ${{ inputs.build_type == 'daily' }}
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq skopeo
           SUFFIX=""
           if [ -n "${{ inputs.suffix }}" ]; then
             SUFFIX="-${{ inputs.suffix }}"
           fi
           DATE=$(date +'%Y%m%d')
           # Temp tags were created in SWR by build-push-digest, so clean them up there.
-          for arch in amd64 arm64; do
-            TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${arch}-${DATE}-temp"
-            skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
-              "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
-          done
+          # Skip cleanup if skopeo is not available.
+          if command -v skopeo >/dev/null 2>&1; then
+            for arch in amd64 arm64; do
+              TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${arch}-${DATE}-temp"
+              skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
+                "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
+            done
+          else
+            echo "skopeo not available, skip temp tag cleanup"
+          fi
 
   merge-image-temp:
     name: merge-image-temp
@@ -659,11 +641,6 @@ jobs:
 
           DIGEST_DIR="${{ runner.temp }}/digests"
 
-          # Install skopeo if not present.
-          if ! command -v skopeo >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq skopeo
-          fi
-
           SUFFIX=""
           if [ -n "${{ inputs.suffix }}" ]; then
             SUFFIX="-${{ inputs.suffix }}"
@@ -676,30 +653,22 @@ jobs:
           ls -la "$DIGEST_DIR"
           echo "Creating multi-arch manifest tag: $TAG"
 
-          # shellcheck disable=SC2046
+          # The build step outputs Docker v2 schema2 images (oci-mediatypes=false),
+          # so "docker buildx imagetools create" produces a Docker manifest list
+          # (application/vnd.docker.distribution.manifest.list.v2+json) which SWR
+          # accepts, instead of an OCI image index (application/vnd.oci.image.index.v1+json).
           merge_and_push() {
             local dest_tag="$1"
-            local digest_refs=""
+            local digests=""
             for digest_file in "$DIGEST_DIR"/*; do
               digest=$(basename "$digest_file")
-              short_digest=$(echo "$digest" | cut -c1-12)
-              ARCH_TAG="${dest_tag}-t${short_digest}"
-              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
-              skopeo copy \
-                --format v2s2 \
-                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
-                "docker://${ARCH_TAG}"
-              digest_refs="$digest_refs $ARCH_TAG"
+              digests="$digests $SOURCE_IMAGE@sha256:$digest"
             done
 
             # shellcheck disable=SC2086
-            docker manifest create "$dest_tag" $digest_refs
-            docker manifest push "$dest_tag"
-
-            for digest_ref in $digest_refs; do
-              echo "  Cleaning up $digest_ref"
-              skopeo delete "docker://$digest_ref" || true
-            done
+            docker buildx imagetools create \
+              -t "$dest_tag" \
+              $digests
           }
 
           merge_and_push "$TAG"
@@ -721,7 +690,6 @@ jobs:
       - name: Clean up temp tags
         if: ${{ inputs.build_type == 'daily' }}
         run: |
-          sudo apt-get update -qq && sudo apt-get install -y -qq skopeo
           SUFFIX=""
           if [ -n "${{ inputs.suffix }}" ]; then
             SUFFIX="-${{ inputs.suffix }}"
@@ -729,8 +697,13 @@ jobs:
           VLLM_SHORT=$(echo "${{ inputs.vllm_commit }}" | cut -c1-7)
           ASCEND_SHORT=$(echo "${{ inputs.vllm_ascend_commit }}" | cut -c1-7)
           # Temp tags were created in SWR by build-push-digest, so clean them up there.
-          for arch in amd64 arm64; do
-            TAG="vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}-${arch}-temp"
-            skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
-              "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
-          done
+          # Skip cleanup if skopeo is not available.
+          if command -v skopeo >/dev/null 2>&1; then
+            for arch in amd64 arm64; do
+              TAG="vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}-${arch}-temp"
+              skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
+                "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
+            done
+          else
+            echo "skopeo not available, skip temp tag cleanup"
+          fi

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -541,9 +541,17 @@ jobs:
           SCHEDULE_TAG_PATTERN: ${{ inputs.schedule_tag_pattern }}
           SUFFIX: ${{ env.SUFFIX }}
         run: |
-          DIGESTS=$(printf "$SOURCE_IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))
+          set -euo pipefail
 
-          echo "Digests: $DIGESTS"
+          DIGEST_DIR="${{ runner.temp }}/digests"
+
+          # Install skopeo if not present.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq skopeo
+          fi
+
+          echo "Digests:"
+          ls -la "$DIGEST_DIR"
           echo "Current tags:"
           echo "$TAGS"
 
@@ -557,9 +565,34 @@ jobs:
               continue
             fi
             echo "Creating tag $tag"
-            docker buildx imagetools create \
-              -t "$tag" \
-              $DIGESTS
+
+            # Some registries (e.g. SWR) reject OCI image index produced by
+            # "docker buildx imagetools create". To work around this,
+            # copy each single-arch digest to the destination with a per-arch
+            # temp tag, converting to Docker v2 schema2 format via skopeo, then
+            # create a Docker manifest list which all registries accept.
+            DIGEST_REFS=""
+            for digest_file in "$DIGEST_DIR"/*; do
+              digest=$(basename "$digest_file")
+              short_digest=$(echo "$digest" | cut -c1-12)
+              ARCH_TAG="${tag}-t${short_digest}"
+              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
+              skopeo copy \
+                --format v2s2 \
+                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
+                "docker://${ARCH_TAG}"
+              DIGEST_REFS="$DIGEST_REFS $ARCH_TAG"
+            done
+
+            # shellcheck disable=SC2086
+            docker manifest create "$tag" $DIGEST_REFS
+            docker manifest push "$tag"
+
+            # Clean up per-arch temp tags
+            for digest_ref in $DIGEST_REFS; do
+              echo "  Cleaning up $digest_ref"
+              skopeo delete "docker://$digest_ref" || true
+            done
           done
 
       - name: Clean up temp tags
@@ -623,6 +656,14 @@ jobs:
           SOURCE_IMAGE: ${{ inputs.swr_temp_repo }}
         run: |
           set -euo pipefail
+
+          DIGEST_DIR="${{ runner.temp }}/digests"
+
+          # Install skopeo if not present.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            apt-get update -qq && apt-get install -y -qq skopeo
+          fi
+
           SUFFIX=""
           if [ -n "${{ inputs.suffix }}" ]; then
             SUFFIX="-${{ inputs.suffix }}"
@@ -630,12 +671,38 @@ jobs:
           VLLM_SHORT=$(echo "${{ inputs.vllm_commit }}" | cut -c1-7)
           ASCEND_SHORT=$(echo "${{ inputs.vllm_ascend_commit }}" | cut -c1-7)
           TAG="${IMAGE}:vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}"
-          DIGESTS=$(printf "$SOURCE_IMAGE@sha256:%s " $(ls ${{ runner.temp }}/digests))
-          echo "Digests: $DIGESTS"
+
+          echo "Digests:"
+          ls -la "$DIGEST_DIR"
           echo "Creating multi-arch manifest tag: $TAG"
-          docker buildx imagetools create \
-            -t "$TAG" \
-            $DIGESTS
+
+          # shellcheck disable=SC2046
+          merge_and_push() {
+            local dest_tag="$1"
+            local digest_refs=""
+            for digest_file in "$DIGEST_DIR"/*; do
+              digest=$(basename "$digest_file")
+              short_digest=$(echo "$digest" | cut -c1-12)
+              ARCH_TAG="${dest_tag}-t${short_digest}"
+              echo "  Copying $SOURCE_IMAGE@sha256:$digest → $ARCH_TAG (format v2s2)"
+              skopeo copy \
+                --format v2s2 \
+                "docker://${SOURCE_IMAGE}@sha256:${digest}" \
+                "docker://${ARCH_TAG}"
+              digest_refs="$digest_refs $ARCH_TAG"
+            done
+
+            # shellcheck disable=SC2086
+            docker manifest create "$dest_tag" $digest_refs
+            docker manifest push "$dest_tag"
+
+            for digest_ref in $digest_refs; do
+              echo "  Cleaning up $digest_ref"
+              skopeo delete "docker://$digest_ref" || true
+            done
+          }
+
+          merge_and_push "$TAG"
 
           # ===== Daily scenario: also push daily tag =====
           if [ "${{ inputs.build_type }}" = "daily" ]; then
@@ -648,9 +715,7 @@ jobs:
               DAILY_TAG="${IMAGE}:nightly-${PATTERN}-cann${CANN_VERSION}-${DATE}"
             fi
             echo "Creating daily tag: $DAILY_TAG"
-            docker buildx imagetools create \
-              -t "$DAILY_TAG" \
-              $DIGESTS
+            merge_and_push "$DAILY_TAG"
           fi
 
       - name: Clean up temp tags

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -63,16 +63,12 @@ jobs:
       target: a2
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-a3:
     if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a3') }}
@@ -81,16 +77,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-310p:
     if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), '310p') }}
@@ -99,16 +91,12 @@ jobs:
       target: 310p
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
   build-a5:
     if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a5') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
@@ -116,13 +104,9 @@ jobs:
       target: a5
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -18,9 +18,15 @@
 # This workflow builds nightly images as a layer-cache warm-up at 20:00 Beijing time.
 # The nightly test workflows (Nightly-A2, Nightly-A3) each rebuild the image fresh
 # before running tests, so this schedule only serves to pre-populate the build cache.
+# PR builds: add the 'nightly-image-build' label to a PR to run a build-only
+# verification (login/push/merge are skipped, no image is published).
 name: Nightly Image Build Schedule
 
 on:
+  pull_request:
+    branches:
+      - 'main'
+    types: [ labeled ]
   workflow_dispatch:
     inputs:
       vllm_ascend_branch:
@@ -57,12 +63,13 @@ on:
 
 jobs:
   build-a2:
-    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a2') }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.label.name == 'nightly-image-build') && contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a2') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -71,12 +78,13 @@ jobs:
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
 
   build-a3:
-    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a3') }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.label.name == 'nightly-image-build') && contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a3') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -85,12 +93,13 @@ jobs:
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
 
   build-310p:
-    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), '310p') }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.label.name == 'nightly-image-build') && contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), '310p') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: 310p
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -98,15 +107,29 @@ jobs:
       SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
   build-a5:
-    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a5') }}
+    if: ${{ (github.event_name != 'pull_request' || github.event.label.name == 'nightly-image-build') && contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a5') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a5
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
+      should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
       SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+
+  trigger-image-sync:
+    name: Trigger quay.io sync
+    if: ${{ !cancelled() && github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' && (needs.build-a2.result == 'success' || needs.build-a3.result == 'success' || needs.build-310p.result == 'success' || needs.build-a5.result == 'success') }}
+    needs: [build-a2, build-a3, build-310p, build-a5]
+    runs-on: linux-amd64-cpu-4
+    steps:
+      - name: Dispatch sync-vllm-ascend
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOOLS_TOKEN }}
+        run: |
+          gh workflow run sync-vllm-ascend.yml \
+            --repo ascend-gha-runners/sync-tools

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -70,6 +70,7 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
+      soc: '910b'
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -85,6 +86,7 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
+      soc: 'a3'
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -100,6 +102,7 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
+      soc: '310p'
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
@@ -114,6 +117,7 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
+      soc: '950'
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -77,6 +77,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -72,6 +72,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -88,6 +88,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -81,6 +81,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -80,6 +80,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -73,6 +73,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -81,6 +81,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Install _rust_tool_parser for the Rust frontend.
+ARG RUSTUP_DIST_SERVER
+ARG RUSTUP_UPDATE_ROOT
+ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
+    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
 RUN cd /vllm-workspace/vllm && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh


### PR DESCRIPTION
## What this PR does / why we need it?

The CI image build workflow (`_schedule_image_build.yaml`) passes `RUSTUP_DIST_SERVER` and `RUSTUP_UPDATE_ROOT` as build-args pointing to the internal nginx-pypi-cache mirror (`http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup`).

However, none of the Dockerfiles declared these as `ARG`, so the build-args were **silently dropped**. `build_rust.sh` (run by rustup) then fell back to the default `https://static.rust-lang.org`, which is **unreachable from the build containers** (TCP connection timeout), failing the A3 image build.

**Fix**: declare `ARG RUSTUP_DIST_SERVER` / `ARG RUSTUP_UPDATE_ROOT` and re-export them as `ENV` right before the `build_rust.sh` step in **all 8 Dockerfiles**, so rustup downloads the toolchain from the internal mirror.

### Files changed
- `Dockerfile`
- `Dockerfile.310p`
- `Dockerfile.310p.openEuler`
- `Dockerfile.a3`
- `Dockerfile.a3.openEuler`
- `Dockerfile.a5`
- `Dockerfile.a5.openEuler`
- `Dockerfile.openEuler`

Each gets:
```dockerfile
ARG RUSTUP_DIST_SERVER
ARG RUSTUP_UPDATE_ROOT
ENV RUSTUP_DIST_SERVER=$RUSTUP_DIST_SERVER \
    RUSTUP_UPDATE_ROOT=$RUSTUP_UPDATE_ROOT
```

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

- Not yet validated in CI; this addresses the `static.rust-lang.org` TCP connection timeout seen in run 34455867720 (A3 Ubuntu amd64 build)
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
