### PR TITLE
[BugFix][MRV2] Recognize wrapped Mamba cache groups

### DIFF
--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -1,55 +1,19 @@
-import ast
 from dataclasses import replace
-from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import numpy as np
 import pytest
 import torch
-from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
-    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
-from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
-from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.utils import vllm_version_is
-from vllm_ascend.worker.v2.attn_utils import (
-    _allocate_kv_cache,
-    _reshape_kv_cache_v2,
-    get_kv_cache_spec,
-)
-from vllm_ascend.worker.v2.model_runner import NPUModelRunner
-from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
 from vllm_ascend.worker.v2.model_states.mamba_hybrid import (
     AscendMambaHybridModelState,
 )
-
-
-def _make_kv_cache_tensor(
-    size: int,
-    layer_names: list[str],
-    page_size: int = 0,
-    *,
-    layer_stride: int | None = None,
-    offset: int = 0,
-) -> KVCacheTensor:
-    """Build a KVCacheTensor; vLLM #51718 renamed shared_by -> layers on main."""
-    if vllm_version_is("0.28.0"):
-        return KVCacheTensor(size=size, shared_by=layer_names)
-    return KVCacheTensor(
-        size=size,
-        layers=layer_names,
-        layer_stride=page_size if layer_stride is None else layer_stride,
-        block_stride=page_size,
-        offset=offset,
-    )
 
 
 def _mamba_spec() -> MambaSpec:
@@ -60,48 +24,9 @@ def _mamba_spec() -> MambaSpec:
     )
 
 
-def _kv_cache_config(
-    spec: MambaSpec,
-    *,
-    num_blocks: int = 3,
-) -> KVCacheConfig:
-    return KVCacheConfig(
-        num_blocks=num_blocks,
-        kv_cache_tensors=[
-            _make_kv_cache_tensor(
-                num_blocks * spec.page_size_bytes,
-                ["linear_attn"],
-                spec.page_size_bytes,
-            ),
-        ],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                layer_names=["linear_attn"],
-                kv_cache_spec=spec,
-            )
-        ],
-    )
-
-
-def _group(spec: MambaSpec):
-    return SimpleNamespace(
-        kv_cache_group_id=0,
-        kv_cache_spec=spec,
-        layer_names=["linear_attn"],
-    )
-
-
-def test_mamba_model_state_inherits_upstream_state_management():
-    assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
-    assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
-    assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
-
-
 @pytest.mark.parametrize("wrapped_group_ids", [(), (1, 3), (1,)], ids=["plain", "uniform", "mixed"])
