### PR TITLE
[v0.27.1rc][Feature] support Kimi K3 DSpark with DCP

### DIFF
--- a/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
+++ b/tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py
@@ -417,6 +417,7 @@ def test_stateful_handoff_preserves_decode_graph(
 ):
     # Exercise the real dispatcher and DP synchronization using CPU metadata only.
     runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.dcp_size = 1
     runner.dp_size = dp_size
     runner.dp_rank = 0
     runner.parallel_config = SimpleNamespace(

--- a/tests/ut/attention/test_mla_cp.py
+++ b/tests/ut/attention/test_mla_cp.py
@@ -35,6 +35,39 @@ def test_mla_dcp_extends_v1_backend() -> None:
     assert {"cp_seq_len", "dcp_mtp_attn_mask"} <= dcp_fields
 
 
+def test_mla_dcp_decode_metadata_slices_mtp_mask_to_decode_batch() -> None:
+    decode = AscendMLADCPDecodeMetadata(
+        input_positions=torch.arange(4),
+        block_table=torch.ones((1, 2), dtype=torch.int32),
+        seq_lens=torch.tensor([20]),
+        max_seq_lens=20,
+        seq_lens_list=[20],
+    )
+    mtp_mask = torch.zeros((2, 8, 32), dtype=torch.bool)
+    dcp_metadata = SimpleNamespace(
+        draft_cp_seq_len=torch.tensor([10, 11], dtype=torch.int32),
+        dcp_mtp_attn_mask=mtp_mask,
+    )
+    builder = AscendMlaDCPMetadataBuilder.__new__(AscendMlaDCPMetadataBuilder)
+    builder.num_decodes = 1
+    builder._require_dcp_metadata = lambda _metadata: dcp_metadata
+
+    with patch.object(
+        AscendMLAMetadataBuilder,
+        "build_decode_metadata",
+        return_value=decode,
+    ):
+        result = builder.build_decode_metadata(
+            common_prefix_len=0,
+            common_attn_metadata=SimpleNamespace(),
+        )
+
+    assert result is decode
+    assert result.cp_seq_len.tolist() == [10]
+    assert result.dcp_mtp_attn_mask.shape == (1, 8, 32)
+    assert result.dcp_mtp_attn_mask.data_ptr() == mtp_mask.data_ptr()
+
+
 def test_mla_dcp_reorg_decode_query_gathers_fused_query() -> None:
     impl = AscendMlaDCPImpl.__new__(AscendMlaDCPImpl)
     impl.dcp_size = 2
@@ -155,3 +188,72 @@ def test_mla_dcp_mixed_cache_hit_batch_uses_decode_bsnd_metadata(mock_fia) -> No
     assert call_kwargs["actual_seq_lengths"] == [4]
     assert call_kwargs["block_table"].shape[0] == 1
     assert call_kwargs["actual_seq_lengths_kv"].tolist() == [10]
+
+
+@patch(
+    "vllm_ascend.attention.context_parallel.mla_cp._EXTRA_CTX",
+    SimpleNamespace(is_draft_model=False, capturing=False),
+)
+@patch("vllm_ascend.attention.context_parallel.mla_cp.torch_npu.npu_fused_infer_attention_score")
+def test_mla_dcp_uses_native_global_query_heads_for_fia(mock_fia) -> None:
+    impl = AscendMlaDCPImpl.__new__(AscendMlaDCPImpl)
+    impl.dcp_size = 8
+    impl.num_heads = 12
+    impl.num_kv_heads = 1
+    impl.kv_lora_rank = 3
+    impl.qk_rope_head_dim = 2
+    impl.scale = 1.0
+    impl.speculative_config = SimpleNamespace(num_speculative_tokens=3)
+
+    merged = {}
+
+    def merge(output, softmax_lse, _rank):
+        merged["output_shape"] = output.shape
+        merged["softmax_lse_shape"] = softmax_lse.shape
+        return output
+
+    impl._merge_dcp_attention_output = merge
+    impl._v_up_proj_batch_major = lambda output: output
+
+    decode = AscendMLADCPDecodeMetadata(
+        input_positions=torch.arange(4),
+        block_table=torch.ones((1, 2), dtype=torch.int32),
+        seq_lens=torch.tensor([20]),
+        max_seq_lens=20,
+        seq_lens_list=[20],
+        cp_seq_len=torch.tensor([10], dtype=torch.int32),
+        dcp_mtp_attn_mask=torch.zeros((1, 1, 4, 4)),
+    )
+    metadata = AscendMLAMetadata(
+        num_actual_tokens=4,
+        slot_mapping=torch.arange(4),
+        query_start_loc=torch.tensor([0, 4]),
+        seq_lens=torch.tensor([20]),
+        seq_lens_cpu=torch.tensor([20]),
+        block_tables=torch.ones((1, 2), dtype=torch.int32),
+        num_decodes=1,
+        num_decode_tokens=4,
+        num_prefills=0,
+        query_lens=[4],
+        attn_state=AscendAttentionState.DecodeOnly,
+        decode=decode,
+    )
+
+    q_nope = torch.randn(4, 96, 3)
+    q_pe = torch.randn(4, 96, 2)
+    k_nope = torch.randn(2, 1, 2, 3)
+    k_pe = torch.randn(2, 1, 2, 2)
+    mock_fia.return_value = (
+        torch.randn(1, 4, 96, 3),
+        torch.randn(1, 96, 4, 1),
+    )
+
+    impl._forward_decode(q_nope, q_pe, k_nope, k_pe, 2, metadata)
+
+    call_args = mock_fia.call_args.args
+    call_kwargs = mock_fia.call_args.kwargs
+    assert call_args[0].shape == (1, 4, 96, 3)
+    assert call_kwargs["query_rope"].shape == (1, 4, 96, 2)
+    assert call_kwargs["num_heads"] == 96
+    assert merged["output_shape"] == (4, 96, 3)
+    assert merged["softmax_lse_shape"] == (4, 96, 1)

--- a/tests/ut/attention/test_mla_cp_mask_slice.py
+++ b/tests/ut/attention/test_mla_cp_mask_slice.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from vllm_ascend.attention.context_parallel.mla_cp import (
+    AscendMLADCPDecodeMetadata,
+    AscendMlaDCPMetadataBuilder,
+)
+from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
+
+
+@patch.object(AscendMLAMetadataBuilder, "build_decode_metadata")
+def test_mla_dcp_decode_metadata_slices_mtp_mask_to_decode_batch(mock_build) -> None:
+    decode = AscendMLADCPDecodeMetadata(
+        input_positions=torch.arange(4),
+        block_table=torch.ones((1, 2), dtype=torch.int32),
+        seq_lens=torch.tensor([20]),
+        max_seq_lens=20,
+        seq_lens_list=[20],
+    )
+    mock_build.return_value = decode
+
+    mtp_mask = torch.zeros((2, 8, 32), dtype=torch.bool)
+    dcp_metadata = SimpleNamespace(
+        draft_cp_seq_len=torch.tensor([10, 11], dtype=torch.int32),
+        dcp_mtp_attn_mask=mtp_mask,
+    )
+    builder = AscendMlaDCPMetadataBuilder.__new__(AscendMlaDCPMetadataBuilder)
+    builder.num_decodes = 1
+    builder._require_dcp_metadata = lambda _metadata: dcp_metadata
+
+    result = builder.build_decode_metadata(
+        common_prefix_len=0,
+        common_attn_metadata=SimpleNamespace(),
+    )
+
+    assert result.cp_seq_len.tolist() == [10]
+    assert result.dcp_mtp_attn_mask.shape == (1, 8, 32)
+    assert result.dcp_mtp_attn_mask.data_ptr() == mtp_mask.data_ptr()

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -333,6 +333,22 @@ def test_sequence_index_buffers_cover_spec_decode_when_cudagraph_disabled():
     assert non_spec_indices.numel() == 0
 
 
+def test_dspark_target_reorder_threshold_includes_base_token():
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=7,
+    )
+    builder.vllm_config.speculative_config.method = "dspark"
+    builder.vllm_config.speculative_config.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(sample_from_anchor=True),
+    )
+
+    builder._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+
+    assert builder.reorder_batch_threshold == 8
+
+
 def _cache_index_first_column(cache_indices: torch.Tensor) -> torch.Tensor:
     if cache_indices.dim() == 1:
         return cache_indices

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -333,7 +333,10 @@ def test_sequence_index_buffers_cover_spec_decode_when_cudagraph_disabled():
     assert non_spec_indices.numel() == 0
 
 
-def test_dspark_target_reorder_threshold_includes_base_token():
+@pytest.mark.parametrize("sample_from_anchor", [False, True])
+def test_dspark_target_reorder_threshold_includes_base_token_regardless_of_anchor(
+    sample_from_anchor: bool,
+):
     builder = _make_builder(
         device=torch.device("cpu"),
         num_heads=32,
@@ -341,7 +344,7 @@ def test_dspark_target_reorder_threshold_includes_base_token():
     )
     builder.vllm_config.speculative_config.method = "dspark"
     builder.vllm_config.speculative_config.draft_model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(sample_from_anchor=True),
+        hf_config=SimpleNamespace(sample_from_anchor=sample_from_anchor),
     )
 
     builder._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
