### PR TITLE
[BugFix][Model] Automatically configure MiniMax-M3 mixed KV cache on A5

### DIFF
--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -14,6 +14,7 @@ from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_pro
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.platform import (
     NPUPlatform,
+    _configure_minimax_m3_a5_mixed_kv_cache,
     _setup_compile_backend,
     _validate_eplb_config,
     _validate_sfa_dcp_kv_sp,
@@ -98,6 +99,93 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(NPUPlatform.simple_compile_backend, "eager")
         self.assertEqual(NPUPlatform.ray_device_key, "NPU")
         self.assertEqual(NPUPlatform.device_control_env_var, "ASCEND_RT_VISIBLE_DEVICES")
+
+    @patch(
+        "vllm_ascend.platform.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_a5_minimax_m3_fp8_automatically_keeps_gqa_cache_bf16(self, _mock_profile):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                architecture="MiniMaxM3SparseForCausalLM",
+                hf_text_config=SimpleNamespace(
+                    num_hidden_layers=5,
+                    sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                ),
+            ),
+            cache_config=SimpleNamespace(
+                cache_dtype="fp8",
+                kv_cache_dtype_skip_layers=[],
+            ),
+        )
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+        self.assertEqual(
+            vllm_config.cache_config.kv_cache_dtype_skip_layers,
+            ["0", "1", "2"],
+        )
+
+    def test_minimax_m3_mixed_kv_cache_auto_config_is_strictly_scoped(self):
+        test_cases = (
+            (AscendDeviceType.A3, "MiniMaxM3SparseForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "MiniMaxM2ForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "LlamaForCausalLM", "fp8"),
+            (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "auto"),
+            (AscendDeviceType.A5, "MiniMaxM3SparseForCausalLM", "bfloat16"),
+        )
+        for device_type, architecture, cache_dtype in test_cases:
+            with self.subTest(
+                device_type=device_type,
+                architecture=architecture,
+                cache_dtype=cache_dtype,
+            ):
+                vllm_config = SimpleNamespace(
+                    model_config=SimpleNamespace(
+                        architecture=architecture,
+                        hf_text_config=SimpleNamespace(
+                            num_hidden_layers=5,
+                            sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                        ),
+                    ),
+                    cache_config=SimpleNamespace(
+                        cache_dtype=cache_dtype,
+                        kv_cache_dtype_skip_layers=[],
+                    ),
+                )
+                with patch(
+                    "vllm_ascend.platform.get_current_hardware_profile",
+                    return_value=get_hardware_profile(device_type),
+                ):
+                    _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+                self.assertEqual(vllm_config.cache_config.kv_cache_dtype_skip_layers, [])
+
+    @patch(
+        "vllm_ascend.platform.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_a5_minimax_m3_fp8_preserves_explicit_cache_skip_layers(self, _mock_profile):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                architecture="MiniMaxM3SparseForConditionalGeneration",
+                hf_text_config=SimpleNamespace(
+                    num_hidden_layers=5,
+                    sparse_attention_config={"sparse_attention_freq": [0, 0, 0, 1, 1]},
+                ),
+            ),
+            cache_config=SimpleNamespace(
+                cache_dtype="fp8_e4m3",
+                kv_cache_dtype_skip_layers=[4, "sliding_window"],
+            ),
+        )
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
+
+        self.assertEqual(
+            vllm_config.cache_config.kv_cache_dtype_skip_layers,
+            ["4", "sliding_window", "0", "1", "2"],
+        )
 
     @patch("vllm_ascend.platform.enable_sp", return_value=False)
     @patch("vllm_ascend.platform.enable_sfa_dcp_replicated_indexer", return_value=True)

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -76,6 +76,12 @@ logger.info_once(
 _CUSTOM_OP_REGISTERED = False
 # Delete after the driver is released; temporarily hard-coded to 4
 MAX_REDUCED_CAPTURE_SIZES = 4
+_MINIMAX_M3_ARCHITECTURES = frozenset(
+    {
+        "MiniMaxM3SparseForCausalLM",
+        "MiniMaxM3SparseForConditionalGeneration",
+    }
+)
 
 
 class NPUPlatform(Platform):
@@ -633,6 +639,40 @@ class NPUPlatform(Platform):
         }
 
 