-@patch("vllm.v1.worker.gpu.model_states.mamba_hybrid.preprocess_mamba_align_fused_kernel")
-def test_mamba_align_preprocess_preserves_wrapped_group_indices(mock_preprocess_kernel, wrapped_group_ids):
-    """The first real batch must find recurrent groups before copying state."""
-    mamba_spec = replace(_mamba_spec(), mamba_cache_mode="align", num_speculative_blocks=3)
+def test_get_mamba_group_info_preserves_group_indices(wrapped_group_ids):
+    mamba_spec = _mamba_spec()
     attention_spec = FullAttentionSpec(
         block_size=16,
         num_kv_heads=1,
@@ -117,501 +42,50 @@ def test_mamba_align_preprocess_preserves_wrapped_group_indices(mock_preprocess_
         groups.append(KVCacheGroupSpec(layer_names=list(layer_specs), kv_cache_spec=group_spec))
     kv_cache_config = KVCacheConfig(num_blocks=8, kv_cache_tensors=[], kv_cache_groups=groups)
     state = AscendMambaHybridModelState.__new__(AscendMambaHybridModelState)
-    state._align_mode = True
     state._mamba_spec = None
     state._mamba_group_ids = []
-    state._mamba_state_idx_gpu = object()
-    state._mamba_src_col_gpu = object()
-    state._mamba_src_off_gpu = object()
-    state.num_accepted_tokens_gpu = object()
-    state._ensure_align_ctx = MagicMock()
-    input_batch = SimpleNamespace(num_reqs=1, idx_mapping=object(), query_start_loc=object())
-    block_tables = tuple(object() for _ in groups)
 
-    state.preprocess_state(input_batch, block_tables, kv_cache_config, num_computed_tokens=object())
+    with patch(
+        "vllm.v1.worker.mamba_utils.get_mamba_groups",
+        side_effect=AssertionError("MRV2 group lookup must not call the shared resolver"),
+    ) as shared_resolver:
+        group_ids, spec = state._get_mamba_group_info(kv_cache_config)
+        shared_resolver.assert_not_called()
 
-    state._ensure_align_ctx.assert_called_once_with(kv_cache_config, [1, 3], block_tables)
-    assert mock_preprocess_kernel.__getitem__.return_value.call_args.kwargs["MAMBA_BLOCK_SIZE"] == mamba_spec.block_size
-    state._ensure_align_ctx.return_value.run_fused_precopy.assert_called_once_with(
-        1,
-        state._mamba_state_idx_gpu,
-        state._mamba_src_col_gpu,
-        state._mamba_src_off_gpu,
-        input_batch.idx_mapping,
-    )
+    assert group_ids == [1, 3]
+    assert spec is mamba_spec
+    assert state._mamba_group_ids is group_ids
+    assert state._mamba_spec is spec
 
 
-@pytest.mark.parametrize("missing_mamba", [True, False], ids=["missing", "inconsistent"])
-def test_mamba_group_lookup_rejects_invalid_cache_groups(missing_mamba):
+@pytest.mark.parametrize("case", ["missing", "inconsistent", "inconsistent_wrapped", "inconsistent_within_wrapper"])
+def test_get_mamba_group_info_rejects_invalid_cache_groups(case):
     spec = _mamba_spec()
-    kv_cache_config = _kv_cache_config(spec)
-    if missing_mamba:
-        kv_cache_config.kv_cache_groups.clear()
+    groups = [KVCacheGroupSpec(layer_names=["linear_attn"], kv_cache_spec=spec)]
+    if case == "missing":
+        groups.clear()
+    elif case == "inconsistent":
+        groups.append(KVCacheGroupSpec(layer_names=["other_mamba"], kv_cache_spec=replace(spec, block_size=32)))
     else:
-        kv_cache_config.kv_cache_groups.append(
-            KVCacheGroupSpec(layer_names=["other_mamba"], kv_cache_spec=replace(spec, block_size=32))
-        )
+        other_spec = replace(spec, shapes=((2, 4), (2, 2)))
+        layer_specs = {
+            "wrapped.0": spec if case == "inconsistent_within_wrapper" else other_spec,
+            "wrapped.1": other_spec,
+        }
+        wrapped_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        assert wrapped_spec is not None
+        wrapped_group = KVCacheGroupSpec(layer_names=list(layer_specs), kv_cache_spec=wrapped_spec)
+        if case == "inconsistent_within_wrapper":
+            groups = [wrapped_group]
+        else:
+            groups.append(wrapped_group)
+    kv_cache_config = KVCacheConfig(num_blocks=8, kv_cache_tensors=[], kv_cache_groups=groups)
     state = AscendMambaHybridModelState.__new__(AscendMambaHybridModelState)
     state._mamba_spec = None
     state._mamba_group_ids = []
 
-    with pytest.raises(AssertionError, match="no mamba layers in the model" if missing_mamba else None):
+    with pytest.raises(AssertionError, match="no mamba layers in the model" if case == "missing" else None):
         state._get_mamba_group_info(kv_cache_config)
 
-
-def test_mrv2_advertises_standardized_shared_kv_backing():
-    assert NPUModelRunner.supports_standardized_shared_kv_backing is True
-
-
-def test_prepare_inputs_propagates_padded_request_count():
-    model_runner_path = Path(__file__).resolve().parents[3] / "vllm_ascend" / "worker" / "v2" / "model_runner.py"
-    module = ast.parse(model_runner_path.read_text(encoding="utf-8"))
-    prepare_inputs = next(
-        node for node in ast.walk(module) if isinstance(node, ast.FunctionDef) and node.name == "prepare_inputs"
-    )
-
-    assignments = {
-        target.id: node.value
-        for node in ast.walk(prepare_inputs)
-        if isinstance(node, ast.Assign)
-        for target in node.targets
-        if isinstance(target, ast.Name)
-    }
-    query_start_loc_values = [
-        ast.unparse(node.value)
-        for node in ast.walk(prepare_inputs)
-        if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == "query_start_loc" for target in node.targets)
-    ]
-    # prepare_inputs copies the rank-local padded request count from the
-    # persistent input-buffer query_start_loc, then trims it in place.
-    assert query_start_loc_values == [
-        "self.input_buffers.query_start_loc",
-        "query_start_loc[:num_reqs_padded + 1]",
-    ]
-    assert ast.unparse(assignments["seq_lens"]) == "self.input_buffers.seq_lens[:num_reqs_padded]"
-
-    input_batch = next(
-        node
-        for node in ast.walk(prepare_inputs)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "AscendInputBatch"
-    )
-    keywords = {keyword.arg: keyword.value for keyword in input_batch.keywords}
-    padded_count = keywords["num_reqs_after_padding"]
-    assert isinstance(padded_count, ast.Name)
-    assert padded_count.id == "num_reqs_padded"
-
-
-@patch("vllm_ascend.worker.v2.model_states.mamba_hybrid.build_attn_metadata")
-def test_prepare_attn_marks_uniform_full_graph_padding_as_spec(mock_build_attn_metadata):
-    expected_metadata = {"gdn": object()}
-    mock_build_attn_metadata.return_value = expected_metadata
-    state = SimpleNamespace(
-        vllm_config=SimpleNamespace(num_speculative_tokens=3),
-        num_accepted_tokens_gpu=torch.tensor([2, 3], dtype=torch.int32),
-        max_model_len=1024,
-    )
-    input_batch = SimpleNamespace(
-        num_reqs=2,
-        num_reqs_after_padding=4,
-        num_tokens=8,
-        num_tokens_after_padding=16,
-        is_prefilling_np=np.array([False, False]),
-        idx_mapping=torch.tensor([0, 1]),
-        num_draft_tokens_per_req=np.array([3, 3], dtype=np.int32),
-        num_scheduled_tokens=np.array([4, 4], dtype=np.int32),
-        query_start_loc=torch.tensor([0, 4, 8, 12, 16], dtype=torch.int32),
-        query_start_loc_np=np.array([0, 4, 8, 12, 16], dtype=np.int32),
-        seq_lens=None,
-        dcp_local_seq_lens=None,
-        seq_lens_np=np.ones(4, dtype=np.int32),
-        positions=None,
-        attn_state=None,
-    )
-
-    metadata = AscendMambaHybridModelState.prepare_attn(
-        state,
-        input_batch=input_batch,
-        cudagraph_mode=CUDAGraphMode.FULL,
-        block_tables=(),
-        slot_mappings=torch.empty(0, dtype=torch.int64),
-        attn_groups=[],
-        kv_cache_config=MagicMock(),
-    )
-
-    assert metadata is expected_metadata
-    model_metadata = mock_build_attn_metadata.call_args.kwargs["model_specific_attn_metadata"]
-    assert model_metadata.num_decode_draft_tokens_cpu.tolist() == [3, 3, 3, 3]
-    assert model_metadata.num_accepted_tokens.tolist() == [2, 3, 1, 1]
-
-
-@patch(
-    "vllm_ascend.worker.v2.attn_utils.get_current_vllm_config",
-    return_value=SimpleNamespace(kv_transfer_config=None),
-)
-def test_mamba_cache_reshape_returns_contiguous_state_tensors(_mock_config):
-    spec = _mamba_spec()
-    kv_cache_config = _kv_cache_config(spec)
-
-    raw_caches = _allocate_kv_cache(
-        kv_cache_config,
-        shared_layers={},
-        device=torch.device("cpu"),
-    )
-    raw_cache = raw_caches["linear_attn"]
-    assert isinstance(raw_cache, torch.Tensor)
-    assert raw_cache.numel() == 3 * spec.page_size_bytes
-
-    caches = _reshape_kv_cache_v2(
-        attn_groups=[_group(spec)],
-        kv_cache_raw_tensors=raw_caches,
-        cache_dtype="auto",
-        kernel_block_sizes=[spec.block_size],
-        shared_kv_cache_layers={},
-        kv_cache_config=kv_cache_config,
-    )
-    state_tensors = caches["linear_attn"]
-    assert isinstance(state_tensors, list)
-    assert len(state_tensors) == len(spec.shapes)
-
-    conv_state, ssm_state = state_tensors
-    assert conv_state.shape == (3, 2, 3)
-    assert ssm_state.shape == (3, 2, 2)
-    assert conv_state.dtype == torch.float16
-    assert ssm_state.dtype == torch.float32
-    assert conv_state.is_contiguous()
-    assert ssm_state.is_contiguous()
-    assert conv_state.data_ptr() == raw_cache.data_ptr()
-    assert ssm_state.data_ptr() - raw_cache.data_ptr() == (conv_state.numel() * conv_state.element_size())
-
-
-@patch(
-    "vllm_ascend.worker.v2.attn_utils.get_current_vllm_config",
-    return_value=SimpleNamespace(kv_transfer_config=None),
-)
-def test_hybrid_cache_exposes_attention_views_and_mamba_states(_mock_config):
-    attention_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float16,
-        page_size_padded=20,
-    )
-    mamba_spec = MambaSpec(
-        block_size=4,
-        shapes=((2,), (4,)),
-        dtypes=(torch.float16, torch.float16),
-        page_size_padded=20,
-    )
-    assert attention_spec.real_page_size_bytes == 16
-    assert attention_spec.page_size_bytes == 20
-    assert mamba_spec.page_size_bytes == 20
-
-    if vllm_version_is("0.28.0"):
-        kv_cache_tensors = [
-            _make_kv_cache_tensor(40, ["full_attn", "linear_attn"], 20),
-            _make_kv_cache_tensor(40, ["mtp_attn"], 20),
-        ]
-    else:
-        kv_cache_tensors = [
-            _make_kv_cache_tensor(
-                80,
-                ["full_attn", "mtp_attn"],
-                20,
-                layer_stride=40,
-            ),
-            # Every descriptor aliases the same backing. The Mamba group starts
-            # at byte zero and overlays the first attention-layer region.
-            _make_kv_cache_tensor(
-                80,
-                ["linear_attn"],
-                20,
-                layer_stride=40,
-            ),
-        ]
-
-    kv_cache_config = KVCacheConfig(
-        num_blocks=2,
-        kv_cache_tensors=kv_cache_tensors,
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                layer_names=["full_attn", "mtp_attn"],
-                kv_cache_spec=attention_spec,
-            ),
-            KVCacheGroupSpec(
-                layer_names=["linear_attn"],
-                kv_cache_spec=mamba_spec,
-            ),
-        ],
-    )
-    raw_caches = _allocate_kv_cache(
-        kv_cache_config,
-        shared_layers={},
-        device=torch.device("cpu"),
-    )
-    raw_cache = raw_caches["linear_attn"]
-    assert isinstance(raw_cache, torch.Tensor)
-    full_attn_raw = raw_caches["full_attn"]
-    mtp_attn_raw = raw_caches["mtp_attn"]
-    assert isinstance(full_attn_raw, torch.Tensor)
-    assert isinstance(mtp_attn_raw, torch.Tensor)
-    if vllm_version_is("0.28.0"):
-        assert full_attn_raw is raw_cache
-    else:
-        assert full_attn_raw.data_ptr() == raw_cache.data_ptr()
-        backing_ptr = raw_cache.untyped_storage().data_ptr()
-        assert full_attn_raw.untyped_storage().data_ptr() == backing_ptr
-        assert mtp_attn_raw.untyped_storage().data_ptr() == backing_ptr
-        assert mtp_attn_raw.data_ptr() - backing_ptr == 40
-
-    backend = MagicMock()
-    backend.get_kv_cache_shape.return_value = (2, 2, 4, 1, 1)
-    attention_group = SimpleNamespace(
-        kv_cache_group_id=0,
-        kv_cache_spec=attention_spec,
-        layer_names=["full_attn", "mtp_attn"],
-        backend=backend,
-    )
-    mamba_group = SimpleNamespace(
-        kv_cache_group_id=1,
-        kv_cache_spec=mamba_spec,
-        layer_names=["linear_attn"],
-    )
-    caches = _reshape_kv_cache_v2(
-        attn_groups=[attention_group, mamba_group],
-        kv_cache_raw_tensors=raw_caches,
-        cache_dtype="auto",
-        kernel_block_sizes=[4, 4],
-        shared_kv_cache_layers={},
-        kv_cache_config=kv_cache_config,
-    )
-
-    key_cache, value_cache = caches["full_attn"]
-    mtp_key_cache, mtp_value_cache = caches["mtp_attn"]
-    mamba_states = caches["linear_attn"]
-    assert isinstance(mamba_states, list)
-    conv_state, ssm_state = mamba_states
-    assert conv_state.shape == (2, 2)
-    assert ssm_state.shape == (2, 4)
-    assert conv_state.is_contiguous()
-    assert ssm_state.is_contiguous()
-    assert conv_state.data_ptr() == raw_cache.data_ptr()
-    assert ssm_state.data_ptr() - raw_cache.data_ptr() == (conv_state.numel() * conv_state.element_size())
-    assert key_cache.data_ptr() == ssm_state.data_ptr()
-    assert value_cache.data_ptr() - raw_cache.data_ptr() == 24
-    assert key_cache.is_contiguous()
-    assert value_cache.is_contiguous()
-    assert mtp_key_cache.shape == key_cache.shape
-    assert mtp_value_cache.shape == value_cache.shape
-    if not vllm_version_is("0.28.0"):
-        assert mtp_key_cache.data_ptr() - key_cache.data_ptr() == 40
-        assert mtp_value_cache.data_ptr() - value_cache.data_ptr() == 40
-
-
-@patch(
-    "vllm_ascend.worker.v2.attn_utils._get_attention_kv_cache_dims",
-    return_value=(4, 4),
-)
-@patch(
-    "vllm_ascend.worker.v2.attn_utils.get_current_vllm_config",
-    return_value=SimpleNamespace(kv_transfer_config=None),
-)
-def test_attention_cache_reshape_uses_virtual_kernel_block_count(
-    _mock_config,
-    _mock_cache_dims,
-):
-    spec = AscendMLAAttentionSpec(
-        block_size=64,
-        num_kv_heads=1,
-        head_size=8,
-        dtype=torch.float16,
-    )
-    assert spec.page_size_bytes == 1024
-
-    num_blocks = 3
-    raw_cache = torch.zeros(num_blocks * spec.page_size_bytes, dtype=torch.int8)
-    backend = MagicMock()
-    backend.get_kv_cache_shape.side_effect = (
-        lambda num_kernel_blocks, block_size, _num_heads, _head_size, _cache_dtype: (
-            num_kernel_blocks,
-            block_size,
-            1,
-            8,
-        )
-    )
-    group = SimpleNamespace(
-        kv_cache_group_id=0,
-        kv_cache_spec=spec,
-        layer_names=["mla_attn"],
-        backend=backend,
-    )
-
-    caches = _reshape_kv_cache_v2(
-        attn_groups=[group],
-        kv_cache_raw_tensors={"mla_attn": raw_cache},
-        cache_dtype="auto",
-        kernel_block_sizes=[4],
-        shared_kv_cache_layers={},
-        kv_cache_config=KVCacheConfig(
-            num_blocks=num_blocks,
-            kv_cache_tensors=[
-                _make_kv_cache_tensor(
-                    raw_cache.numel(),
-                    ["mla_attn"],
-                    spec.page_size_bytes,
-                ),
-            ],
-            kv_cache_groups=[
-                KVCacheGroupSpec(
-                    layer_names=["mla_attn"],
-                    kv_cache_spec=spec,
-                )
-            ],
-        ),
-    )
-
-    key_cache, value_cache = caches["mla_attn"]
-    num_kernel_blocks = num_blocks * spec.block_size // 4
-    assert key_cache.shape == (num_kernel_blocks, 4, 1, 4)
-    assert value_cache.shape == key_cache.shape
-    assert key_cache.is_contiguous()
-    assert value_cache.is_contiguous()
-    assert backend.get_kv_cache_shape.call_args.args[0] == num_kernel_blocks
-
-
-@patch("vllm_ascend.worker.v2.attn_utils.get_layers_from_vllm_config")
-def test_get_kv_cache_spec_keeps_mamba_layers(mock_get_layers):
-    spec = _mamba_spec()
-    mamba_layer = MagicMock()
-    mamba_layer.kv_sharing_target_layer_name = None
-    mamba_layer.get_kv_cache_spec.return_value = spec
-    mock_get_layers.return_value = {"linear_attn": mamba_layer}
-
-    assert get_kv_cache_spec(MagicMock()) == {"linear_attn": spec}
-
-
-@patch("vllm_ascend.worker.v2.attn_utils.get_layers_from_vllm_config")
-def test_mamba_spec_follows_aligned_attention_spec(
-    mock_get_layers,
-):
-    attention_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float16,
-    )
-    mamba_spec = MambaSpec(
-        block_size=4,
-        shapes=((2,), (4,)),
-        dtypes=(torch.float16, torch.float16),
-        page_size_padded=20,
-    )
-
-    class FakeAttention:
-        kv_sharing_target_layer_name = None
-
-        def get_kv_cache_spec(self, _vllm_config):
-            return attention_spec
-
-    mamba_layer = MagicMock()
-    mamba_layer.kv_sharing_target_layer_name = None
-    mamba_layer.get_kv_cache_spec.return_value = mamba_spec
-    mock_get_layers.return_value = {
-        "linear_attn": mamba_layer,
-        "full_attn": FakeAttention(),
-    }
-
-    specs = get_kv_cache_spec(MagicMock())
-
-    assert list(specs) == ["full_attn", "linear_attn"]
-    assert specs["full_attn"].page_size_bytes == 20
-    # vLLM #51718 removed AttentionSpec.indexes_kv_by_block_stride on main;
-    # page_size_padded carries the padded/block-stride-indexed page there.
-    if vllm_version_is("0.28.0"):
-        assert specs["full_attn"].indexes_kv_by_block_stride is True
-    else:
-        assert specs["full_attn"].page_size_padded == 20
-
-
-@patch("vllm_ascend.worker.v2.attn_utils.get_layers_from_vllm_config")
-def test_get_kv_cache_spec_aligns_nondivisible_attention_and_mamba_pages(
-    mock_get_layers,
-):
-    small_attention_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=3,
-        dtype=torch.float16,
-    )
-    large_attention_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=5,
-        dtype=torch.float16,
-    )
-    mamba_spec = MambaSpec(
-        block_size=4,
-        shapes=((2,), (4,)),
-        dtypes=(torch.float16, torch.float16),
-        page_size_padded=20,
-    )
-    assert small_attention_spec.page_size_bytes == 48
-    assert large_attention_spec.page_size_bytes == 80
-    assert mamba_spec.page_size_bytes == 20
-
-    class FakeAttention:
-        kv_sharing_target_layer_name = None
-
-        def __init__(self, spec):
-            self.spec = spec
-
-        def get_kv_cache_spec(self, _vllm_config):
-            return self.spec
-
-    mamba_layer = MagicMock()
-    mamba_layer.kv_sharing_target_layer_name = None
-    mamba_layer.get_kv_cache_spec.return_value = mamba_spec
-    mock_get_layers.return_value = {
-        "small_attn": FakeAttention(small_attention_spec),
-        "linear_attn": mamba_layer,
-        "large_attn": FakeAttention(large_attention_spec),
-    }
-
-    specs = get_kv_cache_spec(MagicMock())
-
-    assert {spec.page_size_bytes for spec in specs.values()} == {80}
-    # vLLM #51718 removed AttentionSpec.indexes_kv_by_block_stride on main.
-    # The marker is gone, so the main-lane assertions verify the observable
-    # alignment effect instead: the under-sized spec is padded to the common
-    # page, and the already-aligned spec reports the common page size.
-    if vllm_version_is("0.28.0"):
-        assert specs["small_attn"].indexes_kv_by_block_stride is True
-        assert specs["large_attn"].indexes_kv_by_block_stride is True
-    else:
-        assert specs["small_attn"].page_size_padded == 80
-        assert specs["large_attn"].page_size_bytes == 80
-    assert specs["linear_attn"].page_size_padded == 80
-
-
-@patch("vllm_ascend.worker.v2.model_states.mamba_hybrid.AscendMambaHybridModelState")
-def test_hybrid_model_selects_mamba_model_state(mock_mamba_state):
-    vllm_config = MagicMock()
-    vllm_config.model_config.is_hybrid = True
-    model = torch.nn.Module()
-    encoder_cache = MagicMock()
-    device = torch.device("cpu")
-
-    state = init_asecnd_model_state(
-        vllm_config,
-        model,
-        encoder_cache,
-        device,
-    )
-
-    assert state is mock_mamba_state.return_value
-    mock_mamba_state.assert_called_once_with(
-        vllm_config,
-        model,
-        encoder_cache,
-        device,
-    )
+    assert state._mamba_spec is None
+    assert state._mamba_group_ids == []

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -1,9 +1,11 @@
 import ast
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
@@ -12,6 +14,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
@@ -92,6 +95,68 @@ def test_mamba_model_state_inherits_upstream_state_management():
     assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
     assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
     assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
