### PR TITLE
[Feature] Support DeepSeek V4 DSpark MRV1 ACLGraph

### DIFF
--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
@@ -46,13 +46,31 @@ DSPARK_DYNAMIC_SPEC_CONFIG = {
 
 @pytest.mark.parametrize("model_name", MODELS)
 @pytest.mark.parametrize(
-    ("expected_acceptance_length", "num_speculative_tokens", "additional_config"),
+    (
+        "expected_acceptance_length",
+        "num_speculative_tokens",
+        "enforce_eager",
+        "additional_config",
+    ),
     [
-        pytest.param(3.33, 5, {"enable_dsa_cp": False}, id="dspark"),
-        pytest.param(3.45, 7, {"enable_dsa_cp": True}, id="dsa-cp-dspark"),
+        pytest.param(
+            3.33,
+            5,
+            False,
+            {"enable_dsa_cp": False},
+            id="dspark-aclgraph",
+        ),
+        pytest.param(
+            3.45,
+            7,
+            True,
+            {"enable_dsa_cp": True},
+            id="dsa-cp-dspark",
+        ),
         pytest.param(
             3.35,
             5,
+            True,
             {
                 "enable_flashcomm1": False,
                 "enable_dsa_cp": False,
@@ -76,6 +94,7 @@ def test_deepseek_v4_dspark_acceptance_tp4(
     model_name,
     expected_acceptance_length,
     num_speculative_tokens,
+    enforce_eager,
     additional_config,
 ):
     _run_speculative_decoding(
@@ -83,7 +102,7 @@ def test_deepseek_v4_dspark_acceptance_tp4(
         speculative_config={
             "method": "dspark",
             "num_speculative_tokens": num_speculative_tokens,
-            "enforce_eager": True,
+            "enforce_eager": enforce_eager,
         },
         expected_acceptance_length=expected_acceptance_length,
         runner_kwargs={

--- a/tests/ut/spec_decode/test_dspark_graph_dispatch_regression.py
+++ b/tests/ut/spec_decode/test_dspark_graph_dispatch_regression.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for DSpark target-descriptor graph dispatch."""
+
+from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+
+class _TargetDescriptorProposer(AscendSpecDecodeBaseProposer):
+    def __init__(self) -> None:
+        pass
+
+    def uses_target_batch_descriptor_for_graph(self) -> bool:
+        return True
+
+
+def test_large_non_uniform_eager_descriptor_is_not_used_for_draft() -> None:
+    proposer = _TargetDescriptorProposer()
+    target_prefill = BatchDescriptor(
+        num_tokens=16288,
+        num_reqs=None,
+        uniform=False,
+    )
+
+    assert not proposer._can_use_target_batch_descriptor_for_graph(
+        CUDAGraphMode.NONE,
+        target_prefill,
+    )
+
+
+def test_uniform_full_descriptor_is_used_for_draft_graph() -> None:
+    proposer = _TargetDescriptorProposer()
+    target_decode = BatchDescriptor(
+        num_tokens=32,
+        num_reqs=4,
+        uniform=True,
+    )
+
+    assert proposer._can_use_target_batch_descriptor_for_graph(
+        CUDAGraphMode.FULL,
+        target_decode,
+    )

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 import torch
 from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MLAAttentionSpec,
@@ -115,6 +116,65 @@ def test_build_draft_metadata_submits_only_non_cp_device_tasks(
         executor.submit.assert_called_once_with(tasks)
     else:
         executor.submit.assert_not_called()
+
+
+def test_build_draft_metadata_uses_external_event_key_for_full_graph():
+    task = DeviceMetadataTask(DeviceMetadataStage.ATTENTION, lambda: None, 7)
+
+    class DraftMetadataProvider:
+        def enable_device_metadata(self):
+            pass
+
+        def take_device_metadata_tasks(self):
+            return (task,)
+
+        def build_for_drafting(self, common_attn_metadata, draft_index, **kwargs):
+            return SimpleNamespace()
+
+    builder = DraftMetadataProvider()
+    group = SimpleNamespace(
+        kv_cache_group_id=0,
+        layer_names=["draft.attn"],
+        get_metadata_builder=lambda: builder,
+    )
+    executor = MagicMock()
+    proposer = SimpleNamespace(
+        draft_attn_groups=[group],
+        use_compress=False,
+        method="dspark",
+        runner=SimpleNamespace(device_metadata_executor=executor),
+        dcp_size=1,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(prefill_context_parallel_size=1)
+        ),
+        sliding_window=None,
+        _per_group_block_table_buffers={
+            0: torch.ones((1, 1), dtype=torch.int32)
+        },
+        _per_group_query_slot_mapping_buffers={
+            0: torch.zeros(1, dtype=torch.int32)
+        },
+    )
+    common_attn_metadata = SimpleNamespace(
+        num_reqs=1,
+        block_table_tensor=torch.ones((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int32),
+    )
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=1, uniform=True)
+
+    AscendSpecDecodeBaseProposer.build_draft_attn_metadata(
+        proposer,
+        common_attn_metadata,
+        num_input_tokens=1,
+        num_actual_tokens=1,
+        batch_descriptor=descriptor,
+    )
+
+    executor.submit.assert_called_once_with(
+        [task],
+        batch_descriptor=descriptor,
+        event_namespace="dspark-draft",
+    )
 
 
 @pytest.mark.parametrize("has_task", [True, False])
@@ -520,7 +580,10 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
             hf_config=hf_config,
             draft_sample_method=draft_sample_method,
         )
-        expected_max_query_tokens = _MAX_BATCH_SIZE * expected_num_query_per_req
+        expected_max_query_tokens = _MAX_BATCH_SIZE * max(
+            expected_num_query_per_req,
+            1 + _NUM_SPECULATIVE_TOKENS,
+        )
         assert proposer.sample_from_anchor is expected_sample_from_anchor
         assert proposer.num_query_per_req == expected_num_query_per_req
         assert proposer.max_query_tokens == expected_max_query_tokens
@@ -874,3 +937,146 @@ class TestInitializeAttnBackend(_DSparkProposerTestBase):
         assert set(proposer.draft_attn_groups[0].layer_names) == set(draft_layers)
         assert proposer.draft_attn_groups[0].kv_cache_group_id == 0
         assert proposer._layer_group_idx == [0] * 5
+
+
+class TestDSparkACLGraphContract(_DSparkProposerTestBase):
+    def test_maps_uniform_target_descriptor_to_draft_tokens(self) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=4,
+            block_size=7,
+        )
+        target_desc = BatchDescriptor(
+            num_tokens=32,
+            num_reqs=4,
+            uniform=True,
+        )
+
+        assert proposer.get_graph_num_input_tokens(target_desc) == 28
+        assert proposer.uses_target_batch_descriptor_for_graph()
+
+    def test_non_uniform_descriptor_uses_target_token_fallback(self) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=4,
+            block_size=7,
+        )
+        target_desc = BatchDescriptor(
+            num_tokens=31,
+            num_reqs=4,
+            uniform=False,
+        )
+
+        assert proposer.get_graph_num_input_tokens(target_desc) == 31
+
+    def test_target_descriptor_padding_uses_draft_query_geometry(self) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=64,
+            num_reqs=4,
+            block_size=5,
+        )
+        num_actual_reqs = 3
+        num_actual_query_tokens = 15
+        num_actual_context_tokens = 18
+        proposer._dflash_num_context = num_actual_context_tokens
+        proposer._dflash_hidden_states.fill_(7)
+        proposer._context_positions_buffer.fill_(7)
+        proposer._per_group_context_slot_mapping_buffers[0].fill_(7)
+        proposer._per_group_query_slot_mapping_buffers[0].fill_(7)
+
+        seq_lens = torch.tensor([20, 21, 22], dtype=torch.int32)
+        common_attn_metadata = SimpleNamespace(
+            num_reqs=num_actual_reqs,
+            query_start_loc=torch.tensor([0, 5, 10, 15], dtype=torch.int32),
+            query_start_loc_cpu=torch.tensor(
+                [0, 5, 10, 15], dtype=torch.int32
+            ),
+            seq_lens=seq_lens.clone(),
+            _seq_lens_cpu=seq_lens.clone(),
+            seq_lens_cpu=seq_lens.clone(),
+            seq_lens_cpu_upper_bound=seq_lens.clone(),
+            num_computed_tokens_cpu=torch.tensor(
+                [15, 16, 17], dtype=torch.int32
+            ),
+            is_prefilling=torch.tensor([False, False, False]),
+            block_table_tensor=torch.empty(0),
+            slot_mapping=torch.empty(0),
+            actual_seq_lengths_q=[5, 5, 5],
+            num_actual_tokens=num_actual_query_tokens,
+            num_input_tokens=num_actual_query_tokens,
+        )
+        target_desc = BatchDescriptor(
+            num_tokens=24,
+            num_reqs=4,
+            uniform=True,
+        )
+
+        num_reqs_padded = proposer.prepare_target_batch_descriptor_for_graph(
+            common_attn_metadata,
+            target_desc,
+            num_actual_query_tokens,
+        )
+        proposer._pad_draft_buffers(
+            num_actual_query_tokens,
+            proposer.get_graph_num_input_tokens(target_desc),
+        )
+
+        assert num_reqs_padded == 4
+        assert common_attn_metadata.num_reqs == 4
+        assert common_attn_metadata.num_actual_tokens == 20
+        assert common_attn_metadata.num_input_tokens == 20
+        assert torch.equal(
+            common_attn_metadata.query_start_loc_cpu,
+            torch.tensor([0, 5, 10, 15, 20], dtype=torch.int32),
+        )
+        assert torch.equal(
+            common_attn_metadata.seq_lens,
+            torch.tensor([20, 21, 22, 5], dtype=torch.int32),
+        )
+        assert torch.equal(
+            common_attn_metadata._seq_lens_cpu,
+            torch.tensor([20, 21, 22, 5], dtype=torch.int32),
+        )
+        assert common_attn_metadata.actual_seq_lengths_q == [5, 5, 5, 5]
+        assert proposer._dflash_num_context == 24
+        assert torch.count_nonzero(
+            proposer._dflash_hidden_states[num_actual_context_tokens:24]
+        ) == 0
+        assert torch.count_nonzero(
+            proposer._context_positions_buffer[num_actual_context_tokens:24]
+        ) == 0
+        assert torch.all(
+            proposer._per_group_context_slot_mapping_buffers[0][
+                num_actual_context_tokens:24
+            ]
+            == -1
+        )
+        assert torch.all(
+            proposer._per_group_query_slot_mapping_buffers[0][15:20] == -1
+        )
+
+    @pytest.mark.parametrize("supported", [False, True])
+    def test_model_capability_gate(self, supported: bool) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=32,
+            num_reqs=2,
+            block_size=3,
+        )
+        proposer.model = SimpleNamespace(supports_dspark_aclgraph=supported)
+
+        assert proposer._model_supports_dspark_aclgraph() is supported
+
+    def test_binds_persistent_context_slot_mappings_per_layer(self) -> None:
+        proposer = self._make_proposer(
+            max_num_tokens=32,
+            num_reqs=2,
+            block_size=3,
+        )
+        proposer._layer_group_idx = [0, 0]
+        expected = proposer._per_group_context_slot_mapping_buffers[0]
+
+        proposer._bind_context_slot_mapping_buffers()
+
+        assert proposer._context_slot_mapping_buffers is not None
+        assert proposer._context_slot_mapping_buffers[0] is expected
+        assert proposer._context_slot_mapping_buffers[1] is expected

--- a/tests/ut/worker/test_device_metadata.py
+++ b/tests/ut/worker/test_device_metadata.py
@@ -199,6 +199,23 @@ def test_external_event_frontiers_must_remain_stable(executor_env):
     assert not executor.submission_in_flight
 
 
+def test_external_event_frontiers_are_isolated_by_namespace(executor_env):
+    executor, calls, allocations = executor_env
+    descriptor = BatchDescriptor(num_tokens=4, num_reqs=4)
+
+    executor.submit(_tasks(calls), descriptor, event_namespace="target")
+    executor.release()
+    executor.submit(
+        _tasks(calls)[:-1],
+        descriptor,
+        event_namespace="dspark-draft",
+    )
+
+    assert executor.uses_external_events
+    assert allocations[-2:] == ["external-3", "external-4"]
+    executor.release()
+
+
 def test_submit_failure_keeps_partial_submission_in_flight(executor_env):
     executor, calls, _ = executor_env
 

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -328,6 +328,10 @@ class DeepseekV4DSparkModel(nn.Module):
 
 @support_torch_compile
 class DSparkDeepseekV4ForCausalLM(nn.Module, DeepseekV2MixtureOfExperts, SupportsEagle3):
+    # This adapter provides fixed-address graph inputs, persistent DSA
+    # metadata, and an address-stable context-KV scatter path.
+    supports_dspark_aclgraph = True
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         assert vllm_config.speculative_config is not None

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -5,19 +5,24 @@ from typing import Any
 
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import BatchDescriptor, get_forward_context
+from vllm.logger import logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import set_ascend_forward_context
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
-from vllm_ascend.attention.utils import enable_pcp
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, enable_pcp
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
+
+
+_DSPARK_ACLGRAPH_CAPABILITY = "supports_dspark_aclgraph"
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -69,10 +74,11 @@ class AscendDSparkProposer(AscendDflashProposer):
                 num_speculative_tokens=self.num_speculative_tokens,
                 device=device,
             )
-        # DSpark runs eager only (Ascend cudagraph unsupported on this path).
-        self.use_cuda_graph = False
-        # Max query tokens depend on whether sampling from anchor or not.
-        self.max_query_tokens = self.max_batch_size * self.num_query_per_req
+        # Keep enough fixed-address space for both anchor-first (N) and
+        # bonus-anchor (N + 1) checkpoints. The active width is still selected
+        # by num_query_per_req.
+        graph_query_width = max(self.num_query_per_req, 1 + self.num_speculative_tokens)
+        self.max_query_tokens = self.max_batch_size * graph_query_width
         # Position ids for the draft query block [max_query_tokens].
         # Overrides dflash:49; v2 uses input_buffers.positions.
         self.positions = torch.zeros(
@@ -104,6 +110,178 @@ class AscendDSparkProposer(AscendDflashProposer):
         self._per_group_query_slot_mapping_buffers: dict[int, torch.Tensor] = {}
         self._per_group_context_slot_mapping_buffers: dict[int, torch.Tensor] = {}
         self._context_slot_mapping_buffers: list[torch.Tensor | None] | None = None
+
+    def _model_supports_dspark_aclgraph(self) -> bool:
+        """Return whether the loaded DSpark adapter opted in to ACLGraph."""
+        return bool(getattr(self.get_model(), _DSPARK_ACLGRAPH_CAPABILITY, False))
+
+    def _maybe_share_lm_head(self, model) -> None:
+        # Check the model capability after loading, but before the base class
+        # wraps the merged draft runnable with ACLGraphWrapper.
+        if self.use_cuda_graph:
+            if not self._model_supports_dspark_aclgraph():
+                logger.warning_once(
+                    "The loaded DSpark draft model does not declare ACLGraph support; "
+                    "falling back to eager drafting while keeping the target graph enabled."
+                )
+                self.use_cuda_graph = False
+            elif self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.FULL_DECODE_ONLY:
+                logger.warning_once(
+                    "DSpark MRV1 ACLGraph currently supports only "
+                    "FULL_DECODE_ONLY; falling back to eager drafting."
+                )
+                self.use_cuda_graph = False
+        super()._maybe_share_lm_head(model)
+
+    def uses_target_batch_descriptor_for_graph(self) -> bool:
+        """DSpark caches graphs by the target verifier descriptor."""
+        return True
+
+    def get_graph_num_input_tokens(self, batch_descriptor: BatchDescriptor) -> int:
+        """Map a target verifier descriptor to DSpark's query width."""
+        if batch_descriptor.uniform and batch_descriptor.num_reqs is not None:
+            return batch_descriptor.num_reqs * self.num_query_per_req
+        return batch_descriptor.num_tokens
+
+    def _pad_request_tensor(
+        self,
+        tensor: torch.Tensor | None,
+        num_actual_reqs: int,
+        num_reqs_padded: int,
+        pad_value: int = 0,
+    ) -> torch.Tensor | None:
+        if tensor is None:
+            return None
+        padded = self._adjust_tensor(tensor[:num_actual_reqs], num_reqs_padded)
+        if num_reqs_padded > num_actual_reqs and pad_value != 0:
+            padded[num_actual_reqs:].fill_(pad_value)
+        return padded
+
+    def prepare_target_batch_descriptor_for_graph(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        batch_descriptor: BatchDescriptor,
+        num_actual_tokens: int,
+    ) -> int:
+        """Translate verifier padding to DSpark's fixed-width draft batch."""
+        if batch_descriptor.num_reqs is None:
+            raise ValueError("A uniform DSpark graph descriptor must include num_reqs")
+
+        num_actual_reqs = common_attn_metadata.num_reqs
+        num_reqs_padded = batch_descriptor.num_reqs
+        if num_reqs_padded < num_actual_reqs:
+            raise ValueError(
+                "DSpark graph request capacity is smaller than the runtime batch: "
+                f"{num_reqs_padded} < {num_actual_reqs}"
+            )
+
+        num_input_tokens = num_reqs_padded * self.num_query_per_req
+        if num_input_tokens < num_actual_tokens:
+            raise ValueError(
+                "DSpark graph token capacity is smaller than the runtime draft: "
+                f"{num_input_tokens} < {num_actual_tokens}"
+            )
+
+        # The target and draft share a graph cache key, but their uniform query
+        # widths differ: the verifier has K + 1 tokens/request and anchor-first
+        # DSpark has K. Materialize the latter explicitly for all padded rows.
+        common_attn_metadata.query_start_loc = (
+            self.arange_dflash[: num_reqs_padded + 1]
+            * self.num_query_per_req
+        )
+        common_attn_metadata.query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: num_reqs_padded + 1]).clone()
+            * self.num_query_per_req
+        ).to(torch.int32)
+
+        common_attn_metadata.seq_lens = self._pad_request_tensor(
+            common_attn_metadata.seq_lens,
+            num_actual_reqs,
+            num_reqs_padded,
+            self.num_query_per_req,
+        )
+        seq_lens_cpu = self._pad_request_tensor(
+            common_attn_metadata._seq_lens_cpu,
+            num_actual_reqs,
+            num_reqs_padded,
+            self.num_query_per_req,
+        )
+        if seq_lens_cpu is None:
+            seq_lens_cpu = self._pad_request_tensor(
+                common_attn_metadata.seq_lens_cpu,
+                num_actual_reqs,
+                num_reqs_padded,
+                self.num_query_per_req,
+            )
+        common_attn_metadata._seq_lens_cpu = seq_lens_cpu
+        common_attn_metadata.seq_lens_cpu = (
+            seq_lens_cpu.clone() if seq_lens_cpu is not None else None
+        )
+        common_attn_metadata.seq_lens_cpu_upper_bound = (
+            seq_lens_cpu.clone() if seq_lens_cpu is not None else None
+        )
+        common_attn_metadata.num_computed_tokens_cpu = self._pad_request_tensor(
+            common_attn_metadata.num_computed_tokens_cpu,
+            num_actual_reqs,
+            num_reqs_padded,
+        )
+        if getattr(common_attn_metadata, "_num_computed_tokens_cpu", None) is not None:
+            common_attn_metadata._num_computed_tokens_cpu = self._pad_request_tensor(
+                common_attn_metadata._num_computed_tokens_cpu,
+                num_actual_reqs,
+                num_reqs_padded,
+            )
+        if common_attn_metadata.is_prefilling is not None:
+            common_attn_metadata.is_prefilling = self._pad_request_tensor(
+                common_attn_metadata.is_prefilling,
+                num_actual_reqs,
+                num_reqs_padded,
+            )
+
+        primary_gid = self.draft_attn_groups[0].kv_cache_group_id
+        common_attn_metadata.block_table_tensor = (
+            self._per_group_block_table_buffers[primary_gid][:num_reqs_padded]
+        )
+        common_attn_metadata.slot_mapping = (
+            self._per_group_query_slot_mapping_buffers[primary_gid][
+                :num_input_tokens
+            ]
+        )
+        common_attn_metadata.actual_seq_lengths_q = [
+            self.num_query_per_req
+        ] * num_reqs_padded
+        common_attn_metadata.num_reqs = num_reqs_padded
+        common_attn_metadata.num_actual_tokens = num_input_tokens
+        common_attn_metadata.num_input_tokens = num_input_tokens
+
+        # Context KV still comes from the verifier input and therefore uses the
+        # target K + 1 width. Clear padded rows so replay cannot consume stale
+        # hidden states, positions, or cache slots from an earlier larger batch.
+        num_actual_context = self._dflash_num_context
+        num_graph_context = batch_descriptor.num_tokens
+        if num_graph_context < num_actual_context:
+            raise ValueError(
+                "DSpark graph context capacity is smaller than the verifier input: "
+                f"{num_graph_context} < {num_actual_context}"
+            )
+        if num_graph_context > num_actual_context:
+            self._dflash_hidden_states[
+                num_actual_context:num_graph_context
+            ].zero_()
+            self._context_positions_buffer[
+                num_actual_context:num_graph_context
+            ].zero_()
+            for context_slots in self._per_group_context_slot_mapping_buffers.values():
+                context_slots[num_actual_context:num_graph_context].fill_(-1)
+        self._dflash_num_context = num_graph_context
+        return num_reqs_padded
+
+    def _bind_context_slot_mapping_buffers(self) -> None:
+        """Bind persistent per-layer context mappings before graph capture."""
+        self._context_slot_mapping_buffers = [
+            self._per_group_context_slot_mapping_buffers[group_idx]
+            for group_idx in self._layer_group_idx
+        ]
 
     def _compute_confidence(
         self,
@@ -293,10 +471,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
             )
-        # to compute self._context_slot_mapping_buffers from dict to list
-        self._context_slot_mapping_buffers = [
-            self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
-        ]
+        self._bind_context_slot_mapping_buffers()
 
         effective_seq_lens = cad.seq_lens
         if has_num_rejected:
@@ -338,6 +513,85 @@ class AscendDSparkProposer(AscendDflashProposer):
 
         return num_query_total, token_indices_to_sample, cad, None
 
+    def _build_graph_capture_attn_metadata(
+        self,
+        num_reqs: int,
+        num_input_tokens: int,
+        batch_descriptor: BatchDescriptor,
+    ) -> list[dict[str, Any]]:
+        """Build DSpark metadata with graph-stable MRV1 buffers.
+
+        The main branch owns asynchronous DSA metadata construction in the
+        base proposer. Reuse that path here so sparse indices, SAS metadata,
+        and external-event synchronization all follow the same lifecycle as a
+        normal DSpark draft step.
+        """
+        if not self.draft_attn_groups:
+            return []
+
+        num_query_total = num_reqs * self.num_query_per_req
+        self._per_group_block_table_buffers = {
+            group.kv_cache_group_id: self._per_group_block_tables[
+                group.kv_cache_group_id
+            ]
+            for group in self.draft_attn_groups
+        }
+        self._bind_context_slot_mapping_buffers()
+
+        query_start_loc = self.query_start_loc_group[0][: num_reqs + 1]
+        query_start_loc.copy_(
+            self.arange_dflash[: num_reqs + 1] * self.num_query_per_req
+        )
+        query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone()
+            * self.num_query_per_req
+        ).to(torch.int32)
+
+        seq_lens = self.seq_lens_group[0][:num_reqs]
+        seq_lens.copy_(self.runner.seq_lens[:num_reqs])
+        # The verifier descriptor contains N + 1 tokens per request, whereas
+        # anchor-first DSpark executes N query tokens per request.
+        target_query_width = 1 + self.num_speculative_tokens
+        seq_lens.sub_(target_query_width).clamp_(min=0).add_(
+            self.num_query_per_req
+        )
+        seq_lens_cpu = (
+            self.runner.optimistic_seq_lens_cpu[:num_reqs]
+            - target_query_width
+        ).clamp(min=0) + self.num_query_per_req
+
+        primary_gid = self.draft_attn_groups[0].kv_cache_group_id
+        common_attn_metadata = AscendCommonAttentionMetadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens_cpu=seq_lens_cpu,
+            _seq_lens_cpu=seq_lens_cpu,
+            seq_lens_cpu_upper_bound=seq_lens_cpu,
+            seq_lens=seq_lens,
+            num_reqs=num_reqs,
+            num_actual_tokens=num_query_total,
+            num_input_tokens=num_input_tokens,
+            max_query_len=self.num_query_per_req,
+            max_seq_len=0,
+            actual_seq_lengths_q=[self.num_query_per_req] * num_reqs,
+            decode_token_per_req=self.num_query_per_req,
+            block_table_tensor=self._per_group_block_table_buffers[primary_gid][
+                :num_reqs
+            ],
+            slot_mapping=self._per_group_query_slot_mapping_buffers[primary_gid],
+            positions=self.positions,
+            attn_state=AscendAttentionState.ChunkedPrefill,
+            causal=False,
+            is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
+        )
+        multi_steps_attn_metadata, _ = self.build_draft_attn_metadata(
+            common_attn_metadata,
+            num_input_tokens,
+            num_query_total,
+            batch_descriptor=batch_descriptor,
+        )
+        return multi_steps_attn_metadata
+
     @torch.inference_mode()
     def dummy_run(
         self,
@@ -351,7 +605,11 @@ class AscendDSparkProposer(AscendDflashProposer):
         **kwargs,
     ) -> None:
         num_query_total = num_reqs * self.num_query_per_req
-        num_query_tokens = min(num_query_total if num_reqs > 0 else num_tokens, self.max_query_tokens)
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and batch_descriptor is not None:
+            graph_query_tokens = self.get_graph_num_input_tokens(batch_descriptor)
+        else:
+            graph_query_tokens = num_query_total if num_reqs > 0 else num_tokens
+        num_query_tokens = min(graph_query_tokens, self.max_query_tokens)
 
         (
             num_input_tokens,
@@ -364,29 +622,67 @@ class AscendDSparkProposer(AscendDflashProposer):
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
-        context_positions = self._context_positions_buffer[:num_input_tokens]
-        context_states = self.hidden_states[:num_input_tokens]
+        graph_context_tokens = (
+            batch_descriptor.num_tokens
+            if aclgraph_runtime_mode == CUDAGraphMode.FULL
+            and batch_descriptor is not None
+            else num_input_tokens
+        )
+        context_positions = self._context_positions_buffer[:graph_context_tokens]
+        context_states = self.hidden_states[:graph_context_tokens]
 
         self.token_indices_to_sample.fill_(0)
         self._pad_draft_buffers(num_query_total, num_input_tokens)
 
+        multi_steps_attn_metadata = []
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+            if batch_descriptor is None:
+                raise ValueError("FULL DSpark graph capture requires a batch descriptor")
+            self._dflash_hidden_states[:graph_context_tokens].zero_()
+            self._context_positions_buffer[:graph_context_tokens].zero_()
+            for query_slots in self._per_group_query_slot_mapping_buffers.values():
+                query_slots[:num_input_tokens].fill_(-1)
+            for context_slots in self._per_group_context_slot_mapping_buffers.values():
+                context_slots[:graph_context_tokens].fill_(-1)
+            multi_steps_attn_metadata = self._build_graph_capture_attn_metadata(
+                num_reqs,
+                num_input_tokens,
+                batch_descriptor,
+            )
+
+        active_device_metadata_executor = (
+            getattr(self.runner, "device_metadata_executor", None)
+            if multi_steps_attn_metadata
+            else None
+        )
+        if (
+            active_device_metadata_executor is not None
+            and not active_device_metadata_executor.submission_in_flight
+        ):
+            active_device_metadata_executor = None
+
         with set_ascend_forward_context(
-            None,
+            multi_steps_attn_metadata[0] if multi_steps_attn_metadata else None,
             self.vllm_config,
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
-            num_actual_tokens=num_input_tokens,
+            num_actual_tokens=num_query_total,
             in_profile_run=is_profile,
             batch_descriptor=batch_descriptor,
             aclgraph_runtime_mode=aclgraph_runtime_mode,
             is_draft_model=True,
-            draft_attn_metadatas=[],
+            draft_attn_metadatas=multi_steps_attn_metadata,
+            device_metadata_executor=active_device_metadata_executor,
             eplb_heat_collection_status=(
                 self.runner.eplb_heat_collection_status if self.runner.dynamic_eplb else False
             ),
         ):
             if is_profile:
-                self.model.precompute_and_store_context_kv(context_states, context_positions)
+                self.model.precompute_and_store_context_kv(
+                    context_states,
+                    context_positions,
+                    self._context_slot_mapping_buffers,
+                )
                 self.model(
                     input_ids=self.input_ids[:num_query_total],
                     positions=self._get_positions(num_query_total),
@@ -394,13 +690,27 @@ class AscendDSparkProposer(AscendDflashProposer):
                 )
 
             else:
-                self._dflash_num_context = num_input_tokens
+                self._dflash_num_context = graph_context_tokens
                 self._runnable(
                     num_input_tokens=num_input_tokens,
                     batch_size=num_reqs,
                     token_indices_to_sample=self.token_indices_to_sample[: num_reqs * self.num_speculative_tokens],
                     target_positions=self._get_positions(num_input_tokens),
                     inputs_embeds=None,
-                    multi_steps_attn_metadata=[],
-                    num_tokens=num_input_tokens,
+                    multi_steps_attn_metadata=multi_steps_attn_metadata,
+                    num_tokens=num_query_total,
                 )
+
+            forward_context = get_forward_context()
+            if (
+                forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                and not _EXTRA_CTX.capturing
+            ):
+                self._update_full_graph_params(
+                    forward_context,
+                    num_input_tokens,
+                    multi_steps_attn_metadata,
+                )
+
+        if active_device_metadata_executor is not None:
+            active_device_metadata_executor.release()

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -642,6 +642,45 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # when update. So we can use the shallow copy.
         return copy.copy(attn_metadata)
 
+    def uses_target_batch_descriptor_for_graph(self) -> bool:
+        return False
+
+    def get_graph_num_input_tokens(self, batch_descriptor: BatchDescriptor) -> int:
+        return batch_descriptor.num_tokens
+
+    def prepare_target_batch_descriptor_for_graph(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        batch_descriptor: BatchDescriptor,
+        num_actual_tokens: int,
+    ) -> int:
+        """Prepare draft metadata keyed by a target-model graph descriptor.
+
+        Most proposers dispatch their own graph descriptor and never call this
+        hook. A proposer that reuses the target descriptor can override it to
+        translate target padding into its own query geometry.
+        """
+        return common_attn_metadata.num_reqs
+
+    def _can_use_target_batch_descriptor_for_graph(
+        self,
+        runtime_mode: CUDAGraphMode,
+        batch_descriptor: BatchDescriptor,
+    ) -> bool:
+        """Whether a target descriptor can safely key the draft graph.
+
+        A non-uniform descriptor returned with eager/piecewise fallback carries
+        the target batch token count (which can be a large prefill), not the
+        number of draft queries. It must never replace the actual draft token
+        count used to build attention metadata.
+        """
+        return (
+            self.uses_target_batch_descriptor_for_graph()
+            and runtime_mode == CUDAGraphMode.FULL
+            and batch_descriptor.uniform
+            and batch_descriptor.num_reqs is not None
+        )
+
     @torch.inference_mode()
     def dummy_run(
         self,
@@ -922,7 +961,28 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         has_lora = len(self.runner.input_batch.lora_id_to_lora_request) > 0
         uniform_decode = target_model_batch_desc.uniform
 
-        if self.use_cuda_graph:
+        try_target_batch_descriptor = (
+            self.use_cuda_graph
+            and self.uses_target_batch_descriptor_for_graph()
+            and target_model_batch_desc is not None
+        )
+        use_target_batch_descriptor = False
+        if try_target_batch_descriptor:
+            aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
+                num_tokens=target_model_batch_desc.num_tokens,
+                uniform_decode=uniform_decode,
+                has_lora=has_lora,
+            )
+            use_target_batch_descriptor = self._can_use_target_batch_descriptor_for_graph(
+                aclgraph_runtime_mode,
+                batch_descriptor,
+            )
+            num_input_tokens = (
+                self.get_graph_num_input_tokens(batch_descriptor)
+                if use_target_batch_descriptor
+                else num_tokens
+            )
+        elif self.use_cuda_graph:
             _, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
                 num_tokens=num_tokens, uniform_decode=uniform_decode, has_lora=has_lora
             )
@@ -938,7 +998,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if num_tokens_across_dp is not None:
             num_input_tokens = int(num_tokens_across_dp[self.dp_rank].item())
 
-        if self.use_cuda_graph:
+        if use_target_batch_descriptor:
+            # The ACLGraph cache key remains the target verifier descriptor;
+            # only the draft execution width is transformed.
+            num_input_tokens = self.get_graph_num_input_tokens(batch_descriptor)
+        elif self.use_cuda_graph:
             aclgraph_runtime_mode, batch_descriptor = self.runner.cudagraph_dispatcher.dispatch(
                 num_tokens=num_input_tokens, uniform_decode=uniform_decode, has_lora=has_lora
             )
@@ -947,7 +1011,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode = CUDAGraphMode.NONE
             batch_descriptor = None
 
-        if aclgraph_runtime_mode == CUDAGraphMode.FULL:
+        if aclgraph_runtime_mode == CUDAGraphMode.FULL and use_target_batch_descriptor:
+            num_reqs_padded = self.prepare_target_batch_descriptor_for_graph(
+                common_attn_metadata,
+                batch_descriptor,
+                num_tokens,
+            )
+        elif aclgraph_runtime_mode == CUDAGraphMode.FULL:
             # TODO: Due to the inconsistency between the proposer `dispatcher` and model runner, this padding
             # should have been done in model runner but not. For example, at prefill stage, target model
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
@@ -1058,7 +1128,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self._pad_draft_buffers(num_tokens, num_input_tokens)
         multi_steps_attn_metadata, attn_metadata_i = self.build_draft_attn_metadata(
-            common_attn_metadata, num_input_tokens, num_tokens
+            common_attn_metadata,
+            num_input_tokens,
+            num_tokens,
+            batch_descriptor=(
+                batch_descriptor
+                if aclgraph_runtime_mode == CUDAGraphMode.FULL
+                else None
+            ),
         )
 
         if self.uses_mrope:
@@ -2369,6 +2446,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         common_attn_metadata,
         num_input_tokens,
         num_actual_tokens,
+        batch_descriptor: BatchDescriptor | None = None,
     ):
         # FIXME(woosuk): The below two ops cause synchronization. Optimize.
         assert len(self.draft_attn_groups) > 0
@@ -2437,7 +2515,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
         if device_metadata_executor is not None and device_metadata_tasks:
-            device_metadata_executor.submit(device_metadata_tasks)
+            if batch_descriptor is None:
+                device_metadata_executor.submit(device_metadata_tasks)
+            else:
+                device_metadata_executor.submit(
+                    device_metadata_tasks,
+                    batch_descriptor=batch_descriptor,
+                    event_namespace="dspark-draft",
+                )
         multi_steps_attn_metadata = [per_layer_attn_metadata]
         # Copy the old attn_metadata and update
         attn_metadata_i = per_layer_attn_metadata[self.draft_attn_groups[0].layer_names[0]]

--- a/vllm_ascend/worker/device_metadata.py
+++ b/vllm_ascend/worker/device_metadata.py
@@ -49,13 +49,19 @@ class DeviceMetadataExecutor:
         self.stream = torch.npu.Stream()
         self._inputs_ready = torch.npu.Event()
         self._stage_ready: dict[tuple[DeviceMetadataStage, int], torch.npu.Event] = {}
-        self._external_stage_ready: dict[tuple[BatchDescriptor, DeviceMetadataStage, int], torch.npu.ExternalEvent] = {}
-        self._external_frontiers: dict[BatchDescriptor, tuple[tuple[DeviceMetadataStage, int], ...]] = {}
+        self._external_stage_ready: dict[
+            tuple[str, BatchDescriptor, DeviceMetadataStage, int],
+            torch.npu.ExternalEvent,
+        ] = {}
+        self._external_frontiers: dict[
+            tuple[str, BatchDescriptor],
+            tuple[tuple[DeviceMetadataStage, int], ...],
+        ] = {}
         self._buffer_reusable = torch.npu.Event()
         self._has_reuse_fence = False
         self._submission_in_flight = False
         self._waited_stages: set[tuple[DeviceMetadataStage, int]] = set()
-        self._batch_descriptor: BatchDescriptor | None = None
+        self._external_key: tuple[str, BatchDescriptor] | None = None
 
     @property
     def submission_in_flight(self) -> bool:
@@ -63,12 +69,13 @@ class DeviceMetadataExecutor:
 
     @property
     def uses_external_events(self) -> bool:
-        return self._batch_descriptor is not None
+        return self._external_key is not None
 
     def submit(
         self,
         tasks: Iterable[DeviceMetadataTask],
         batch_descriptor: BatchDescriptor | None = None,
+        event_namespace: str = "target",
     ) -> None:
         if self._submission_in_flight:
             raise RuntimeError("The previous device metadata submission has not been released")
@@ -76,21 +83,34 @@ class DeviceMetadataExecutor:
         if not ordered_tasks:
             raise ValueError("At least one device metadata task is required")
         submitted_frontiers = tuple(dict.fromkeys((task.stage, task.group_id) for task in ordered_tasks))
-        expected_frontiers = self._external_frontiers.get(batch_descriptor) if batch_descriptor is not None else None
+        external_key = (
+            (event_namespace, batch_descriptor)
+            if batch_descriptor is not None
+            else None
+        )
+        expected_frontiers = (
+            self._external_frontiers.get(external_key)
+            if external_key is not None
+            else None
+        )
         if expected_frontiers is not None and expected_frontiers != submitted_frontiers:
             raise RuntimeError("Device metadata frontiers changed for an existing full-graph batch descriptor")
         for task in ordered_tasks:
             frontier = (task.stage, task.group_id)
-            external_frontier = (batch_descriptor, *frontier) if batch_descriptor is not None else None
+            external_frontier = (
+                (*external_key, *frontier)
+                if external_key is not None
+                else None
+            )
             if external_frontier is not None and external_frontier not in self._external_stage_ready:
                 self._external_stage_ready[external_frontier] = torch.npu.ExternalEvent()
             elif external_frontier is None and frontier not in self._stage_ready:
                 self._stage_ready[frontier] = torch.npu.Event()
-        if batch_descriptor is not None and expected_frontiers is None:
-            self._external_frontiers[batch_descriptor] = submitted_frontiers
+        if external_key is not None and expected_frontiers is None:
+            self._external_frontiers[external_key] = submitted_frontiers
 
         self._submission_in_flight = True
-        self._batch_descriptor = batch_descriptor
+        self._external_key = external_key
         self._waited_stages.clear()
         self._inputs_ready.record(torch.npu.current_stream())
         with torch.npu.stream(self.stream):
@@ -104,10 +124,12 @@ class DeviceMetadataExecutor:
                     task = ordered_tasks[task_index]
                     task.run()
                     frontier = (stage, task.group_id)
-                    if batch_descriptor is None:
+                    if external_key is None:
                         self._stage_ready[frontier].record(self.stream)
                     else:
-                        self._external_stage_ready[(batch_descriptor, *frontier)].record(self.stream)
+                        self._external_stage_ready[(*external_key, *frontier)].record(
+                            self.stream
+                        )
                     task_index += 1
 
     def wait(self, stage: DeviceMetadataStage, group_id: int) -> None:
@@ -116,10 +138,10 @@ class DeviceMetadataExecutor:
         frontier = (stage, group_id)
         if frontier not in self._waited_stages:
             stream = torch.npu.current_stream()
-            if self._batch_descriptor is None:
+            if self._external_key is None:
                 stream.wait_event(self._stage_ready[frontier])
             else:
-                event = self._external_stage_ready[(self._batch_descriptor, *frontier)]
+                event = self._external_stage_ready[(*self._external_key, *frontier)]
                 event.wait(stream)
                 event.reset(stream)
             self._waited_stages.add(frontier)
@@ -130,7 +152,7 @@ class DeviceMetadataExecutor:
         self._buffer_reusable.record(torch.npu.current_stream())
         self._has_reuse_fence = True
         self._submission_in_flight = False
-        self._batch_descriptor = None
+        self._external_key = None
 
 
 def wait_for_device_metadata(stage: DeviceMetadataStage, group_id: int) -> None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -5781,6 +5781,10 @@ class NPUModelRunner(GPUModelRunner):
             and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_extract_hidden_states()
+                or (
+                    self.speculative_config.use_dspark()
+                    and self.drafter.use_cuda_graph
+                )
             )
         ):
             assert isinstance(
@@ -5796,12 +5800,23 @@ class NPUModelRunner(GPUModelRunner):
             for desc in descs
         })
 
