### PR TITLE
[Device][Feature] Support Ascend SoC version 256

### DIFF
--- a/tests/ut/device/test_device_config.py
+++ b/tests/ut/device/test_device_config.py
@@ -27,6 +27,7 @@ def clear_device_config_cache():
     [
         ("ascend910b1", AscendDeviceType.A2),
         ("ASCEND910_9391", AscendDeviceType.A3),
+        ("ASCEND910_9363", AscendDeviceType.A3),
         ("ascend310p3vir08", AscendDeviceType._310P),
         ("ascend950_9599", AscendDeviceType.A5),
     ],
@@ -40,6 +41,7 @@ def test_device_type_from_soc_version(soc_version, expected):
     [
         (220, AscendDeviceType.A2),
         (255, AscendDeviceType.A3),
+        (256, AscendDeviceType.A3),
         (203, AscendDeviceType._310P),
         (260, AscendDeviceType.A5),
     ],
@@ -97,6 +99,7 @@ def test_unknown_build_soc_version_is_rejected(soc_version):
         device_type_from_soc_version(soc_version)
 
 
-def test_unknown_runtime_soc_version_is_rejected():
+@pytest.mark.parametrize("soc_version", [257, 999])
+def test_unknown_runtime_soc_version_is_rejected(soc_version):
     with pytest.raises(RuntimeError, match="Cannot support runtime soc_version"):
-        device_type_from_runtime_soc(999)
+        device_type_from_runtime_soc(soc_version)

--- a/vllm_ascend/device/hardware.py
+++ b/vllm_ascend/device/hardware.py
@@ -38,6 +38,7 @@ _SOC_VERSION_TO_DEVICE_TYPE = {
     "ascend910_9392": AscendDeviceType.A3,
     "ascend910_9382": AscendDeviceType.A3,
     "ascend910_9362": AscendDeviceType.A3,
+    "ascend910_9363": AscendDeviceType.A3,
     "ascend310p1": AscendDeviceType._310P,
     "ascend310p3": AscendDeviceType._310P,
     "ascend310p5": AscendDeviceType._310P,
@@ -66,7 +67,7 @@ def device_type_from_runtime_soc(soc_version: int) -> AscendDeviceType:
 
     if 220 <= soc_version <= 225:
         return AscendDeviceType.A2
-    if 250 <= soc_version <= 255:
+    if 250 <= soc_version <= 256:
         return AscendDeviceType.A3
     if 200 <= soc_version <= 205:
         return AscendDeviceType._310P


### PR DESCRIPTION
### What this PR does / why we need it?

Extends A3 support for the new device identifiers reported by the Ascend910 9363 SoC:

- Expands the runtime SoC ID range from `250-255` to `250-256`, so runtime ID `256` is recognized as `AscendDeviceType.A3`.
- Maps the build-time `SOC_VERSION` value `ascend910_9363` to `AscendDeviceType.A3`.

Adds regression coverage for the build-time mapping and the runtime upper boundary, including that runtime SoC `257` remains unsupported.

Fixes #15569

### Does this PR introduce _any_ user-facing change?

Yes. A3 devices with NPU name `9363` and runtime SoC ID `256` are now recognized during both package build and runtime validation.

### How was this patch tested?

- Ruff lint passed for the changed files.
- Ruff format check passed for the changed files.
- Python syntax checks and direct boundary checks passed (`255`/`256` resolve to A3; `257` raises `RuntimeError`).
- Added parameterized unit coverage for `ASCEND910_9363` and runtime SoC IDs `256`/`257`.
- The repository's pytest suite was not run in this Windows environment because its test setup requires `torch` and `vllm`; CI should run the added parameterized unit coverage.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