+
+
+@pytest.mark.parametrize("wrapped_group_ids", [(), (1, 3), (1,)], ids=["plain", "uniform", "mixed"])
+@patch("vllm.v1.worker.gpu.model_states.mamba_hybrid.preprocess_mamba_align_fused_kernel")
+def test_mamba_align_preprocess_preserves_wrapped_group_indices(mock_preprocess_kernel, wrapped_group_ids):
+    """The first real batch must find recurrent groups before copying state."""
+    mamba_spec = replace(_mamba_spec(), mamba_cache_mode="align", num_speculative_blocks=3)
+    attention_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+    )
+    groups = []
+    for group_id, spec in enumerate([attention_spec, mamba_spec, attention_spec, mamba_spec]):
+        layer_specs = {f"group.{group_id}.layer.{i}": spec for i in range(2)}
+        # Include a wrapped attention group to check that it is skipped.
+        group_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs) if group_id in (0, *wrapped_group_ids) else spec
+        assert group_spec is not None
+        groups.append(KVCacheGroupSpec(layer_names=list(layer_specs), kv_cache_spec=group_spec))
+    kv_cache_config = KVCacheConfig(num_blocks=8, kv_cache_tensors=[], kv_cache_groups=groups)
+    state = AscendMambaHybridModelState.__new__(AscendMambaHybridModelState)
+    state._align_mode = True
+    state._mamba_spec = None
+    state._mamba_group_ids = []
+    state._mamba_state_idx_gpu = object()
+    state._mamba_src_col_gpu = object()
+    state._mamba_src_off_gpu = object()
+    state.num_accepted_tokens_gpu = object()
+    state._ensure_align_ctx = MagicMock()
+    input_batch = SimpleNamespace(num_reqs=1, idx_mapping=object(), query_start_loc=object())
+    block_tables = tuple(object() for _ in groups)
+
+    state.preprocess_state(input_batch, block_tables, kv_cache_config, num_computed_tokens=object())
+
+    state._ensure_align_ctx.assert_called_once_with(kv_cache_config, [1, 3], block_tables)
+    assert mock_preprocess_kernel.__getitem__.return_value.call_args.kwargs["MAMBA_BLOCK_SIZE"] == mamba_spec.block_size
+    state._ensure_align_ctx.return_value.run_fused_precopy.assert_called_once_with(
+        1,
+        state._mamba_state_idx_gpu,
+        state._mamba_src_col_gpu,
+        state._mamba_src_off_gpu,
+        input_batch.idx_mapping,
+    )
+
+
+@pytest.mark.parametrize("missing_mamba", [True, False], ids=["missing", "inconsistent"])
+def test_mamba_group_lookup_rejects_invalid_cache_groups(missing_mamba):
+    spec = _mamba_spec()
+    kv_cache_config = _kv_cache_config(spec)
+    if missing_mamba:
+        kv_cache_config.kv_cache_groups.clear()
+    else:
+        kv_cache_config.kv_cache_groups.append(
+            KVCacheGroupSpec(layer_names=["other_mamba"], kv_cache_spec=replace(spec, block_size=32))
+        )
+    state = AscendMambaHybridModelState.__new__(AscendMambaHybridModelState)
+    state._mamba_spec = None
+    state._mamba_group_ids = []
+
+    with pytest.raises(AssertionError, match="no mamba layers in the model" if missing_mamba else None):
+        state._get_mamba_group_info(kv_cache_config)
 
 
 def test_mrv2_advertises_standardized_shared_kv_backing():

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -21,8 +21,7 @@ from typing import Any
 import numpy as np
 import torch
 from vllm.config.compilation import CUDAGraphMode