@@ -830,45 +833,77 @@ def test_one_token_prefill_selection_respects_recurrent_state(
 
 
 @pytest.mark.parametrize(
-    ("seq_len", "expected_spec_decodes", "expected_prefills"),
+    "dcp_size,num_spec,context_len,mixed_spec,graph_mode",
     [
-        pytest.param(4, 0, 1, id="first_chunk_stays_prefill"),
-        pytest.param(8, 1, 0, id="stateful_chunk_folds_into_spec"),
+        (1, 3, 0, False, CUDAGraphMode.NONE),
+        (1, 3, 384, False, CUDAGraphMode.NONE),
+        (1, 5, 384, True, CUDAGraphMode.FULL_DECODE_ONLY),
+        (16, 5, 0, False, CUDAGraphMode.NONE),
+        (16, 5, 384, False, CUDAGraphMode.NONE),
+        (16, 5, 384, False, CUDAGraphMode.FULL_DECODE_ONLY),
+        (16, 5, 384, True, CUDAGraphMode.NONE),
+        (16, 5, 384, True, CUDAGraphMode.FULL_DECODE_ONLY),
     ],
 )
-def test_spec_sized_prefill_fold_requires_recurrent_state(
+def test_spec_width_prompt_chunk_folds_only_without_dcp(
     monkeypatch: pytest.MonkeyPatch,
-    seq_len: int,
-    expected_spec_decodes: int,
-    expected_prefills: int,
+    dcp_size: int,
+    num_spec: int,
+    context_len: int,
+    mixed_spec: bool,
+    graph_mode: CUDAGraphMode,
 ):
     _patch_missing_runtime_cdiv(monkeypatch)
-    common_attn_metadata = create_common_attn_metadata(
-        BatchSpec(seq_lens=[seq_len], query_lens=[4]),
-        block_size=16,
+    width = num_spec + 1
+    query_lens = [width, width] if mixed_spec else [width]
+    seq_lens = [768 + width, context_len + width] if mixed_spec else [context_len + width]
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=seq_lens, query_lens=query_lens),
+        block_size=384,
         device=torch.device("cpu"),
     )
+    common.is_prefilling = torch.tensor([False, True] if mixed_spec else [True])
+    common.block_table_tensor = torch.arange(len(query_lens) * 10, dtype=torch.int32).view(-1, 10)
     builder = _make_builder(
         device=torch.device("cpu"),
         num_heads=32,
-        num_speculative_tokens=3,
+        num_speculative_tokens=num_spec,
+        mamba_cache_mode="align",
+        block_size=384,
+        num_speculative_blocks=num_spec,
+        cudagraph_mode=graph_mode,
     )
-
-    attn_metadata = builder.build(
+    builder.vllm_config.parallel_config.decode_context_parallel_size = dcp_size
+    accepted = torch.tensor([2, 1] if mixed_spec else [1], dtype=torch.int32)
+    metadata = builder.build(
         0,
-        common_attn_metadata,
-        num_accepted_tokens=torch.ones(1, dtype=torch.int32),
-        num_decode_draft_tokens_cpu=torch.full((1,), -1, dtype=torch.int32),
+        common,
+        num_accepted_tokens=accepted,
+        num_decode_draft_tokens_cpu=torch.tensor([num_spec, -1] if mixed_spec else [-1], dtype=torch.int32),
     )
 
-    assert attn_metadata.num_spec_decodes == expected_spec_decodes
-    assert attn_metadata.num_prefills == expected_prefills
-    if expected_spec_decodes:
-        assert attn_metadata.spec_sequence_masks.tolist() == [True]
-        assert attn_metadata.num_accepted_tokens.tolist() == [4]
+    assert accepted.tolist() == ([2, 1] if mixed_spec else [1])
+    if dcp_size == 1 and context_len > 0:
+        assert metadata.num_prefills == 0
+        assert metadata.num_prefill_tokens == 0
+        assert metadata.num_spec_decodes == 1 + int(mixed_spec)
+        assert metadata.spec_sequence_masks.tolist() == ([True, True] if mixed_spec else [True])
+        assert metadata.num_accepted_tokens.tolist() == ([2, width] if mixed_spec else [width])
+        return
+
+    # DCP retains prefill state semantics regardless of the prompt chunk width.
+    assert metadata.num_prefills == 1
+    assert metadata.num_prefill_tokens == width
+    assert metadata.num_spec_decodes == int(mixed_spec)
+    assert metadata.prefill_has_initial_state.tolist() == [context_len > 0]
+    expected_slot = (10 if mixed_spec else 0) + (seq_lens[-1] - 1) // 384
+    assert metadata.prefill_state_indices.tolist() == [expected_slot]
+    if mixed_spec:
+        assert metadata.spec_sequence_masks.tolist() == [True, False]
+        assert metadata.num_accepted_tokens.tolist() == [2]
     else:
-        assert attn_metadata.spec_sequence_masks is None
-        assert attn_metadata.num_accepted_tokens is None
+        assert metadata.spec_sequence_masks is None
+        assert metadata.num_accepted_tokens is None
 
 
 def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -26,14 +26,17 @@ def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
     assert normalized.block_size == 7
 
 
-def _make_k3_dspark_config(dcp_size: int = 8):
+def _make_k3_dspark_config(
+    dcp_size: int = 8,
+    method: str = "dspark",
+):
     draft_hf_config = SimpleNamespace(
         ptd_token_id=163839,
         dspark_noise_token_id=163839,
         mask_token_id=None,
     )
     return SimpleNamespace(
-        method="dspark",
+        method=method,
         target_parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp_size,
         ),
@@ -41,54 +44,80 @@ def _make_k3_dspark_config(dcp_size: int = 8):
             architectures=["K3DSparkModel"],
             hf_config=draft_hf_config,
         ),
-        use_dspark=lambda: True,
+        use_dspark=lambda: method == "dspark",
     )
 
 
 def test_k3_dspark_dcp_is_hidden_only_during_upstream_validation(monkeypatch):
     config = _make_k3_dspark_config()
-    observed_dcp_sizes = []
+    original_parallel_config = config.target_parallel_config
+    validated_parallel_configs = []
 
-    def validate_without_gpu_guard(candidate):
-        observed_dcp_sizes.append(
-            candidate.target_parallel_config.decode_context_parallel_size
-        )
+    def validate_config(validated_config):
+        validated_parallel_configs.append(validated_config.target_parallel_config)
+        assert validated_config.target_parallel_config.decode_context_parallel_size == 1
 
     monkeypatch.setattr(
-        patch_speculative_config, "_orig_post_init", validate_without_gpu_guard
+        patch_speculative_config,
+        "_orig_post_init",
+        validate_config,
     )
 
     patch_speculative_config._dspark_post_init(config)
 
-    assert observed_dcp_sizes == [1]
+    assert len(validated_parallel_configs) == 1
+    assert validated_parallel_configs[0] is not original_parallel_config
+    assert config.target_parallel_config is original_parallel_config
+    assert config.target_parallel_config.decode_context_parallel_size == 8
+
+
+def test_k3_dspark_dcp_restores_parallel_config_when_validation_fails(
+    monkeypatch,
+):
+    config = _make_k3_dspark_config()
+    original_parallel_config = config.target_parallel_config
+
+    def raise_validation_error(validated_config):
+        assert validated_config.target_parallel_config is not original_parallel_config
+        assert validated_config.target_parallel_config.decode_context_parallel_size == 1
+        raise ValueError("some other speculative config error")
+
+    monkeypatch.setattr(
+        patch_speculative_config,
+        "_orig_post_init",
+        raise_validation_error,
+    )
+
+    with pytest.raises(ValueError, match="some other speculative config error"):
+        patch_speculative_config._dspark_post_init(config)
+
+    assert config.target_parallel_config is original_parallel_config
     assert config.target_parallel_config.decode_context_parallel_size == 8
 
 
 @pytest.mark.parametrize(
-    ("dcp_size", "message"),
+    ("config", "expected_dcp_size"),
     [
-        (1, "upstream speculative config error"),
-        (8, "some other speculative config error"),
+        (_make_k3_dspark_config(dcp_size=1), 1),
+        (_make_k3_dspark_config(method="eagle"), 8),
     ],
 )
-def test_k3_dspark_dcp_restores_config_and_propagates_validation_errors(
-    monkeypatch, dcp_size, message
+def test_non_dcp_dspark_config_is_not_replaced_during_validation(
+    monkeypatch,
+    config,
+    expected_dcp_size,
 ):
-    config = _make_k3_dspark_config(dcp_size=dcp_size)
-    observed_dcp_sizes = []
+    original_parallel_config = config.target_parallel_config
 
-    def raise_validation_error(candidate):
-        observed_dcp_sizes.append(
-            candidate.target_parallel_config.decode_context_parallel_size
-        )
-        raise ValueError(message)
+    def validate_config(validated_config):
+        assert validated_config.target_parallel_config is original_parallel_config
+        assert validated_config.target_parallel_config.decode_context_parallel_size == expected_dcp_size
 
     monkeypatch.setattr(
-        patch_speculative_config, "_orig_post_init", raise_validation_error
+        patch_speculative_config,
+        "_orig_post_init",
+        validate_config,
     )
 
-    with pytest.raises(ValueError, match=message):
-        patch_speculative_config._dspark_post_init(config)
-
-    assert observed_dcp_sizes == [1]
-    assert config.target_parallel_config.decode_context_parallel_size == dcp_size
+    patch_speculative_config._dspark_post_init(config)
+    assert config.target_parallel_config is original_parallel_config

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -1,7 +1,15 @@
+from types import SimpleNamespace
+
+import pytest
 from transformers import Qwen3Config
 from vllm.config.speculative import SpeculativeConfig
 
-import vllm_ascend.patch.platform.patch_speculative_config  # noqa: F401
+from vllm_ascend.patch.platform import patch_speculative_config
+
+_UPSTREAM_K3_DSPARK_DCP_ERROR = (
+    patch_speculative_config._UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT
+    + "; set decode_context_parallel_size=1."
+)
 
 
 def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
@@ -21,3 +29,59 @@ def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
     assert normalized.mask_token_id == 163824
     assert normalized.target_layer_ids == [7, 23, 51, 67, 83]
     assert normalized.block_size == 7
+
+
+def _make_k3_dspark_config(dcp_size: int = 8):
+    draft_hf_config = SimpleNamespace(
+        ptd_token_id=163839,
+        dspark_noise_token_id=163839,
+        mask_token_id=None,
+    )
+    return SimpleNamespace(
+        method="dspark",
+        target_parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+        ),
+        draft_model_config=SimpleNamespace(
+            architectures=["K3DSparkModel"],
+            hf_config=draft_hf_config,
+        ),
+        use_dspark=lambda: True,
+    )
+
+
+def test_k3_dspark_dcp_bypasses_upstream_gpu_guard(monkeypatch):
+    config = _make_k3_dspark_config()
+
+    def raise_upstream_guard(_config):
+        raise ValueError(_UPSTREAM_K3_DSPARK_DCP_ERROR)
+
+    monkeypatch.setattr(
+        patch_speculative_config, "_orig_post_init", raise_upstream_guard
+    )
+
+    patch_speculative_config._dspark_post_init(config)
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (
+            _make_k3_dspark_config(dcp_size=1),
+            _UPSTREAM_K3_DSPARK_DCP_ERROR,
+        ),
+        (_make_k3_dspark_config(), "some other speculative config error"),
+    ],
+)
+def test_k3_dspark_dcp_does_not_hide_other_validation_errors(
+    monkeypatch, config, message
+):
+    def raise_validation_error(_config):
+        raise ValueError(message)
+
+    monkeypatch.setattr(
+        patch_speculative_config, "_orig_post_init", raise_validation_error
+    )
+
+    with pytest.raises(ValueError, match=message):
+        patch_speculative_config._dspark_post_init(config)

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -6,11 +6,6 @@ from vllm.config.speculative import SpeculativeConfig
 
 from vllm_ascend.patch.platform import patch_speculative_config
 
