### PR TITLE
[BugFix][SpecDecode] Align GLM DSpark auxiliary states with the upstream PP relay

### DIFF
--- a/tests/ut/patch/worker/test_patch_deepseek_v2.py
+++ b/tests/ut/patch/worker/test_patch_deepseek_v2.py
@@ -2,6 +2,11 @@
 
 from types import SimpleNamespace
 
+import torch
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2Model
+from vllm.sequence import IntermediateTensors
+
+from vllm_ascend.patch.worker import patch_deepseek_v2
 from vllm_ascend.patch.worker.patch_deepseek_v2 import _should_skip_indexer_init
 
 
@@ -34,3 +39,112 @@ def test_mtp_layer_keeps_indexer():
         "model.layers.80.self_attn",
         skip_topk=True,
     )
+
+
+class _FakePPGroup:
+    def __init__(self, is_first_rank: bool, is_last_rank: bool):
+        self.is_first_rank = is_first_rank
+        self.is_last_rank = is_last_rank
+        self.world_size = 2
+        self.rank_in_group = 0 if is_first_rank else 1
+
+
+class _AddLayer(torch.nn.Module):
+    def __init__(self, delta: float):
+        super().__init__()
+        self.delta = delta
+
+    def forward(self, positions, hidden_states, residual, llama_4_scaling):
+        del positions, llama_4_scaling
+        residual = torch.zeros_like(hidden_states) if residual is None else residual + self.delta
+        return hidden_states + self.delta, residual
+
+
+def _model(start_layer: int, end_layer: int, aux_layers: tuple[int, ...], hidden_size: int = 2):
+    model = DeepseekV2Model.__new__(DeepseekV2Model)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace()
+    model.hidden_size = hidden_size
+    model.start_layer = start_layer
+    model.end_layer = end_layer
+    # Decoders index their layers by absolute layer id, with placeholders for
+    # the layers other PP stages own.
+    model.layers = torch.nn.ModuleList([_AddLayer(1.0) for _ in range(end_layer)])
+    model.aux_hidden_state_layers = tuple(aux_layers)
+    model._aux_slot_base_cached = 0
+    model._aux_upstream_total_cached = 0
+    model.embed_input_ids = lambda input_ids: torch.zeros(input_ids.shape[0], hidden_size)
+    model.norm = lambda hidden_states, residual: (hidden_states + residual, None)
+    return model
+
+
+def _run_forward(monkeypatch, model, pp_group, intermediate_tensors=None):
+    monkeypatch.setattr(patch_deepseek_v2, "get_pp_group", lambda: pp_group)
+    input_ids = torch.zeros(4, dtype=torch.long) if intermediate_tensors is None else None
+    return patch_deepseek_v2._patched_forward(
+        model,
+        input_ids,
+        torch.zeros(4, dtype=torch.long),
+        intermediate_tensors,
+    )
+
+
+def test_deepseek_v2_decoder_opts_into_the_upstream_aux_relay():
+    # Upstream refuses PP with a target-driven drafter unless the decoder
+    # declares support, and relays the states through its own slots.
+    assert DeepseekV2Model.supports_aux_hidden_states_over_pp is True
+    assert DeepseekV2Model.AUX_HIDDEN_STATE_KEY == "aux_hidden_states_"
+    for member in ("pack_local_aux_hidden_states", "collect_remote_aux_hidden_states"):
+        assert callable(getattr(DeepseekV2Model, member))
+
+
+def test_aux_capture_follows_the_upstream_layer_ids(monkeypatch):
+    # Upstream ids are one-based layer outputs, plus the first stage's entry
+    # state, so four layers with ids {0, 4} capture exactly two states.
+    model = _model(0, 4, aux_layers=(0, 4))
+
+    hidden_states, aux_hidden_states = _run_forward(monkeypatch, model, _FakePPGroup(True, True))
+
+    assert hidden_states.shape == (4, 2)
+    assert len(aux_hidden_states) == 2
+
+
+def test_middle_stage_packs_only_its_own_states_after_the_upstream_slots(monkeypatch):
+    # Split 42/36 with GLM-5.2's aux ids: the first stage owns ids 2/20/39, so
+    # this stage publishes ids 58/75 in the slots that follow them.
+    model = _model(42, 78, aux_layers=(2, 20, 39, 58, 75))
+    model._aux_slot_base_cached = 3
+    intermediate_tensors = IntermediateTensors(
+        {
+            "hidden_states": torch.zeros(4, 2),
+            "residual": torch.zeros(4, 2),
+        }
+    )
+
+    out = _run_forward(monkeypatch, model, _FakePPGroup(False, False), intermediate_tensors)
+
+    assert isinstance(out, IntermediateTensors)
+    aux_keys = {key for key in out.tensors if key.startswith("aux_hidden_states_")}
+    # The relay forwards slots 0..2, so only 3 and 4 are produced here.
+    assert aux_keys == {"aux_hidden_states_3", "aux_hidden_states_4"}
+
+
+def test_last_stage_appends_local_states_after_the_relayed_ones(monkeypatch):
+    model = _model(42, 78, aux_layers=(2, 20, 39, 58, 75))
+    model._aux_slot_base_cached = 3
+    model._aux_upstream_total_cached = 3
+    intermediate_tensors = IntermediateTensors(
+        {
+            "hidden_states": torch.zeros(4, 2),
+            "residual": torch.zeros(4, 2),
+            "aux_hidden_states_0": torch.full((4, 2), 10.0),
+            "aux_hidden_states_1": torch.full((4, 2), 11.0),
+            "aux_hidden_states_2": torch.full((4, 2), 12.0),
+        }
+    )
+
+    _, aux_hidden_states = _run_forward(monkeypatch, model, _FakePPGroup(False, True), intermediate_tensors)
+
+    assert len(aux_hidden_states) == 5
+    # Earlier stages' states first: they hold the lower layer indices.
+    assert [float(state[0, 0]) for state in aux_hidden_states[:3]] == [10.0, 11.0, 12.0]