-from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
-from vllm.v1.worker import mamba_utils
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec, UniformTypeKVCacheSpecs
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
     MambaHybridAttnMetadata,
     MambaHybridModelState,
@@ -44,9 +43,24 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
 
     def _get_mamba_group_info(self, kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
         if self._mamba_spec is None:
-            # Ascend's shared resolver also handles MambaSpec entries nested
-            # in UniformTypeKVCacheSpecs, preserving the worker's group IDs.
-            self._mamba_group_ids, self._mamba_spec = mamba_utils.get_mamba_groups(kv_cache_config)
+            group_ids: list[int] = []
+            specs: list[MambaSpec] = []
+            for i, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = group.kv_cache_spec
+                if isinstance(spec, MambaSpec):
+                    group_ids.append(i)
+                    specs.append(spec)
+                elif isinstance(spec, UniformTypeKVCacheSpecs):
+                    mamba_specs = [s for s in spec.kv_cache_specs.values() if isinstance(s, MambaSpec)]
+                    if mamba_specs and len(mamba_specs) == len(spec.kv_cache_specs):
+                        # Preserve the original group index once, while checking
+                        # every wrapped layer against the upstream invariant.
+                        group_ids.append(i)
+                        specs.extend(mamba_specs)
+            assert specs, "no mamba layers in the model"
+            assert all(specs[0] == s for s in specs)
+            self._mamba_group_ids = group_ids
+            self._mamba_spec = specs[0]
         return self._mamba_group_ids, self._mamba_spec
 
     def prepare_attn(

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -21,7 +21,8 @@ from typing import Any
 import numpy as np
 import torch
 from vllm.config.compilation import CUDAGraphMode
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
     MambaHybridAttnMetadata,
     MambaHybridModelState,
@@ -40,6 +41,13 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
     :class:`MambaHybridModelState`. ``AscendModelState`` remains the second
     base so cooperative ``super()`` calls retain the Ascend model-state MRO.
     """
+
+    def _get_mamba_group_info(self, kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
+        if self._mamba_spec is None:
+            # Ascend's shared resolver also handles MambaSpec entries nested
+            # in UniformTypeKVCacheSpecs, preserving the worker's group IDs.
+            self._mamba_group_ids, self._mamba_spec = mamba_utils.get_mamba_groups(kv_cache_config)
+        return self._mamba_group_ids, self._mamba_spec
 
     def prepare_attn(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

MRV2 can fail on the first real request with
`AssertionError: no mamba layers in the model` when Ascend's KV cache
grouping wraps Mamba specs in `UniformTypeKVCacheSpecs`. The inherited
lookup only checks the outer spec type, so it misses the recurrent states
inside these groups.

Use the shared Ascend Mamba group resolver in
`AscendMambaHybridModelState._get_mamba_group_info()`. This recognizes
both plain and wrapped Mamba specs while preserving their original
group indices and caching the lookup result.

Add regression coverage for plain, wrapped, mixed, missing, and
inconsistent cache groups.

### Does this PR introduce _any_ user-facing change?

Yes. MRV2 can process requests with wrapped Mamba cache groups without
crashing during align-state preprocessing, including the affected
Qwen3.6 + Eagle3 configuration.

### How was this patch tested?

- Five isolated regression cases passed against both vLLM v0.28.0 and
  the current local vLLM source. These checks exercised the cache-spec,
  group-resolution, and preprocessing code with hardware dependencies
  stubbed.
- Before the fix, the wrapped-group case reproduced the reported
  assertion, and the mixed-group case exposed missing group indices.
  Both passed after the fix.
- Ruff lint and formatting checks, and `git diff --check`, passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