-_UPSTREAM_K3_DSPARK_DCP_ERROR = (
-    patch_speculative_config._UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT
-    + "; set decode_context_parallel_size=1."
-)
-
 
 def test_legacy_qwen3_dspark_config_uses_qwen3_loader():
     config = Qwen3Config(
@@ -50,33 +45,42 @@ def _make_k3_dspark_config(dcp_size: int = 8):
     )
 
 
-def test_k3_dspark_dcp_bypasses_upstream_gpu_guard(monkeypatch):
+def test_k3_dspark_dcp_is_hidden_only_during_upstream_validation(monkeypatch):
     config = _make_k3_dspark_config()
+    observed_dcp_sizes = []
 
-    def raise_upstream_guard(_config):
-        raise ValueError(_UPSTREAM_K3_DSPARK_DCP_ERROR)
+    def validate_without_gpu_guard(candidate):
+        observed_dcp_sizes.append(
+            candidate.target_parallel_config.decode_context_parallel_size
+        )
 
     monkeypatch.setattr(
-        patch_speculative_config, "_orig_post_init", raise_upstream_guard
+        patch_speculative_config, "_orig_post_init", validate_without_gpu_guard
     )
 
     patch_speculative_config._dspark_post_init(config)
 
+    assert observed_dcp_sizes == [1]
+    assert config.target_parallel_config.decode_context_parallel_size == 8
+
 
 @pytest.mark.parametrize(
-    ("config", "message"),
+    ("dcp_size", "message"),
     [
-        (
-            _make_k3_dspark_config(dcp_size=1),
-            _UPSTREAM_K3_DSPARK_DCP_ERROR,
-        ),
-        (_make_k3_dspark_config(), "some other speculative config error"),
+        (1, "upstream speculative config error"),
+        (8, "some other speculative config error"),
     ],
 )
-def test_k3_dspark_dcp_does_not_hide_other_validation_errors(
-    monkeypatch, config, message
+def test_k3_dspark_dcp_restores_config_and_propagates_validation_errors(
+    monkeypatch, dcp_size, message
 ):
-    def raise_validation_error(_config):
+    config = _make_k3_dspark_config(dcp_size=dcp_size)
+    observed_dcp_sizes = []
+
+    def raise_validation_error(candidate):
+        observed_dcp_sizes.append(
+            candidate.target_parallel_config.decode_context_parallel_size
+        )
         raise ValueError(message)
 
     monkeypatch.setattr(
@@ -85,3 +89,6 @@ def test_k3_dspark_dcp_does_not_hide_other_validation_errors(
 
     with pytest.raises(ValueError, match=message):
         patch_speculative_config._dspark_post_init(config)
+
+    assert observed_dcp_sizes == [1]
+    assert config.target_parallel_config.decode_context_parallel_size == dcp_size

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -3,7 +3,7 @@
 import math
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -721,6 +721,35 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
     manager = AscendMambaManager(**manager_kwargs)
 
     assert manager.block_size == mamba_spec.block_size
+
+
+def test_ascend_mamba_cache_lookup_ignores_dcp_sharding() -> None:
+    """Mamba states are replicated, unlike DCP-sharded attention KV cache."""
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+
+    with patch.object(
+        AscendMambaManager.__mro__[1],
+        "find_longest_cache_hit",
+        return_value=((), 0),
+    ) as find_cache_hit:
+        AscendMambaManager.find_longest_cache_hit(
+            block_hashes=[],
+            max_length=0,
+            kv_cache_group_ids=[1],
+            block_pool=MagicMock(),
+            kv_cache_spec=mamba_spec,
+            alignment_tokens=16,
+            dcp_world_size=8,
+            pcp_world_size=1,
+            drop_eagle_block=False,
+        )
+
+    assert find_cache_hit.call_args.kwargs["dcp_world_size"] == 1
 
 
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -732,8 +732,12 @@ def test_ascend_mamba_cache_lookup_ignores_dcp_sharding() -> None:
         mamba_cache_mode="none",
     )
 
+    # The patch module replaces vLLM's public MambaManager symbol with the
+    # Ascend subclass, so patch the subclass's direct base explicitly.
+    base_mamba_manager = AscendMambaManager.__base__
+    assert base_mamba_manager is not None
     with patch.object(
-        AscendMambaManager.__mro__[1],
+        base_mamba_manager,
         "find_longest_cache_hit",
         return_value=((), 0),
     ) as find_cache_hit:

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -592,6 +592,52 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert proposer.draft_attn_groups[0].kv_cache_spec.block_size == 384
         assert kwargs["block_size"] == 128
 
+    def test_dcp_updates_slot_kernel_and_parallel_block_metadata(self, monkeypatch):
+        kernel = MagicMock()
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
+            kernel,
+        )
+        proposer = self._make_proposer(max_num_tokens=64, num_reqs=1, block_size=5)
+        proposer.dcp_size = 8
+        proposer.dcp_rank = 3
+        proposer.vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=1),
+        )
+        dcp_manager = SimpleNamespace(
+            prepare_spec_decode_first_pass_inputs=MagicMock(),
+            prepare_spec_decode_drafting_cp_metadata=MagicMock(),
+        )
+        proposer.runner = SimpleNamespace(
+            dcp_manager=dcp_manager,
+        )
+
+        num_query_total, _, cad, extra, _, _ = self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=1,
+            block_size=5,
+        )
+
+        kwargs = kernel[1,].call_args.kwargs
+        assert kwargs["DCP_SIZE"] == 8
+        assert kwargs["DCP_RANK"] == 3
+        assert kwargs["CP_INTERLEAVE_SIZE"] == 1
+        assert extra == (None, None)
+        dcp_manager.prepare_spec_decode_first_pass_inputs.assert_not_called()
+        dcp_manager.prepare_spec_decode_drafting_cp_metadata.assert_not_called()
+        metadata = cad.context_parallel_metadata
+        assert np.array_equal(
+            metadata.num_computed_tokens_of_dcp,
+            np.array([[16, 16, 16, 16, 16, 16, 16, 16]], dtype=np.int32),
+        )
+        assert torch.equal(
+            metadata.query_lens_cpu,
+            torch.tensor([5], dtype=torch.int32),
+        )
+        assert metadata.max_query_len == 5
+        assert metadata.dcp_mtp_attn_mask is None
+        assert num_query_total == 5
+
     def test_cad_rewritten_to_cross_attention_shape(self):
         num_reqs, block_size, max_num_tokens = 4, 5, 256
         proposer = self._make_proposer(max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size)

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -344,6 +344,7 @@ class _DSparkProposerTestBase:
         context=None,
         num_rejected=None,
         with_optional_attrs=False,