--- a/tests/ut/worker/v2/test_spec_pp_guard_lane.py
+++ b/tests/ut/worker/v2/test_spec_pp_guard_lane.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.worker.v2 import pp_utils
+from vllm_ascend.worker.v2.pp_utils import (
+    SpecPPSupport,
+    bypass_upstream_spec_pp_guard,
+    is_legacy_spec_pp_lane,
+)
+
+RELEASE_LANES = ("0.28.0", "0.29.0")
+
+
+def _force_lane(monkeypatch, lane: str) -> None:
+    """Pin the vLLM lane the module under test sees."""
+    monkeypatch.setattr(pp_utils, "vllm_version_is", lambda version: version == lane)
+
+
+@pytest.mark.parametrize("lane", RELEASE_LANES)
+def test_release_lanes_need_the_ascend_path(monkeypatch, lane):
+    _force_lane(monkeypatch, lane)
+    assert is_legacy_spec_pp_lane()
+
+
+def test_main_needs_no_ascend_path(monkeypatch):
+    _force_lane(monkeypatch, "0.0.0-dev")
+    assert not is_legacy_spec_pp_lane()
+
+
+@pytest.mark.parametrize("lane", RELEASE_LANES)
+def test_pp_guard_bypasses_on_release_lanes(monkeypatch, lane):
+    _force_lane(monkeypatch, lane)
+    config = SimpleNamespace(parallel_config=SimpleNamespace(pipeline_parallel_size=2))
+    support = SpecPPSupport(bypass_upstream_pp_guard=True)
+
+    with bypass_upstream_spec_pp_guard(config, support) as bypassed:
+        assert bypassed
+        assert config.parallel_config.pipeline_parallel_size == 1
+
+    assert config.parallel_config.pipeline_parallel_size == 2
+
+
+def test_pp_guard_is_inert_on_upstream_main(monkeypatch):
+    """Upstream builds the PP state itself, so Ascend must not mask PP there."""
+    _force_lane(monkeypatch, "0.0.0-dev")
+    config = SimpleNamespace(parallel_config=SimpleNamespace(pipeline_parallel_size=2))
+    support = SpecPPSupport(bypass_upstream_pp_guard=True)
+
+    with bypass_upstream_spec_pp_guard(config, support) as bypassed:
+        assert not bypassed
+        assert config.parallel_config.pipeline_parallel_size == 2