+def _configure_minimax_m3_a5_mixed_kv_cache(vllm_config: VllmConfig) -> None:
+    """Keep MiniMax-M3 GQA KV cache in BF16 on the A5 FP8 path."""
+    model_config = vllm_config.model_config
+    cache_config = vllm_config.cache_config
+    if (
+        model_config is None
+        or cache_config is None
+        or model_config.architecture not in _MINIMAX_M3_ARCHITECTURES
+        or cache_config.cache_dtype not in ("fp8", "fp8_e4m3")
+        or not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
+    ):
+        return
+
+    text_config = model_config.hf_text_config
+    sparse_config = getattr(text_config, "sparse_attention_config", None) or {}
+    sparse_freq = sparse_config.get("sparse_attention_freq") or []
+    sparse_layer_ids = {layer_idx for layer_idx, freq in enumerate(sparse_freq) if freq != 0}
+    gqa_layer_ids = [
+        str(layer_idx) for layer_idx in range(text_config.num_hidden_layers) if layer_idx not in sparse_layer_ids
+    ]
+    if not gqa_layer_ids:
+        return
+
+    skip_layers = list(dict.fromkeys(str(layer) for layer in (cache_config.kv_cache_dtype_skip_layers or [])))
+    known_skip_layers = set(skip_layers)
+    skip_layers.extend(layer for layer in gqa_layer_ids if layer not in known_skip_layers)
+    cache_config.kv_cache_dtype_skip_layers = skip_layers
+    logger.info_once(
+        "Using BF16 KV cache for MiniMax-M3 GQA layers %s on Ascend A5; other layers retain the configured %s policy.",
+        ", ".join(gqa_layer_ids),
+        cache_config.cache_dtype,
+    )
+
+
 def _fix_incompatible_config(vllm_config: VllmConfig) -> None:
     """
     Check and correct parameters in VllmConfig that are incompatible with Ascend NPU.
@@ -666,6 +706,8 @@ def _fix_incompatible_config(vllm_config: VllmConfig) -> None:
                 "Parameter is not supported on Ascend NPU. parameter=calculate_kv_scales, action: resetting to False."
             )
             vllm_config.cache_config.calculate_kv_scales = False
+
+        _configure_minimax_m3_a5_mixed_kv_cache(vllm_config)
 
     # ==================== 3. MultiModal Config ====================
     multimodal_config = getattr(model_config, "multimodal_config", None) if model_config else None


### PR DESCRIPTION
### What this PR does / why we need it?

Ports the automatic MiniMax-M3 A5 mixed KV-cache policy from #15897 to `main`.

When the resolved model is MiniMax-M3, the device supports FP8 attention, and `--kv-cache-dtype fp8` (or `fp8_e4m3`) is selected, the platform derives dense GQA layer IDs from `sparse_attention_freq` and adds them to `kv_cache_dtype_skip_layers` before workers start. Existing explicit skip-layer settings are preserved.

This keeps dense GQA KV cache in BF16 while MSA and index caches retain the configured FP8 policy, without requiring users to list skip layers in startup scripts.

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax-M3 on Ascend A5 only needs:

```bash
--kv-cache-dtype fp8
```

The dense GQA skip layers are configured automatically.

### How was this patch tested?

- Added unit coverage for automatic A5 + MiniMax-M3 + FP8 selection.
- Added negative coverage for non-A5, non-MiniMax, and non-FP8 configurations.
- Added coverage that preserves and deduplicates explicit skip-layer settings.
- `ruff format --check vllm_ascend/platform.py tests/ut/test_platform.py`
- `ruff check vllm_ascend/platform.py tests/ut/test_platform.py`
- `python -m compileall -q vllm_ascend/platform.py tests/ut/test_platform.py`
- `git diff --check origin/main...HEAD`
- The port has the same stable patch ID as the automatic-policy delta in #15897: `82a55ef7d737668c2bb60c0d668eaac9ace60731`.
- The targeted pytest was not run locally because this Windows environment does not have vLLM, PyTorch, or pytest installed; CI verification is required.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