+        inherited_prefill_flags=None,
     ):
         """Drive ``set_inputs_first_pass`` with a configurable cad.
 
@@ -362,6 +363,8 @@ class _DSparkProposerTestBase:
         seq_lens_cpu = torch.full((num_reqs,), host_seq_len, dtype=torch.int32)
         cad = SimpleNamespace(
             num_reqs=num_reqs,
+            is_prefilling=inherited_prefill_flags,
+            context_parallel_metadata=None,
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=query_start_loc_cpu,
             seq_lens=torch.full((num_reqs,), seq_len, dtype=torch.int32),
@@ -384,6 +387,58 @@ class _DSparkProposerTestBase:
         return num_query_total, token_indices, cad, extra, next_token_ids, target_hidden_states
 
 
+class TestDSparkDraftQueryPhase(_DSparkProposerTestBase):
+    @pytest.mark.parametrize("dcp_size", [1, 8])
+    def test_only_dcp_overrides_target_prefill_flags(self, monkeypatch, dcp_size):
+        from vllm_ascend.attention.utils import split_decodes_and_prefills
+
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
+            MagicMock(),
+        )
+        monkeypatch.setattr(
+            "vllm_ascend.attention.utils.is_pd_decode_recompute_scheduler_enabled",
+            lambda: False,
+        )
+        proposer = self._make_proposer(max_num_tokens=64, num_reqs=2, block_size=5)
+        proposer.dcp_size = dcp_size
+        proposer.dcp_rank = 0
+        proposer.vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=384),
+        )
+
+        def check_dcp_metadata(*, common_attn_metadata, num_query_per_req):
+            assert common_attn_metadata.is_prefilling.tolist() == [False, False]
+            assert common_attn_metadata._seq_lens_cpu.tolist() == [133, 133]
+            common_attn_metadata.context_parallel_metadata = SimpleNamespace(
+                query_lens_cpu=torch.tensor([5, 5], dtype=torch.int32),
+                max_query_len=5,
+            )
+            return None, None
+
+        manager = SimpleNamespace(
+            prepare_dspark_first_pass_cp_metadata=MagicMock(side_effect=check_dcp_metadata),
+        )
+        proposer.runner = SimpleNamespace(dcp_manager=manager)
+        inherited = torch.tensor([False, True], dtype=torch.bool)
+        _, _, cad, _, _, hidden = self._invoke_set_inputs_first_pass(
+            proposer,
+            num_reqs=2,
+            block_size=5,
+            context=2,
+            inherited_prefill_flags=inherited,
+        )
+        assert cad.is_prefilling.tolist() == ([False, False] if dcp_size > 1 else [False, True])
+        assert proposer._dflash_num_context == 2
+        assert torch.equal(proposer._dflash_hidden_states[:2], hidden)
+        assert split_decodes_and_prefills(
+            cad,
+            decode_threshold=6,
+            treat_short_extends_as_decodes=False,
+        ) == ((2, 0, 10, 0) if dcp_size > 1 else (1, 1, 5, 5))
+        assert manager.prepare_dspark_first_pass_cp_metadata.call_count == (dcp_size > 1)
+
+
 class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
     """Guard: under multi-DP the dspark draft proposer must hand DSA attention a
     full-length positions buffer so ``positions[:num_input_tokens]`` never reads