+        get_draft_graph_num_tokens = getattr(
+            self.drafter,
+            "get_graph_num_input_tokens",
+            lambda desc: desc.num_tokens,
+        )
+        draft_capture_sizes = sorted({
+            get_draft_graph_num_tokens(desc)
+            for _, descs in capture_descs
+            for desc in descs
+        })
+
         # NOTE: Since aclgraph_batch_sizes cannot be determined until here,
         # we set the graph params right before initializing the keys.
         if self.use_aclgraph:
             set_graph_params(capture_sizes)
             if self.speculative_config:
-                set_draft_graph_params(capture_sizes)
+                set_draft_graph_params(draft_capture_sizes)
 
     def capture_model(self) -> int:
         """Capture NPU graphs and return actual graph pool memory bytes consumed."""


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables ACLGraph execution for the DSpark draft model of DeepSeek V4 speculative decoding on Ascend (Model Runner V1), which previously ran eager-only.

Key changes:

- **DSpark graph-mode support**: `AscendDSparkProposer` now supports ACLGraph capture and replay with graph-stable buffers — fixed-address graph inputs, persistent DSA metadata, and an address-stable context-KV scatter path. `DSparkDeepseekV4ForCausalLM` declares a `supports_dspark_aclgraph` capability flag; if the loaded model does not declare it, or `cudagraph_mode` is not `FULL_DECODE_ONLY`, drafting falls back to eager while the target graph stays enabled.
- **Target-descriptor graph dispatch**: `AscendSpecDecodeBaseProposer` gains hooks (`uses_target_batch_descriptor_for_graph`, `get_graph_num_input_tokens`, `prepare_target_batch_descriptor_for_graph`, `_can_use_target_batch_descriptor_for_graph`) so a proposer can reuse the target verifier's batch descriptor to key the draft graph. DSpark caches its graphs by the target descriptor and translates verifier padding (K+1 tokens/req) into its own draft query geometry (K tokens/req).
- **External-event namespace isolation**: `DeviceMetadataExecutor.submit` accepts an `event_namespace` so draft (`dspark-draft`) and target (`target`) external events are keyed independently.
- **Graph param capture**: `NPUModelRunner` derives draft graph capture sizes through the drafter's `get_graph_num_input_tokens` mapping and enables ACLGraph capture when the DSpark drafter uses graphs.

Why: the DSpark draft previously ran eager-only, leaving speculative-decoding latency on the table. Graph-mode execution removes per-step launch overhead and improves end-to-end DeepSeek V4 DSpark speculative decoding performance on Ascend.

### Does this PR introduce *any* user-facing change?

No. This is an internal performance/implementation change: no API, CLI, config, or interface behavior changes. When graph mode is not applicable, DSpark keeps the previous eager behavior.

### How was this patch tested?

- CI with new and existing unit tests:
  - `tests/ut/spec_decode/test_dspark_proposer.py` — new `TestDSparkACLGraphContract` (descriptor→draft token mapping, target-padding geometry, context-buffer clearing) and external-event key tests.
  - `tests/ut/spec_decode/test_dspark_graph_dispatch_regression.py` — new regression tests: a large non-uniform eager descriptor is never used for draft graph dispatch; a uniform FULL descriptor is.
  - `tests/ut/worker/test_device_metadata.py` — new test that external-event frontiers are isolated by namespace.
- E2E on 4×NPU (TP4): `tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py` — added a `dspark-aclgraph` case (graph enabled, `enforce_eager=False`) alongside the existing eager cases, asserting the expected acceptance length for DeepSeek V4 DSpark.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
