### PR TITLE
[BugFix][Kernel] Derive lightning indexer quant_mode from qk/scale dtypes

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -35,7 +35,7 @@ from vllm_ascend.attention.utils import (
     wait_for_kv_layer_from_connector,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_op import DeviceOperator, qli_quant_mode
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.models.common.ops.sequence_parallel import sp_reduce_scatter
@@ -1330,7 +1330,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 num_heads_k=1,
                 head_dim=self.model_config.hf_config.index_head_dim,
                 topk=self.model_config.hf_config.index_topk,
-                quant_mode=2,
+                quant_mode=qli_quant_mode(*DeviceOperator.INDEXER_QUANT_DTYPES),
                 cu_seqlens_q=qli_cu_seqlens_q,
                 seqused_k=qli_seqused_k,
                 cmp_residual_k=qli_cmp_residual_k,
@@ -2132,7 +2132,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
             key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
             topk=self.index_topk,
-            quant_mode=2,
+            quant_mode=qli_quant_mode(q.dtype, q_scale.dtype),
             cu_seqlens_q=dsa_meta.qli_cu_seqlens_q,
             seqused_k=dsa_meta.qli_seqused_k,
             cmp_residual_k=dsa_meta.qli_cmp_residual_k,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -35,7 +35,7 @@ from vllm_ascend.attention.utils import (
     wait_for_kv_layer_from_connector,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.device_op import DeviceOperator, qli_quant_mode
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.distributed.parallel_state import get_otp_group
@@ -972,7 +972,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 num_heads_k=1,
                 head_dim=self.model_config.hf_config.index_head_dim,  # 128
                 topk=self.model_config.hf_config.index_topk,
-                quant_mode=2,
+                quant_mode=qli_quant_mode(*DeviceOperator.INDEXER_QUANT_DTYPES),
                 cu_seqlens_q=query_start_loc,
                 seqused_k=qli_seqused_k,
                 cmp_residual_k=qli_cmp_residual_k,

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -37,6 +37,29 @@ else:
     triton_q_rms = None  # type: ignore
 
 
+# quant_mode of npu_quant_lightning_indexer(_v2), derived from the actual
+# qk/scale tensor dtypes at runtime. Keyed by (qk dtype, scale dtype); see
+# ops-transformer attention/quant_lightning_indexer_v2_metadata README for
+# the enum.
+_QLI_QUANT_MODES = {
+    (torch.float8_e4m3fn, torch.float32): 1,  # qk: fp8(e4m3) per-token-head, scale: fp32
+    (torch.int8, torch.float16): 2,  # qk: int8 per-token-head, scale: fp16, w: fp16
+    (torch.float8_e4m3fn, torch_npu.float8_e8m0fnu): 3,  # qk: mxfp8(e4m3), scale: fp8(e8m0)
+    (torch_npu.float4_e2m1fn_x2, torch_npu.float8_e8m0fnu): 5,  # qk: mxfp4(e2m1), scale: fp8(e8m0)
+}
+
+
+def qli_quant_mode(qk_dtype: torch.dtype, scale_dtype: torch.dtype) -> int:
+    """Map the runtime qk/scale dtypes to the lightning indexer quant_mode."""
+    try:
+        return _QLI_QUANT_MODES[(qk_dtype, scale_dtype)]
+    except KeyError:
+        raise ValueError(
+            f"unsupported indexer qk quant dtypes ({qk_dtype}, {scale_dtype}) "
+            "for npu_quant_lightning_indexer quant_mode"
+        ) from None
+
+
 class BaseDeviceAdaptor:
     @classmethod
     def reshape_and_cache(cls, key, value, key_cache, value_cache, slot_mapping):
@@ -565,6 +588,10 @@ class BaseDeviceAdaptor:
         torch.ops._C_ascend.npu_scatter_nd_update_sk(indexer_scale_cache, slot_mapping, kv_scale_dummy)
 
     # ===== Lightning Indexer Dtype Prep =====
+
+    # Indexer qk quant dtypes actually produced by indexer_quantize_query and
+    # the prepare_dsa_indexer_* helpers: (qk dtype, scale dtype).
+    INDEXER_QUANT_DTYPES = (torch.int8, torch.float16)
 
     @staticmethod
     def prepare_dsa_indexer_weights(weights):
@@ -1158,6 +1185,10 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
 
     # ===== Lightning Indexer Dtype Prep =====
+
+    # Indexer qk quant dtypes actually produced by indexer_quantize_query and
+    # the prepare_dsa_indexer_* helpers: (qk dtype, scale dtype).
+    INDEXER_QUANT_DTYPES = (torch.float8_e4m3fn, torch.float32)
 
     @staticmethod
     def prepare_dsa_indexer_weights(weights):

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -216,6 +216,8 @@ class AscendIndexerOps:
         metadata: typing.Any,
     ) -> torch.Tensor:
         wait_for_device_metadata(DeviceMetadataStage.INDEXER, id(metadata.qli_metadata))
+        from vllm_ascend.device.device_op import qli_quant_mode
+
         topk_idxs, _ = torch.ops._C_ascend.npu_quant_lightning_indexer_v2(
             query=query,
             key=key_cache,
@@ -223,7 +225,7 @@ class AscendIndexerOps:
             query_dequant_scale=self.device_operator.prepare_dsa_indexer_query_scale(query_scale),
             key_dequant_scale=self.device_operator.prepare_dsa_indexer_key_scale(scale_cache),
             topk=self.index_topk,
-            quant_mode=2,
+            quant_mode=qli_quant_mode(query.dtype, query_scale.dtype),
             cu_seqlens_q=metadata.qli_cu_seqlens_q,
             seqused_k=metadata.qli_seqused_k,
             cmp_residual_k=metadata.qli_cmp_residual_k,


### PR DESCRIPTION
### Description
`quant_mode` of `npu_quant_lightning_indexer(_v2)` was hardcoded to `2` (qk: int8
per-token-head, scale: fp16, w: fp16) at all call sites. This mismatches the
fp8(e4m3) + fp32 scale quantization actually produced by the A5 device adaptor,
leading to wrong tiling/scale handling in the kernel on A5.

This PR derives `quant_mode` from the actual qk/scale tensor dtypes instead of
device-specific hardcoding:

- Add a shared `qli_quant_mode()` mapping in `device_op.py`, keyed by
  `(qk dtype, scale dtype)` — covers mode 1/2 today and 3/5 (mxfp8/mxfp4) for
  future support, raising a clear `ValueError` for unsupported combinations.
- Main operator call sites use the runtime tensor dtypes
  (`q.dtype`, `q_scale.dtype`) directly.
- Metadata-stage calls (where quantized tensors don't exist yet) derive from
  `INDEXER_QUANT_DTYPES` declared alongside the quant helpers in each device
  adaptor, keeping the metadata and main operator modes consistent.

### Tested
- [ ] TODO: A5 device validation
- [x] 910 series: mode unchanged (int8 + fp16 → 2)
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