@@ -394,6 +449,7 @@ class TestDSparkPositionsFullUnderMultiDp(_DSparkProposerTestBase):
         # query_start_loc_cpu[num_reqs] is 0 so _dflash_num_context becomes 0.
         cad = SimpleNamespace(
             num_reqs=num_reqs,
+            is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
             query_start_loc=torch.arange(num_reqs + 1, dtype=torch.int32) * block_size,
             query_start_loc_cpu=torch.zeros(num_reqs + 1, dtype=torch.int32),
             seq_lens=torch.full((num_reqs,), 128, dtype=torch.int32),
@@ -592,7 +648,7 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert proposer.draft_attn_groups[0].kv_cache_spec.block_size == 384
         assert kwargs["block_size"] == 128
 
-    def test_dcp_updates_slot_kernel_and_parallel_block_metadata(self, monkeypatch):
+    def test_dcp_passes_parallel_kernel_args_and_delegates_metadata(self, monkeypatch):
         kernel = MagicMock()
         monkeypatch.setattr(
             "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
@@ -607,6 +663,9 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         dcp_manager = SimpleNamespace(
             prepare_spec_decode_first_pass_inputs=MagicMock(),
             prepare_spec_decode_drafting_cp_metadata=MagicMock(),
+            prepare_dspark_first_pass_cp_metadata=MagicMock(
+                return_value=(None, None),
+            ),
         )
         proposer.runner = SimpleNamespace(
             dcp_manager=dcp_manager,
@@ -625,17 +684,10 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         assert extra == (None, None)
         dcp_manager.prepare_spec_decode_first_pass_inputs.assert_not_called()
         dcp_manager.prepare_spec_decode_drafting_cp_metadata.assert_not_called()
-        metadata = cad.context_parallel_metadata
-        assert np.array_equal(
-            metadata.num_computed_tokens_of_dcp,
-            np.array([[16, 16, 16, 16, 16, 16, 16, 16]], dtype=np.int32),
+        dcp_manager.prepare_dspark_first_pass_cp_metadata.assert_called_once_with(
+            common_attn_metadata=cad,
+            num_query_per_req=5,
         )
-        assert torch.equal(
-            metadata.query_lens_cpu,
-            torch.tensor([5], dtype=torch.int32),
-        )
-        assert metadata.max_query_len == 5
-        assert metadata.dcp_mtp_attn_mask is None
         assert num_query_total == 5
 
     def test_cad_rewritten_to_cross_attention_shape(self):
@@ -696,27 +748,47 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
     """The ``has_num_rejected`` branch must shrink ``seq_lens`` by the rejected
     token count before adding the draft block size, and flag the kernel."""
 
-    def test_seq_lens_subtracts_rejected(self, monkeypatch):
+    @pytest.mark.parametrize("dcp_size", [1, 8])
+    @pytest.mark.parametrize("async_metadata", [False, True])
+    def test_seq_lens_subtracts_rejected(self, monkeypatch, dcp_size, async_metadata):
         monkeypatch.setattr(
             "vllm_ascend.spec_decode.dspark_proposer.copy_and_expand_dflash_and_dspark_inputs_kernel",
             MagicMock(),
         )
         num_reqs, block_size, max_num_tokens = 4, 5, 256
         proposer = self._make_proposer(max_num_tokens=max_num_tokens, num_reqs=num_reqs, block_size=block_size)
+        proposer.dcp_size = dcp_size
+        proposer.dcp_rank = 0
+        proposer.vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=384))
+        expected_host = torch.full((num_reqs,), 131, dtype=torch.int32)
+
+        def check_metadata(*, common_attn_metadata, num_query_per_req):
+            torch.testing.assert_close(common_attn_metadata._seq_lens_cpu, expected_host)
+            return None, None
+
+        proposer.runner = SimpleNamespace(
+            dcp_manager=SimpleNamespace(
+                prepare_dspark_first_pass_cp_metadata=check_metadata,
+            )
+        )
         rejected = torch.full((num_reqs,), 2, dtype=torch.int32)
         _nqt, _ti, cad, _extra = self._invoke_set_inputs_first_pass(
             proposer,
             num_reqs=num_reqs,
             block_size=block_size,
             host_seq_len=126,
-            async_metadata=True,
+            async_metadata=async_metadata,
             num_rejected=rejected,
         )[:4]
+        # CPU lengths already include rejection correction; do not subtract twice.
         # effective = seq_lens(128) - rejected(2) = 126; then + block_size(5) = 131.
         assert torch.equal(cad.seq_lens, torch.full((num_reqs,), 128 - 2 + block_size, dtype=torch.int32))
         expected_host = torch.full((num_reqs,), 126 + block_size, dtype=torch.int32)
         assert torch.equal(cad._seq_lens_cpu, expected_host)
-        assert cad.seq_lens_cpu is None
+        if async_metadata:
+            assert cad.seq_lens_cpu is None
+        else:
+            torch.testing.assert_close(cad.seq_lens_cpu, expected_host)
 
     def test_kernel_called_with_has_num_rejected(self, monkeypatch):
         kernel = MagicMock()

--- a/tests/ut/worker/test_dcp_manager.py
+++ b/tests/ut/worker/test_dcp_manager.py
@@ -39,6 +39,18 @@ def _make_dcp_manager(
     return manager
 
 
+def _enable_batch_info_tracking(
+    manager: DCPManager,
+    max_num_reqs: int = 4,
+) -> None:
+    manager.decode_threshold = 8
+    manager.pd_decode_recompute_scheduler_enabled = False
+    manager.query_lens_full = SimpleNamespace(
+        cpu=torch.full((max_num_reqs,), -1, dtype=torch.int32),
+        copy_to_gpu=MagicMock(),
+    )
+
+
 @pytest.mark.parametrize(
     "dcp_world_size, interleave_size, expected",
     [
@@ -95,6 +107,126 @@ def test_get_dcp_local_seq_lens_interleaves_kv_across_ranks(
     actual = manager._get_dcp_local_seq_lens(seq_lens)
 
     assert torch.equal(actual, torch.tensor(expected))
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_seq_len", "expected_num_computed_tokens"),
+    [
+        (4, 5, [1, 3]),
+        (16, 16, [12, 14]),
+    ],
+)
+def test_prepare_uniform_decode_dummy_run_metadata(
+    seq_len: int,
+    expected_seq_len: int,
+    expected_num_computed_tokens: list[int],
+) -> None:
+    manager = _make_dcp_manager(
+        dcp_world_size=2,
+        dcp_rank=0,
+        interleave_size=1,
+    )
+    _enable_batch_info_tracking(manager)
+    num_scheduled_tokens = np.array([4, 2], dtype=np.int32)
+    stale_num_computed_tokens = np.array([0, 128], dtype=np.int32)
+    stale_num_prompt_tokens = np.array([64, 128], dtype=np.int32)
+
+    metadata = manager.prepare_dummy_run_metadata(
+        num_scheduled_tokens=num_scheduled_tokens,
+        num_reqs=2,
+        seq_len=seq_len,
+        num_computed_tokens=stale_num_computed_tokens,
+        num_prompt_tokens=stale_num_prompt_tokens,
+        uniform_decode=True,
+    )
+
+    assert metadata is not None
+    assert metadata.seq_len == expected_seq_len
+    np.testing.assert_array_equal(
+        metadata.seq_lens_cpu,
+        np.full(2, expected_seq_len, dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        metadata.num_computed_tokens_cpu,
+        np.array(expected_num_computed_tokens, dtype=np.int32),
+    )
+    np.testing.assert_array_equal(manager.decode_req_mask, [True, True])
+    assert manager.num_decode_reqs == 2
+    assert manager.num_prefill_reqs == 0
+    assert manager.num_decode_tokens == 6
+    assert torch.equal(
+        manager.query_lens_full.cpu,
+        torch.tensor([4, 2, 0, 0], dtype=torch.int32),
+    )
+    manager.query_lens_full.copy_to_gpu.assert_called_once_with()
+    np.testing.assert_array_equal(stale_num_computed_tokens, [0, 128])
+    np.testing.assert_array_equal(stale_num_prompt_tokens, [64, 128])
+
+
+def test_prepare_non_uniform_dummy_run_metadata_uses_input_batch_state() -> None:
+    manager = _make_dcp_manager(
+        dcp_world_size=2,
+        dcp_rank=0,
+        interleave_size=1,
+    )
+    _enable_batch_info_tracking(manager)
+    num_scheduled_tokens = np.array([2, 16], dtype=np.int32)
+    num_computed_tokens = np.array([64, 32], dtype=np.int32)
+    num_prompt_tokens = np.array([64, 48], dtype=np.int32)
+
+    metadata = manager.prepare_dummy_run_metadata(
+        num_scheduled_tokens=num_scheduled_tokens,
+        num_reqs=2,
+        seq_len=16,
+        num_computed_tokens=num_computed_tokens,
+        num_prompt_tokens=num_prompt_tokens,
+        uniform_decode=False,
+    )
+
+    assert metadata is None
+    np.testing.assert_array_equal(manager.decode_req_mask, [True, False])
+    assert manager.num_decode_reqs == 1
+    assert manager.num_prefill_reqs == 1
+    assert manager.num_decode_tokens == 2
+    assert torch.equal(
+        manager.query_lens_full.cpu,
+        torch.tensor([2, 16, 0, 0], dtype=torch.int32),
+    )
+    manager.query_lens_full.copy_to_gpu.assert_called_once_with()
+
+
+@pytest.mark.parametrize("prefill_flags", [[False, False], [True, False]])
+def test_prepare_dspark_first_pass_cp_metadata_uses_full_query_kv_length(prefill_flags) -> None:
+    manager = _make_dcp_manager(
+        dcp_world_size=2,
+        dcp_rank=0,
+        interleave_size=1,
+    )
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=2,
+        _seq_lens_cpu=torch.tensor([133, 261], dtype=torch.int32),
+        seq_lens=torch.tensor([133, 261], dtype=torch.int32),
+        is_prefilling=torch.tensor(prefill_flags),
+        context_parallel_metadata=None,
+    )
+
+    long_seq_args = manager.prepare_dspark_first_pass_cp_metadata(
+        common_attn_metadata=common_attn_metadata,
+        num_query_per_req=5,
+    )
+
+    assert long_seq_args == (None, None)
+    metadata = common_attn_metadata.context_parallel_metadata
+    np.testing.assert_array_equal(
+        metadata.num_computed_tokens_of_dcp,
+        np.array([[67, 66], [131, 130]], dtype=np.int32),
+    )
+    assert torch.equal(
+        metadata.query_lens_cpu,
+        torch.tensor([5, 5], dtype=torch.int32),
+    )
+    assert metadata.max_query_len == 5
+    assert metadata.dcp_mtp_attn_mask is None
 
 
 @pytest.mark.parametrize("dcp_rank", [0, 1])

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -155,7 +155,13 @@ class AscendMlaDCPMetadataBuilder(
                 end=self.num_decodes,
             ).tolist()
         decode_metadata.actual_seq_lengths_q = torch.arange(self.num_decodes) + 1
-        decode_metadata.dcp_mtp_attn_mask = dcp_metadata.dcp_mtp_attn_mask
+        # DCP metadata is prepared before attention metadata splits a mixed
+        # batch into decode and prefill sub-batches. Keep the mask batch
+        # dimension aligned with the decode sub-batch, just like cp_seq_len.
+        dcp_mtp_attn_mask = dcp_metadata.dcp_mtp_attn_mask
+        decode_metadata.dcp_mtp_attn_mask = (
+            dcp_mtp_attn_mask[: self.num_decodes] if dcp_mtp_attn_mask is not None else None
+        )
         return decode_metadata
 
 
@@ -523,7 +529,19 @@ class AscendMlaDCPImpl(DCPImplMixin, AscendMLAImpl):
             src_token_idx += padded_local_chunk_seq_len
         reorganized_kv_c_normed = torch.cat(kv_c_segments, dim=0)
         reorganized_k_pe = torch.cat(k_pe_segments, dim=0)
-        assert reorganized_kv_c_normed.shape[0] == sum_seq_len
+        assert reorganized_kv_c_normed.shape[0] == sum_seq_len, (
+            "DCP MLA KV reorg length mismatch: "
+            f"actual={reorganized_kv_c_normed.shape[0]}, "
+            f"expected={sum_seq_len}, chunk_idx={chunk_idx}, "
+            f"toks={toks}, chunk_size={chunk_size}, "
+            f"padded_local_chunk_seq_lens="
+            f"{padded_local_chunk_seq_lens_lst}, "
+            f"local_context_lens_allranks="
+            f"{local_context_lens_allranks}, "
+            f"cu_seq_lens={chunked_context.cu_seq_lens_lst[chunk_idx]}, "
+            f"max_seq_len={max_seq_len}, "
+            f"max_seq_len_check={max_seq_len_check}"
+        )
         assert reorganized_k_pe.shape[0] == sum_seq_len
         assert max_seq_len_check == max_seq_len
         return reorganized_kv_c_normed, reorganized_k_pe

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -295,13 +295,12 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
             speculative_config = self.vllm_config.speculative_config
             method = getattr(speculative_config, "method", None)
             num_spec = getattr(speculative_config, "num_speculative_tokens", None)
-            if num_spec is not None:
-                # dflash counts the base token in addition to the N speculative
-                # tokens; dspark's threshold is just N by design.
-                if method == "dflash":
-                    self.reorder_batch_threshold = 1 + num_spec
-                elif method == "dspark":
-                    self.reorder_batch_threshold = num_spec
+            if num_spec is not None and method in ("dflash", "dspark"):
+                # The target-model verification query always contains the
+                # base token plus N speculative tokens. DSpark's
+                # sample_from_anchor only makes the draft-model forward use N
+                # queries; it must not change target batch reordering.
+                self.reorder_batch_threshold = 1 + num_spec
 
     def _copy_sequence_indices_to_device(
         self,

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -552,11 +552,15 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 # carries no draft tokens. Treat it as ordinary decode unless a
                 # stateful spec-width prompt chunk must use the spec branch.
                 spec_sequence_masks_cpu.zero_()
-            spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
-                m,
-                spec_sequence_masks_cpu,
-                num_accepted_tokens,
-            )
+            # DCP must retain prefill metadata for prompt chunks, even when
+            # their width matches speculative decode. Keep the legacy fold
+            # when decode context parallelism is disabled.
+            if self.vllm_config.parallel_config.decode_context_parallel_size == 1:
+                spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
+                    m,
+                    spec_sequence_masks_cpu,
+                    num_accepted_tokens,
+                )
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:
                 spec_sequence_masks = None

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -95,6 +95,9 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
     TILE_SIZE: tl.constexpr = 256,
+    DCP_SIZE: tl.constexpr = 1,
+    DCP_RANK: tl.constexpr = 0,
+    CP_INTERLEAVE_SIZE: tl.constexpr = 1,
 ):
     # Grid-stride kernel: launch grid is capped at the vector-core count by
     # the caller (grid = min(cdiv(total_work, TILE_SIZE), num_vectorcore)),
@@ -155,11 +158,26 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         # rather than from query_pos. For text-only inputs the two values are
         # identical, so this only changes behaviour for multimodal inputs.
         query_kv_slot_pos = effective_seq_len + q_idx
-        block_num_q = query_kv_slot_pos // block_size
+        if DCP_SIZE > 1:
+            # Match BlockTable._compute_dcp_slot_mapping: the paged cache on
+            # each DCP rank is compacted, so global token positions must first
+            # be mapped to an owner rank and then to that rank's local position.
+            virtual_block_size = CP_INTERLEAVE_SIZE * DCP_SIZE
+            virtual_block_offset = query_kv_slot_pos % virtual_block_size
+            owner_rank = virtual_block_offset // CP_INTERLEAVE_SIZE
+            local_kv_slot_pos = (
+                query_kv_slot_pos // virtual_block_size * CP_INTERLEAVE_SIZE
+                + virtual_block_offset % CP_INTERLEAVE_SIZE
+            )
+        else:
+            owner_rank = DCP_RANK
+            local_kv_slot_pos = query_kv_slot_pos
+        block_num_q = local_kv_slot_pos // block_size
         block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q, mask=mask, other=0).to(
             tl.int64
         )
-        slot_q = block_id_q * block_size + (query_kv_slot_pos % block_size)
+        slot_q = block_id_q * block_size + (local_kv_slot_pos % block_size)
+        slot_q = tl.where(owner_rank == DCP_RANK, slot_q, -1)
         tl.store(out_query_slot_mapping_ptr + offs, slot_q, mask=mask)
 
         bonus = tl.load(next_token_ids_ptr + req_idx, mask=mask, other=0)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -166,8 +166,7 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
             virtual_block_offset = query_kv_slot_pos % virtual_block_size
             owner_rank = virtual_block_offset // CP_INTERLEAVE_SIZE
             local_kv_slot_pos = (
-                query_kv_slot_pos // virtual_block_size * CP_INTERLEAVE_SIZE
-                + virtual_block_offset % CP_INTERLEAVE_SIZE
+                query_kv_slot_pos // virtual_block_size * CP_INTERLEAVE_SIZE + virtual_block_offset % CP_INTERLEAVE_SIZE
             )
         else:
             owner_rank = DCP_RANK

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -35,6 +35,9 @@ class AscendMambaManager(MambaManager):
         pcp_world_size: int = 1,
         drop_eagle_block: bool = False,
     ) -> tuple[list[KVCacheBlock], ...] | tuple[tuple[list[KVCacheBlock], ...], int]:
+        # Mamba recurrent states are replicated across DCP ranks (see
+        # __init__), so their prefix-cache lookup keeps the ordinary logical
+        # block layout. Only attention groups shard their KV cache for DCP.
         return super().find_longest_cache_hit(
             block_hashes=block_hashes,
             max_length=max_length,
@@ -42,7 +45,7 @@ class AscendMambaManager(MambaManager):
             block_pool=block_pool,
             kv_cache_spec=kv_cache_spec,
             alignment_tokens=alignment_tokens,
-            dcp_world_size=dcp_world_size,
+            dcp_world_size=1,
             pcp_world_size=pcp_world_size,
             drop_eagle_block=drop_eagle_block,
         )

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,12 +1,11 @@
+from contextlib import contextmanager
+from copy import copy
+
 from transformers import DeepseekV2Config, PretrainedConfig
 from vllm.config.speculative import SpeculativeConfig
 
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
-
-_UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT = (
-    "MLA DSpark does not currently support decode context parallelism"
-)
 
 
 # Transformers 5.14 inherited a hidden_size % num_heads check from Llama in
@@ -41,30 +40,28 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
     return hf_config
 
 
-def _is_ascend_k3_dspark_dcp(self: SpeculativeConfig) -> bool:
-    """Return whether this is the K3 DSpark+DCP case supported by Ascend."""
-    target_parallel_config = getattr(self, "target_parallel_config", None)
-    draft_model_config = getattr(self, "draft_model_config", None)
-    architectures = getattr(draft_model_config, "architectures", None) or ()
-    return (
-        getattr(self, "method", None) == "dspark"
-        and "K3DSparkModel" in architectures
-        and getattr(target_parallel_config, "decode_context_parallel_size", 1) > 1
-    )
+@contextmanager
+def _without_upstream_dspark_dcp_guard(self: SpeculativeConfig):
+    target_parallel_config = self.target_parallel_config
+    if (
+        getattr(self, "method", None) != "dspark"
+        or target_parallel_config.decode_context_parallel_size <= 1
+    ):
+        yield
+        return
+
+    guard_parallel_config = copy(target_parallel_config)
+    guard_parallel_config.decode_context_parallel_size = 1
+    self.target_parallel_config = guard_parallel_config
+    try:
+        yield
+    finally:
+        self.target_parallel_config = target_parallel_config
 
 
 def _dspark_post_init(self):
-    try:
+    with _without_upstream_dspark_dcp_guard(self):
         _orig_post_init(self)
-    except ValueError as error:
-        # Upstream rejects K3 MLA DSpark+DCP for GPU backends. Ascend has its
-        # own DCP metadata and MLA implementation, so bypass only the matching
-        # upstream guard. Keep all other SpeculativeConfig validation intact.
-        if (
-            _UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT not in str(error)
-            or not _is_ascend_k3_dspark_dcp(self)
-        ):
-            raise
     if self.use_dspark():
         draft_model_config = getattr(self, "draft_model_config", None)
         draft_hf_config = getattr(draft_model_config, "hf_config", None)

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -4,6 +4,10 @@ from vllm.config.speculative import SpeculativeConfig
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
 
+_UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT = (
+    "MLA DSpark does not currently support decode context parallelism"
+)
+
 
 # Transformers 5.14 inherited a hidden_size % num_heads check from Llama in
 # DeepseekV2Config. K3 MLA has independent projection/head dimensions (e.g.
@@ -37,8 +41,30 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
     return hf_config
 
 
+def _is_ascend_k3_dspark_dcp(self: SpeculativeConfig) -> bool:
+    """Return whether this is the K3 DSpark+DCP case supported by Ascend."""
+    target_parallel_config = getattr(self, "target_parallel_config", None)
+    draft_model_config = getattr(self, "draft_model_config", None)
+    architectures = getattr(draft_model_config, "architectures", None) or ()
+    return (
+        getattr(self, "method", None) == "dspark"
+        and "K3DSparkModel" in architectures
+        and getattr(target_parallel_config, "decode_context_parallel_size", 1) > 1
+    )
+
+
 def _dspark_post_init(self):
-    _orig_post_init(self)
+    try:
+        _orig_post_init(self)
+    except ValueError as error:
+        # Upstream rejects K3 MLA DSpark+DCP for GPU backends. Ascend has its
+        # own DCP metadata and MLA implementation, so bypass only the matching
+        # upstream guard. Keep all other SpeculativeConfig validation intact.
+        if (
+            _UPSTREAM_K3_DSPARK_DCP_ERROR_FRAGMENT not in str(error)
+            or not _is_ascend_k3_dspark_dcp(self)
+        ):
+            raise
     if self.use_dspark():
         draft_model_config = getattr(self, "draft_model_config", None)
         draft_hf_config = getattr(draft_model_config, "hf_config", None)

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -7,7 +7,6 @@ from vllm.config.speculative import SpeculativeConfig
 _orig_post_init = SpeculativeConfig.__post_init__
 _orig_hf_config_override = SpeculativeConfig.hf_config_override
 
-
 # Transformers 5.14 inherited a hidden_size % num_heads check from Llama in
 # DeepseekV2Config. K3 MLA has independent projection/head dimensions (e.g.
 # hidden_size=7168, num_heads=96), so that MHA constraint does not apply.
@@ -41,12 +40,9 @@ def _normalize_legacy_qwen3_dspark_config(hf_config: PretrainedConfig) -> Pretra
 
 
 @contextmanager
-def _without_upstream_dspark_dcp_guard(self: SpeculativeConfig):
+def _temporarily_disable_dspark_dcp(self: SpeculativeConfig):
     target_parallel_config = self.target_parallel_config
-    if (
-        getattr(self, "method", None) != "dspark"
-        or target_parallel_config.decode_context_parallel_size <= 1
-    ):
+    if getattr(self, "method", None) != "dspark" or target_parallel_config.decode_context_parallel_size <= 1:
         yield
         return
 
@@ -60,7 +56,8 @@ def _without_upstream_dspark_dcp_guard(self: SpeculativeConfig):
 
 
 def _dspark_post_init(self):
-    with _without_upstream_dspark_dcp_guard(self):
+    # TODO: This block can be deleted after the upstream supports the overlay of mla dcp and dspark
+    with _temporarily_disable_dspark_dcp(self):
         _orig_post_init(self)
     if self.use_dspark():
         draft_model_config = getattr(self, "draft_model_config", None)

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -13,8 +13,9 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
-from vllm_ascend.attention.utils import enable_pcp
+from vllm_ascend.attention.utils import AscendDCPMetadata, enable_pcp
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
@@ -240,6 +241,10 @@ class AscendDSparkProposer(AscendDflashProposer):
         num_query_total = batch_size * self.num_query_per_req
         num_sample_total = batch_size * self.num_speculative_tokens
         has_num_rejected = num_rejected_tokens_gpu is not None
+        dcp_size = getattr(self, "dcp_size", 1)
+        dcp_rank = getattr(self, "dcp_rank", 0)
+        cp_interleave_size = self.vllm_config.parallel_config.cp_kv_cache_interleave_size if dcp_size > 1 else 1
+        long_seq_args = None
         primary_gid = getattr(self, "kv_cache_gid", 0)
         self._per_group_block_table_buffers = {
             attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
@@ -292,6 +297,9 @@ class AscendDSparkProposer(AscendDflashProposer):
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                DCP_SIZE=dcp_size,
+                DCP_RANK=dcp_rank,
+                CP_INTERLEAVE_SIZE=cp_interleave_size,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
@@ -336,7 +344,28 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
-        return num_query_total, token_indices_to_sample, cad, None
+        if dcp_size > 1:
+            seq_lens_cpu = getattr(cad, "_seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                seq_lens_cpu = cad.seq_lens.cpu()
+            local_seq_lens = get_dcp_local_seq_lens(
+                seq_lens_cpu - self.num_query_per_req,
+                dcp_size,
+                cp_interleave_size,
+            )
+            cad.context_parallel_metadata = AscendDCPMetadata(
+                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                query_lens_cpu=torch.full(
+                    (batch_size,),
+                    self.num_query_per_req,
+                    dtype=torch.int32,
+                ),
+                max_query_len=self.num_query_per_req,
+                dcp_mtp_attn_mask=None,
+            )
+            long_seq_args = (None, None)
+
+        return num_query_total, token_indices_to_sample, cad, long_seq_args
 
     @torch.inference_mode()
     def dummy_run(

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -13,9 +13,8 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
-from vllm_ascend.attention.utils import AscendDCPMetadata, enable_pcp
+from vllm_ascend.attention.utils import enable_pcp
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
@@ -345,25 +344,15 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
         if dcp_size > 1:
-            seq_lens_cpu = getattr(cad, "_seq_lens_cpu", None)
-            if seq_lens_cpu is None:
-                seq_lens_cpu = cad.seq_lens.cpu()
-            local_seq_lens = get_dcp_local_seq_lens(
-                seq_lens_cpu - self.num_query_per_req,
-                dcp_size,
-                cp_interleave_size,
+            if cad.is_prefilling is not None:
+                cad.is_prefilling.fill_(False)
+            assert self.runner is not None
+            dcp_manager = getattr(self.runner, "dcp_manager", None)
+            assert dcp_manager is not None
+            long_seq_args = dcp_manager.prepare_dspark_first_pass_cp_metadata(
+                common_attn_metadata=cad,
+                num_query_per_req=self.num_query_per_req,
             )
-            cad.context_parallel_metadata = AscendDCPMetadata(
-                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
-                query_lens_cpu=torch.full(
-                    (batch_size,),
-                    self.num_query_per_req,
-                    dtype=torch.int32,
-                ),
-                max_query_len=self.num_query_per_req,
-                dcp_mtp_attn_mask=None,
-            )
-            long_seq_args = (None, None)
 
         return num_query_total, token_indices_to_sample, cad, long_seq_args
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -179,6 +179,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_sequence_parallel_moe = enable_sp(vllm_config)
 
         self.dcp_size = self.runner.dcp_size
+        self.dcp_rank = self.runner.dcp_rank
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
 
@@ -888,7 +889,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
         assert self.runner is not None
         dcp_manager = getattr(self.runner, "dcp_manager", None)
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
 
@@ -1057,7 +1058,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             "slot_indices": None,
             "mtp_slot_mapping": None,
         }
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             dcp_mtp_inputs = dcp_manager.prepare_spec_decode_mtp_drafting_inputs(
                 common_attn_metadata=common_attn_metadata,
                 attn_metadata=attn_metadata_i,

--- a/vllm_ascend/worker/dcp_utils.py
+++ b/vllm_ascend/worker/dcp_utils.py
@@ -58,6 +58,15 @@ class DCPSpecDecodeFirstPassInputs:
 
 
 @dataclass(frozen=True)
+class DCPDummyRunMetadata:
+    """Synthetic decode state shared by DCP dummy metadata builders."""
+
+    seq_len: int
+    seq_lens_cpu: np.ndarray
+    num_computed_tokens_cpu: np.ndarray
+
+
+@dataclass(frozen=True)
 class DCPAsyncSpecDecodeRebuildResult:
     """Status returned after rebuilding async speculative inputs."""
 
@@ -163,6 +172,43 @@ class DCPManager:
         self.query_lens_full.cpu[:num_reqs] = torch.from_numpy(scheduled)
         self.query_lens_full.cpu[num_reqs:].fill_(0)
         self.query_lens_full.copy_to_gpu()
+
+    def prepare_dummy_run_metadata(
+        self,
+        num_scheduled_tokens: np.ndarray,
+        num_reqs: int,
+        seq_len: int,
+        num_computed_tokens: np.ndarray,
+        num_prompt_tokens: np.ndarray,
+        uniform_decode: bool,
+    ) -> DCPDummyRunMetadata | None:
+        """Initialize DCP state for a model-runner dummy execution.
+
+        Uniform-decode dummy runs do not have scheduler-owned requests, so
+        their request state must be synthesized instead of inherited from the
+        previous real batch. Non-uniform runs keep using the input-batch state.
+        """
+        dummy_metadata = None
+        if uniform_decode:
+            max_query_len = int(num_scheduled_tokens[:num_reqs].max())
+            if seq_len <= max_query_len:
+                seq_len = max_query_len + 1
+            dummy_num_computed_tokens = (seq_len - num_scheduled_tokens[:num_reqs]).astype(np.int32, copy=False)
+            dummy_metadata = DCPDummyRunMetadata(
+                seq_len=seq_len,
+                seq_lens_cpu=(dummy_num_computed_tokens + num_scheduled_tokens[:num_reqs]),
+                num_computed_tokens_cpu=dummy_num_computed_tokens,
+            )
+            num_computed_tokens = dummy_num_computed_tokens
+            num_prompt_tokens = dummy_num_computed_tokens
+
+        self.init_batch_info(
+            num_scheduled_tokens,
+            num_reqs,
+            num_computed_tokens,
+            num_prompt_tokens,
+        )
+        return dummy_metadata
 
     def prepare_spec_decode_first_pass_inputs(
         self,
@@ -467,6 +513,37 @@ class DCPManager:
             self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
         )
 
+    def prepare_dspark_first_pass_cp_metadata(
+        self,
+        common_attn_metadata: Any,
+        num_query_per_req: int,
+    ) -> tuple[None, None]:
+        """Build DCP metadata for DSpark's parallel draft query block.
+
+        DSpark has already extended ``seq_lens`` by the complete draft query
+        width at this point. Its proposer marks every draft query as decode:
+        context KV is stored separately, and attention reads the query block
+        back from the paged cache. Retain the complete sequence length even
+        when the originating target batch contains prefill requests.
+        """
+        from vllm_ascend.attention.utils import AscendDCPMetadata
+
+        seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
+        if seq_lens_cpu is None:
+            seq_lens_cpu = common_attn_metadata.seq_lens.cpu()
+        local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_cpu)
+        common_attn_metadata.context_parallel_metadata = AscendDCPMetadata(
+            num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+            query_lens_cpu=torch.full(
+                (common_attn_metadata.num_reqs,),
+                num_query_per_req,
+                dtype=torch.int32,
+            ),
+            max_query_len=num_query_per_req,
+            dcp_mtp_attn_mask=None,
+        )
+        return None, None
+
     @staticmethod
     def _is_mla_kv_cache_spec(kv_cache_spec: Any) -> bool:
         from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
@@ -686,11 +763,8 @@ class DCPManager:
             interleave_size,
         )[..., self.dcp_world_rank]
         upper = local_q - 1
-        full_mask = (
-            (k_indices[None, None, :] > upper[:, :, None])
-            & (upper[:, :, None] >= 0)
-            & valid_q[:, :, None]
-            & valid_k[:, None, :]
-        )
+        # Before this rank's first key, upper is -1 and every local key is
+        # in the query's future, even if later queries have local context.
+        full_mask = (k_indices[None, None, :] > upper[:, :, None]) & valid_q[:, :, None] & valid_k[:, None, :]
         output[:num_decode_reqs, :max_q, :max_k] = full_mask
         return output

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -191,7 +191,11 @@ from vllm_ascend.utils import (
     weak_ref_tensor,
     weak_ref_tensors,
 )
-from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
+from vllm_ascend.worker.dcp_utils import (
+    DCPAsyncSpecDecodeRebuildResult,
+    DCPDummyRunMetadata,
+    DCPManager,
+)
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
     DeviceMetadataTask,
@@ -3023,9 +3027,12 @@ class NPUModelRunner(GPUModelRunner):
         num_encoder_reqs: int = 0,
     ) -> tuple[CUDAGraphMode, BatchDescriptor, bool, torch.Tensor | None, CUDAGraphStat | None]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
-        # A stateful P/D handoff can use a uniform decode graph even at
-        # prompt_len - 1 computed tokens. Keep first-token prefills out.
         has_initial_state = np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] > 0)