--- a/vllm_ascend/patch/worker/patch_deepseek_v2.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_v2.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.mla import (
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.models.deepseek_v2 import (
+    DeepseekV2ForCausalLM,
     DeepSeekV2FusedQkvAProjLinear,
     DeepseekV2MLAAttention,
     DeepseekV2Model,
@@ -29,6 +30,7 @@ from vllm.model_executor.models.deepseek_v2 import (
     _get_llama_4_scaling,
     yarn_get_mscale,
 )
+from vllm.model_executor.models.interfaces import EagleModelMixin
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.sequence import IntermediateTensors
 
@@ -298,6 +300,57 @@ def _deepseek_v2_mla_attention_init(
 DeepseekV2MLAAttention.__init__ = _deepseek_v2_mla_attention_init
 
 
+def _install_aux_hidden_state_relay() -> None:
+    """Adopt upstream's auxiliary-state relay bookkeeping.
+
+    Upstream validates PP with a target-driven drafter through
+    ``supports_aux_hidden_states_over_pp`` and relays the states itself
+    (``PPHandler.relay_aux_hidden_states``), keying them through the
+    ``EagleModelMixin`` slot layout. This decoder keeps its own capture points
+    and its tensor-parallel all-gather, so it only takes the bookkeeping.
+    """
+    for member in (
+        "AUX_HIDDEN_STATE_KEY",
+        "_aux_slot_base_cached",
+        "_aux_upstream_total_cached",
+        "_set_aux_hidden_state_layers",
+        "_cache_aux_pp_layout",
+        "pack_local_aux_hidden_states",
+        "collect_remote_aux_hidden_states",
+    ):
+        setattr(DeepseekV2Model, member, getattr(EagleModelMixin, member))
+    DeepseekV2Model.supports_aux_hidden_states_over_pp = True
+
+
+_install_aux_hidden_state_relay()
+
+
+def _patched_set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+    # Go through the mixin so the per-stage slot base is cached for the relay.
+    self.model._set_aux_hidden_state_layers(layers)
+
+
+DeepseekV2ForCausalLM.set_aux_hidden_state_layers = _patched_set_aux_hidden_state_layers
+
+
+def _capture_aux_hidden_state(
+    self,
+    aux_hidden_states: list[torch.Tensor],
+    layer_id: int,
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor | None,
+    positions: torch.Tensor,
+) -> None:
+    """Append one auxiliary state under upstream's layer-id convention."""
+    if layer_id not in self.aux_hidden_state_layers:
+        return
+    aux_hidden_state = hidden_states if residual is None else hidden_states + residual
+    if aux_hidden_state.shape[0] != positions.shape[0]:
+        aux_hidden_state = tensor_model_parallel_all_gather(aux_hidden_state, 0)
+        aux_hidden_state = aux_hidden_state[: positions.shape[0]]
+    aux_hidden_states.append(aux_hidden_state)
+
+
 def _patched_forward(
     self,
     input_ids: torch.Tensor | None,
@@ -305,7 +358,8 @@ def _patched_forward(
     intermediate_tensors: IntermediateTensors | None,
     inputs_embeds: torch.Tensor | None = None,
 ) -> torch.Tensor | IntermediateTensors:
-    if get_pp_group().is_first_rank:
+    pp_group = get_pp_group()
+    if pp_group.is_first_rank:
         if inputs_embeds is not None:
             hidden_states = inputs_embeds
         else:
@@ -313,10 +367,12 @@ def _patched_forward(
                 raise ValueError("Either input_ids or inputs_embeds must be provided to DeepseekV2Model.forward")
             hidden_states = self.embed_input_ids(input_ids)
         residual = None
+        remote_aux_hidden_states: list[torch.Tensor] = []
     else:
         assert intermediate_tensors is not None
         hidden_states = intermediate_tensors["hidden_states"]
         residual = intermediate_tensors["residual"]
+        remote_aux_hidden_states = self.collect_remote_aux_hidden_states(intermediate_tensors)
 
     llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
     llama_4_scaling: torch.Tensor | None
@@ -329,21 +385,37 @@ def _patched_forward(
     else:
         llama_4_scaling = None
 
-    aux_hidden_states = []
+    # A stage captures the state entering its first layer (the previous stage
+    # owns it otherwise) and the output of every layer it owns, so the stage
+    # that owns a layer also owns that layer's auxiliary state. That is the
+    # convention upstream's relay bookkeeping assumes.
+    local_aux_hidden_states: list[torch.Tensor] = []
+    if pp_group.is_first_rank:
+        _capture_aux_hidden_state(
+            self,
+            local_aux_hidden_states,
+            self.start_layer,
+            hidden_states,
+            residual,
+            positions,
+        )
     for idx, layer in enumerate(
         islice(self.layers, self.start_layer, self.end_layer),
         start=self.start_layer,
     ):
-        if idx in self.aux_hidden_state_layers:
-            aux_hidden_state = hidden_states + residual
-            if aux_hidden_state.shape[0] != positions.shape[0]:
-                aux_hidden_state = tensor_model_parallel_all_gather(aux_hidden_state, 0)
-                aux_hidden_state = aux_hidden_state[: positions.shape[0]]
-            aux_hidden_states.append(aux_hidden_state)
         hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
+        _capture_aux_hidden_state(self, local_aux_hidden_states, idx + 1, hidden_states, residual, positions)
 
-    if not get_pp_group().is_last_rank:
-        return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+    if not pp_group.is_last_rank:
+        return IntermediateTensors(
+            {
+                "hidden_states": hidden_states,
+                "residual": residual,
+                # This stage's captures take the slots after the upstream ones,
+                # so the relay can keep the received slots in place.
+                **self.pack_local_aux_hidden_states(local_aux_hidden_states),
+            }
+        )
 
     if hidden_states.shape[0] != positions.shape[0]:
         combined_states = torch.cat([hidden_states, residual], dim=-1)
@@ -353,9 +425,8 @@ def _patched_forward(
         hidden_states, residual = combined_states.split([hidden_size, hidden_size], dim=-1)
         residual = residual.contiguous()
 
-    if self.end_layer in self.aux_hidden_state_layers:
-        aux_hidden_states.append(hidden_states + residual)
-
+    # Earlier stages' states come first: they hold the lower layer indices.
+    aux_hidden_states = remote_aux_hidden_states + local_aux_hidden_states
     hidden_states, _ = self.norm(hidden_states, residual)
     if len(aux_hidden_states) > 0:
         return hidden_states, aux_hidden_states

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -66,6 +66,7 @@ from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffe
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 from vllm_ascend.worker.v2.pp_utils import (
     bypass_upstream_spec_pp_guard,
+    is_legacy_spec_pp_lane,
     resolve_spec_pp_support,
     restore_pp_after_upstream_init,
 )
@@ -135,7 +136,10 @@ class NPUModelRunner(GPUModelRunner):
         # init_speculator will return AscendEagleSpeculator when eagle is used.
         # so here we just call init_speculator to reinitialize speculator.
         self.speculator: AscendEagleSpeculator | None = None
-        if self.speculative_config is not None and (not self.use_spec_pp or self.is_last_pp_rank):
+        # Release lanes build an unsharded draft on every rank that owns one;
+        # upstream main places the draft on the last PP rank only.
+        draft_lives_here = self.is_last_pp_rank or (is_legacy_spec_pp_lane() and not self.use_spec_pp)
+        if self.speculative_config is not None and draft_lives_here:
             self.speculator = init_speculator(self.vllm_config, self.device)
             # Shared update_stream: main model (ModelAclGraphManager) and draft
             # (Eagle/DFlash/DSpark AclGraphManager) all use this same stream.

--- a/vllm_ascend/worker/v2/pp_utils.py
+++ b/vllm_ascend/worker/v2/pp_utils.py
@@ -13,6 +13,23 @@ import torch
 from vllm.config import VllmConfig
 from vllm.sequence import IntermediateTensors
 
+from vllm_ascend.utils import vllm_version_is
+
+# The release lane rejects spec + PP and needs Ascend's own PP transport.
+# Release lanes that predate upstream spec + PP support (vLLM #50514, which is
+# not in v0.29.0 either: the release branch forked from main before it landed).
+# Those vLLMs reject the combination before the runner is built, keep the
+# auxiliary states out of the pipeline and let the draft inherit the target PP,
+# so Ascend keeps its own path there. Upstream main builds the PP state itself,
+# broadcasts the draft block and relays the auxiliary states.
+_LEGACY_SPEC_PP_VERSIONS = ("0.28.0", "0.29.0")
+
+
+def is_legacy_spec_pp_lane() -> bool:
+    """Whether this vLLM still needs Ascend's spec + PP workarounds."""
+    return any(vllm_version_is(version) for version in _LEGACY_SPEC_PP_VERSIONS)
+
+
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner
@@ -82,8 +99,14 @@ def bypass_upstream_spec_pp_guard(
     vllm_config: VllmConfig,
     support: SpecPPSupport | None,
 ) -> Iterator[bool]:
-    """Initialize the upstream runner as PP=1 to bypass its Spec+PP guard."""
-    bypass_guard = support.bypass_upstream_pp_guard if support is not None else False
+    """Initialize the upstream runner as PP=1 to bypass its Spec+PP guard.
+
+    Only the release lane rejects spec + PP before the runner is built and needs
+    Ascend to rebuild the skipped PP state. Upstream main owns PP itself, so
+    masking it there would hide state the runner expects to build.
+    """
+    support_bypasses = support.bypass_upstream_pp_guard if support is not None else False
+    bypass_guard = support_bypasses and is_legacy_spec_pp_lane()
     if not bypass_guard:
         yield False
         return


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream main validates pipeline parallelism with a target-driven drafter through
`supports_aux_hidden_states_over_pp` and relays the auxiliary hidden states
itself (`PPHandler.relay_aux_hidden_states`), keying them through the
`EagleModelMixin` slot layout. The DeepseekV2 decoder behind GLM-5.2 and the
DeepSeek-V2/V3 family captured a state one layer earlier than that layout
assumes, so the stage that owns a layer and the stage that owns its auxiliary
state disagreed whenever an auxiliary id landed on a PP stage boundary. With
GLM-5.2's ids `[2, 20, 39, 58, 75]` that is not exotic: the PP4 boundaries are
20/40/59, and `bisect_right` then counts one slot more than the earlier stages
filled, so the relay reads a slot nobody wrote.

This PR only contains that change; nothing from the main2main or GLM DSpark PRs.

- adopt the upstream `EagleModelMixin` slot bookkeeping for this decoder and
  declare `supports_aux_hidden_states_over_pp`, so the runner reserves the slots
  and relays the states itself
- capture under upstream's convention: the state entering the first layer (first
  rank only, the previous stage owns it otherwise) plus the output of every layer
  the stage owns, keeping the tensor-parallel all-gather
- pack the captures into the upstream `aux_hidden_states_<i>` slots and read the
  earlier stages back with `collect_remote_aux_hidden_states`
- keep the Ascend spec + PP workarounds on the release lanes only, through
  `pp_utils.is_legacy_spec_pp_lane()`, which covers `0.28.0` and `0.29.0`:
  neither has upstream spec + PP support (`#50514` landed on main on 2026-09-05,
  after both release branches forked), so they still reject the combination
  before the runner is built and have no draft relay. On main the runner builds
  the PP state itself, so the guard bypass is skipped and the draft is built on
  the last PP rank only.

The MiniMax-M3 and DeepSeek-V4 decoders already capture under the upstream
convention and only need to declare support (done in the main2main PR).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The change was tested on top of #16009 (`[Misc][Main2Main] Main2main 0909`,
vLLM `a97dacb7106ee49f39f3d1fc6ae1800ff724e01d`), applied locally only for the
test run. The engine tarball has no `_version.py`, so the run exports
`VLLM_VERSION=0.30.0` to report a main-like lane (`0.29.0` would now be
classified as a release lane by the gate above).

- `tests/ut/patch/worker/test_patch_deepseek_v2.py`: the decoder declares the
  upstream relay, the capture follows the upstream ids (`{0, 4}` over four layers
  captures two states), a middle stage publishes only its own captures in the
  slots after the relayed ones, and the last stage appends local states after the
  relayed ones.
- `tests/ut/worker/v2/test_spec_pp_guard_lane.py`: `0.28.0` and `0.29.0` are
  release lanes that bypass the Spec+PP guard, while a main-like version is not
  and keeps the partition untouched.
- those two files: 13 passed, plus `ruff check` and `ruff format --check`.

Serving GLM-5.2 W4A8 + DSpark on that pin (8 cards, PP2 x TP4, FULL_DECODE_ONLY
graph mode, async scheduling, prefix caching, chunked prefill, expert parallel):

- a `curl` chat completion answers correctly (`17 * 23` -> `391`,
  `finish_reason=stop`).
- GSM8K-lite, 32 questions at temperature 1.0 / top_p 0.95, scored with the same
  extraction and comparison on both sides (it reproduces the 0.28.0 baseline's
  `32/32` exactly): `31/32`, the single miss being a complete generation that
  answers `12` where the reference is `13`. The same question misses on the
  reference stack as well, so it is single-sample variance rather than a
  sharding or transport artefact.