+        if self.use_dcp:
+            # DCP decode graphs require the full prompt to be computed.
+            has_initial_state = has_initial_state and np.all(
+                self.input_batch.num_computed_tokens_cpu[:num_reqs] >= self.input_batch.num_prompt_tokens[:num_reqs]
+            )
         uniform_decode = (
             (
                 has_initial_state
@@ -3120,7 +3127,7 @@ class NPUModelRunner(GPUModelRunner):
         for_cudagraph_capture: bool = False,
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
-        dcp_dummy_num_computed_tokens_cpu: np.ndarray | None = None,
+        dcp_dummy_metadata: DCPDummyRunMetadata | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
         cudagraph_runtime_mode: CUDAGraphMode | None = None,
@@ -3168,12 +3175,8 @@ class NPUModelRunner(GPUModelRunner):
                 return None, block_table_tensor
 
             fixed_decode_seq_lens_cpu = None
-            if dcp_dummy_num_computed_tokens_cpu is not None:
-                assert num_scheduled_tokens_np is not None
-                fixed_decode_seq_lens_cpu = (
-                    dcp_dummy_num_computed_tokens_cpu[:num_reqs]
-                    + num_scheduled_tokens_np[:num_reqs]
-                )
+            if dcp_dummy_metadata is not None:
+                fixed_decode_seq_lens_cpu = dcp_dummy_metadata.seq_lens_cpu
             elif self.use_async_spec_decode:
                 fixed_decode_seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs].numpy()
 
@@ -3226,7 +3229,7 @@ class NPUModelRunner(GPUModelRunner):
 
         block_table_gid_0, slot_mapping_gid_0 = _get_block_table_and_slot_mapping(0)
         self.long_seq_metadata, block_table_gid_0 = _get_dcp_metadata(block_table_gid_0)
-        if dcp_dummy_num_computed_tokens_cpu is not None:
+        if dcp_dummy_metadata is not None:
             # A DCP dummy decode must not inherit request state from the
             # previous real batch. Keep this local to metadata construction so
             # the persistent input batch is not modified.
@@ -3235,7 +3238,7 @@ class NPUModelRunner(GPUModelRunner):
             ].clone()
             num_computed_tokens_cpu.zero_()
             num_computed_tokens_cpu[:num_reqs].copy_(
-                torch.from_numpy(dcp_dummy_num_computed_tokens_cpu[:num_reqs])
+                torch.from_numpy(dcp_dummy_metadata.num_computed_tokens_cpu)
             )
             is_prefilling = torch.zeros_like(num_computed_tokens_cpu, dtype=torch.bool)
         else:
@@ -3590,7 +3593,7 @@ class NPUModelRunner(GPUModelRunner):
             force_has_lora=num_active_loras > 0,
             force_num_active_loras=num_active_loras,
         )
-        dcp_dummy_num_computed_tokens_cpu = None
+        dcp_dummy_metadata = None
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode
         else:
@@ -3645,30 +3648,20 @@ class NPUModelRunner(GPUModelRunner):
                     )  # type: ignore[assignment]
 
                 if self.use_dcp:
-                    dcp_num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu
-                    dcp_num_prompt_tokens_cpu = self.input_batch.num_prompt_tokens
-                    if uniform_decode:
-                        # Dummy execution has no scheduler-owned requests. Give
-                        # every synthetic request a non-empty context so DCP,
-                        # common attention metadata and MLA all classify it as
-                        # decode. Derive the context from the same post-query
-                        # seq_len used below to keep all metadata consistent.
-                        dummy_seq_len = int(seq_lens)
-                        max_dummy_query_len = int(num_scheduled_tokens[:num_reqs].max())
-                        if dummy_seq_len <= max_dummy_query_len:
-                            dummy_seq_len = max_dummy_query_len + 1
-                            seq_lens = dummy_seq_len
-                        dcp_dummy_num_computed_tokens_cpu = (
-                            dummy_seq_len - num_scheduled_tokens[:num_reqs]
-                        ).astype(np.int32, copy=False)
-                        dcp_num_computed_tokens_cpu = dcp_dummy_num_computed_tokens_cpu
-                        dcp_num_prompt_tokens_cpu = dcp_dummy_num_computed_tokens_cpu
-                    self.dcp_manager.init_batch_info(
-                        num_scheduled_tokens,
-                        num_reqs,
-                        dcp_num_computed_tokens_cpu,
-                        dcp_num_prompt_tokens_cpu,
+                    dcp_dummy_metadata = (
+                        self.dcp_manager.prepare_dummy_run_metadata(
+                            num_scheduled_tokens=num_scheduled_tokens,
+                            num_reqs=num_reqs,
+                            seq_len=int(seq_lens),
+                            num_computed_tokens=(
+                                self.input_batch.num_computed_tokens_cpu
+                            ),
+                            num_prompt_tokens=self.input_batch.num_prompt_tokens,
+                            uniform_decode=uniform_decode,
+                        )
                     )
+                    if dcp_dummy_metadata is not None:
+                        seq_lens = dcp_dummy_metadata.seq_len
 
                 self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
                 self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
@@ -3723,7 +3716,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
-                    dcp_dummy_num_computed_tokens_cpu=dcp_dummy_num_computed_tokens_cpu,
+                    dcp_dummy_metadata=dcp_dummy_metadata,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
                     skip_gdn_state_update=skip_gdn_state_update,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3120,6 +3120,7 @@ class NPUModelRunner(GPUModelRunner):
         for_cudagraph_capture: bool = False,
         num_scheduled_tokens: dict[str, int] | None = None,
         num_scheduled_tokens_np: np.ndarray | None = None,
+        dcp_dummy_num_computed_tokens_cpu: np.ndarray | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         skip_gdn_state_update: bool = False,
         cudagraph_runtime_mode: CUDAGraphMode | None = None,
@@ -3167,7 +3168,13 @@ class NPUModelRunner(GPUModelRunner):
                 return None, block_table_tensor
 
             fixed_decode_seq_lens_cpu = None
-            if self.use_async_spec_decode:
+            if dcp_dummy_num_computed_tokens_cpu is not None:
+                assert num_scheduled_tokens_np is not None
+                fixed_decode_seq_lens_cpu = (
+                    dcp_dummy_num_computed_tokens_cpu[:num_reqs]
+                    + num_scheduled_tokens_np[:num_reqs]
+                )
+            elif self.use_async_spec_decode:
                 fixed_decode_seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs].numpy()
 
             assert num_reqs_padded is not None
@@ -3219,14 +3226,27 @@ class NPUModelRunner(GPUModelRunner):
 
         block_table_gid_0, slot_mapping_gid_0 = _get_block_table_and_slot_mapping(0)
         self.long_seq_metadata, block_table_gid_0 = _get_dcp_metadata(block_table_gid_0)
-        num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu_tensor[
-            :num_reqs_padded
-        ]
-        num_prompt_tokens_cpu = self.input_batch.num_prompt_tokens_cpu_tensor[
-            :num_reqs_padded
-        ]
-        is_prefilling = num_computed_tokens_cpu < num_prompt_tokens_cpu
-        is_prefilling[num_reqs:] = False
+        if dcp_dummy_num_computed_tokens_cpu is not None:
+            # A DCP dummy decode must not inherit request state from the
+            # previous real batch. Keep this local to metadata construction so
+            # the persistent input batch is not modified.
+            num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu_tensor[
+                :num_reqs_padded
+            ].clone()
+            num_computed_tokens_cpu.zero_()
+            num_computed_tokens_cpu[:num_reqs].copy_(
+                torch.from_numpy(dcp_dummy_num_computed_tokens_cpu[:num_reqs])
+            )
+            is_prefilling = torch.zeros_like(num_computed_tokens_cpu, dtype=torch.bool)
+        else:
+            num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu_tensor[
+                :num_reqs_padded
+            ]
+            num_prompt_tokens_cpu = self.input_batch.num_prompt_tokens_cpu_tensor[
+                :num_reqs_padded
+            ]
+            is_prefilling = num_computed_tokens_cpu < num_prompt_tokens_cpu
+            is_prefilling[num_reqs:] = False
         seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs_padded]
         if self.use_async_spec_decode:
             # GPU tensors are authoritative in async mode.
@@ -3570,16 +3590,7 @@ class NPUModelRunner(GPUModelRunner):
             force_has_lora=num_active_loras > 0,
             force_num_active_loras=num_active_loras,
         )
-        if self.use_dcp:
-            self.dcp_manager.init_batch_info(
-                num_scheduled_tokens,
-                num_reqs,
-                self.input_batch.num_computed_tokens_cpu,
-                self.input_batch.num_prompt_tokens,
-            )
-            if self.speculative_config:
-                self.dcp_manager.query_lens_full.cpu[:num_reqs] = torch.from_numpy(num_scheduled_tokens)
-                self.dcp_manager.query_lens_full.copy_to_gpu()
+        dcp_dummy_num_computed_tokens_cpu = None
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode
         else:
@@ -3632,6 +3643,32 @@ class NPUModelRunner(GPUModelRunner):
                         if is_graph_capturing and using_paged_attention(num_tokens, self.vllm_config)
                         else max_query_len
                     )  # type: ignore[assignment]
+
+                if self.use_dcp:
+                    dcp_num_computed_tokens_cpu = self.input_batch.num_computed_tokens_cpu
+                    dcp_num_prompt_tokens_cpu = self.input_batch.num_prompt_tokens
+                    if uniform_decode:
+                        # Dummy execution has no scheduler-owned requests. Give
+                        # every synthetic request a non-empty context so DCP,
+                        # common attention metadata and MLA all classify it as
+                        # decode. Derive the context from the same post-query
+                        # seq_len used below to keep all metadata consistent.
+                        dummy_seq_len = int(seq_lens)
+                        max_dummy_query_len = int(num_scheduled_tokens[:num_reqs].max())
+                        if dummy_seq_len <= max_dummy_query_len:
+                            dummy_seq_len = max_dummy_query_len + 1
+                            seq_lens = dummy_seq_len
+                        dcp_dummy_num_computed_tokens_cpu = (
+                            dummy_seq_len - num_scheduled_tokens[:num_reqs]
+                        ).astype(np.int32, copy=False)
+                        dcp_num_computed_tokens_cpu = dcp_dummy_num_computed_tokens_cpu
+                        dcp_num_prompt_tokens_cpu = dcp_dummy_num_computed_tokens_cpu
+                    self.dcp_manager.init_batch_info(
+                        num_scheduled_tokens,
+                        num_reqs,
+                        dcp_num_computed_tokens_cpu,
+                        dcp_num_prompt_tokens_cpu,
+                    )
 
                 self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
                 self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
@@ -3686,6 +3723,7 @@ class NPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
                     for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
+                    dcp_dummy_num_computed_tokens_cpu=dcp_dummy_num_computed_tokens_cpu,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
                     skip_gdn_state_update=skip_gdn_state_update,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3684,7 +3684,13 @@ class NPUModelRunner(GPUModelRunner):
                     num_reqs_padded=num_reqs_padded,
                     max_query_len=max_query_len,
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
-                    for_cudagraph_capture=is_graph_capturing,
+                    # FULL replay reuses capture-time graph metadata buffers.
+                    # Rebuild them for dummy execution instead of deriving
+                    # request state from the previous real DP batch.
+                    for_cudagraph_capture=(
+                        is_graph_capturing
+                        or cudagraph_runtime_mode == CUDAGraphMode.FULL
+                    ),
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3684,13 +3684,7 @@ class NPUModelRunner(GPUModelRunner):
                     num_reqs_padded=num_reqs_padded,
                     max_query_len=max_query_len,
                     ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,
-                    # FULL replay reuses capture-time graph metadata buffers.
-                    # Rebuild them for dummy execution instead of deriving
-                    # request state from the previous real DP batch.
-                    for_cudagraph_capture=(
-                        is_graph_capturing
-                        or cudagraph_runtime_mode == CUDAGraphMode.FULL
-                    ),
+                    for_cudagraph_capture=is_graph_capturing,
                     num_scheduled_tokens_np=num_scheduled_tokens,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds support for running Kimi K3 DSpark with Decode Context Parallelism (DCP) on Ascend.

The main changes include:

- Add DCP-aware DSpark query slot mapping:
  - Map global KV positions to the owning DCP rank and compact local KV positions.
  - Mark query slots as `-1` on non-owner ranks.
  - Support configurable DCP size, rank, and KV-cache interleave size.

- Add dedicated DCP metadata preparation for DSpark's parallel first-pass query block:
  - Build local sequence lengths from the complete draft query width.
  - Treat the DSpark draft query as decode metadata.
  - Skip the autoregressive MTP DCP path for parallel drafting.

- Align MLA and GDN metadata:
  - Slice the DCP MTP attention mask to the decode sub-batch.
  - Fix the DCP MTP causal mask before a rank's first local key.
  - Use `1 + num_speculative_tokens` as the target verification reorder threshold.
  - Preserve prefill classification for spec-width prompt chunks under DCP.

- Fix DCP dummy/FULL-graph metadata:
  - Synthesize isolated sequence and computed-token state for uniform-decode dummy runs.
  - Avoid inheriting metadata from the previous real batch.
  - Require the full prompt to be computed before selecting a DCP uniform-decode graph.

- Keep Mamba prefix-cache lookup on replicated state by excluding it from DCP KV sharding.

pick-from: https://github.com/vllm-project/vllm-ascend/pull/15855

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
