### PR TITLE
[BugFix] Fix KV pool NPU device binding and avoid Memcache scheduler contexts

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -56,6 +56,10 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules["torch"] = _torch
     sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
 
+_torch_module = sys.modules.get("torch") or importlib.import_module("torch")
+if not hasattr(_torch_module, "npu"):
+    _torch_module.npu = MagicMock()  # type: ignore[attr-defined]
+
 if "torch_npu" not in sys.modules:
     sys.modules["torch_npu"] = MagicMock()
     sys.modules["torch_npu._inductor"] = MagicMock()
@@ -84,6 +88,7 @@ _vllm_mock_modules = [
     "vllm.model_executor.layers.linear",
     "vllm.model_executor.layers.quantization",
     "vllm.platforms",
+    "vllm.platforms.interface",
     "vllm.utils",
     "vllm.utils.hashing",
     "vllm.utils.math_utils",

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -28,6 +28,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
     get_layerwise_protocol,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import base as backend_base
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import memcache_backend as memcache_module
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import mooncake_backend as mooncake_module
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
@@ -70,6 +71,74 @@ class TestBackendABC(unittest.TestCase):
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
             Backend(MagicMock())  # type: ignore[abstract]
+
+
+class TestBackendDeviceBinding(unittest.TestCase):
+    def test_memcache_scheduler_factory_does_not_create_npu_context(self):
+        npu = MagicMock()
+        parallel_config = SimpleNamespace(assigned_physical_gpu_ids=[5])
+        store = MagicMock()
+        store.init.return_value = 0
+        with (
+            patch.object(memcache_module.torch, "npu", npu),
+            patch.object(backend_base, "set_assigned_physical_gpu_ids"),
+            patch.object(
+                backend_base.current_platform,
+                "logical_device_id_to_visible_device_id",
+                return_value=2,
+            ),
+            patch.object(memcache_module, "_validate_device_ub_qos"),
+            patch.object(sys.modules["memcache_hybrid"], "DistributedObjectStore", return_value=store, create=True),
+            patch.object(memcache_module.time, "sleep"),
+        ):
+            backend = MemcacheBackend.create_scheduler_client(parallel_config)
+
+        self.assertEqual(backend.device_id, 2)
+        self.assertIs(backend.store, store)
+        store.init.assert_called_once_with(2, init_bm=False)
+        npu.current_device.assert_not_called()
+        npu.set_device.assert_not_called()
+
+    def test_scheduler_device_id_does_not_bind_assigned_device(self):
+        npu = MagicMock()
+        parallel_config = SimpleNamespace(assigned_physical_gpu_ids=[5])
+        with (
+            patch.object(backend_base.torch, "npu", npu),
+            patch.object(backend_base, "set_assigned_physical_gpu_ids") as set_ids,
+            patch.object(
+                backend_base.current_platform,
+                "logical_device_id_to_visible_device_id",
+                return_value=2,
+            ),
+        ):
+            device_id = backend_base.get_scheduler_device_id(parallel_config)  # type: ignore[arg-type]
+
+        self.assertEqual(device_id, 2)
+        set_ids.assert_called_once_with([5])
+        npu.current_device.assert_not_called()
+        npu.set_device.assert_not_called()
+
+    def test_scheduler_device(self):
+        for assigned_ids, expected in (([5], 2), (None, 3)):
+            with self.subTest(assigned_ids=assigned_ids):
+                npu = MagicMock()
+                npu.current_device.return_value = 3
+                parallel_config = SimpleNamespace(assigned_physical_gpu_ids=assigned_ids)
+                with (
+                    patch.object(backend_base.torch, "npu", npu),
+                    patch.object(backend_base, "set_assigned_physical_gpu_ids") as set_ids,
+                    patch.object(
+                        backend_base.current_platform,
+                        "logical_device_id_to_visible_device_id",
+                        return_value=2,
+                    ),
+                ):
+                    backend_base.set_scheduler_device(parallel_config)  # type: ignore[arg-type]
+
+                npu.set_device.assert_called_once_with(expected)
+                if assigned_ids is not None:
+                    set_ids.assert_called_once_with(assigned_ids)
+                    npu.current_device.assert_not_called()
 
 
 # =========================================================================
@@ -300,6 +369,7 @@ class TestMooncakeBackendSetup(unittest.TestCase):
         contribute_memory: bool = True,
     ) -> MooncakeBackend:
         backend = MooncakeBackend.__new__(MooncakeBackend)
+        backend.device_id = 0
         backend.parallel_config = MagicMock()
         backend.config = config
         backend.local_seg = None
@@ -337,13 +407,16 @@ class TestMooncakeBackendSetup(unittest.TestCase):
                     config=_make_mooncake_store_config(),
                     use_fabric_mem=use_fabric_mem,
                 )
+                backend.device_id = 3
                 store = MagicMock()
                 store.setup.return_value = 0
 
-                result = self._setup_store(backend, store)
+                with patch(f"{self._MODULE_PATH}.torch.npu.set_device") as set_device:
+                    result = self._setup_store(backend, store)
 
                 self.assertIs(result, store)
                 self.assertNotIn("tenant_id", store.setup.call_args.kwargs)
+                set_device.assert_called_once_with(3)
 
     def test_setup_forwards_tenant_for_all_memory_paths(self):
         for use_fabric_mem in (False, True):
@@ -423,6 +496,7 @@ class TestMooncakeBackendMethods(unittest.TestCase):
             patch.object(MooncakeBackend, "__init__", lambda self, pc: None),
         ):
             backend = MooncakeBackend.__new__(MooncakeBackend)
+            backend.device_id = 0
             backend.store = MagicMock()
             backend.config = MagicMock()
             backend.local_seg = "127.0.0.1:1234"
@@ -805,7 +879,7 @@ class TestMemcacheQosInjection(unittest.TestCase):
             patch.dict(os.environ, {}, clear=True),
             patch.object(MemcacheBackend, "_setup_store"),
         ):
-            MemcacheBackend(MagicMock(), local_rank=0, extra_config={"qos_priority": 2})
+            MemcacheBackend(MagicMock(), device_id=0, extra_config={"qos_priority": 2})
             self.assertEqual(os.environ.get(self._ENV), "2")
 
 
@@ -1106,7 +1180,7 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         with patch.object(MemcacheBackend, "__init__", lambda self, pc: None):
             backend = MemcacheBackend.__new__(MemcacheBackend)
             backend.store = MagicMock()
-            backend.local_rank = 0
+            backend.device_id = 0
             # Set internal state to avoid lazy init logic during tests
             backend._lazy_init = False
             backend._store_initialized = True
@@ -1117,6 +1191,52 @@ class TestMemcacheBackendMethods(unittest.TestCase):
         b = self._make_backend()
         b.store.batch_is_exist.return_value = [1]
         self.assertEqual(b.exists(["k1"]), [1])
+
+    def test_setup_uses_captured_device(self):
+        b = self._make_backend()
+        b.device_id = 3
+        b._init_bm = True
+        store = MagicMock()
+        store.init.return_value = 0
+        module_path = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend"
+
+        with (
+            patch.object(
+                sys.modules["memcache_hybrid"],
+                "DistributedObjectStore",
+                return_value=store,
+                create=True,
+            ),
+            patch(f"{module_path}.torch.npu.set_device") as set_device,
+            patch(f"{module_path}.time.sleep"),
+        ):
+            self.assertIs(b._setup_store(), store)
+
+        set_device.assert_called_once_with(3)
+        store.init.assert_called_once_with(3, init_bm=True)
+
+    def test_scheduler_setup_does_not_create_npu_context(self):
+        b = self._make_backend()
+        b.device_id = 3
+        b._init_bm = False
+        store = MagicMock()
+        store.init.return_value = 0
+        module_path = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.memcache_backend"
+
+        with (
+            patch.object(
+                sys.modules["memcache_hybrid"],
+                "DistributedObjectStore",
+                return_value=store,
+                create=True,
+            ),
+            patch(f"{module_path}.torch.npu.set_device") as set_device,
+            patch(f"{module_path}.time.sleep"),
+        ):
+            self.assertIs(b._setup_store(), store)
+
+        set_device.assert_not_called()
+        store.init.assert_called_once_with(3, init_bm=False)
 
     def test_register_buffer(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -5,7 +5,10 @@ from collections.abc import Iterable
 from numbers import Integral
 from typing import Any
 
+import torch
 from vllm.config import ParallelConfig
+from vllm.platforms import current_platform
+from vllm.platforms.interface import set_assigned_physical_gpu_ids
 
 # QoS range supported by the pooled KV store backends. A larger value
 # means a higher transfer priority.
@@ -52,6 +55,19 @@ def require_aligned_batch_results(
     if len(values) != len(keys):
         raise BatchResultShapeError(f"{operation} returned {len(values)} results for {len(keys)} keys")
     return values
+
+
+def get_scheduler_device_id(parallel_config: ParallelConfig) -> int:
+    """Resolve a scheduler's device without creating an NPU context."""
+    assigned_ids = parallel_config.assigned_physical_gpu_ids
+    if assigned_ids is not None:
+        set_assigned_physical_gpu_ids(assigned_ids)
+        return current_platform.logical_device_id_to_visible_device_id(0)
+    return torch.npu.current_device()
+
+
+def set_scheduler_device(parallel_config: ParallelConfig) -> None:
+    torch.npu.set_device(get_scheduler_device_id(parallel_config))
 
 
 class Backend(ABC):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -7,13 +7,13 @@ from typing import Any
 
 import torch
 from vllm.config import ParallelConfig
-from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import (
     QOS_VALUE_MAX,
     QOS_VALUE_MIN,
     Backend,
+    get_scheduler_device_id,
     parse_qos_from_extra_config,
 )
 
@@ -163,14 +163,14 @@ class MemcacheBackend(Backend):
     def __init__(
         self,
         parallel_config: ParallelConfig,
-        local_rank: int | None = None,
+        device_id: int | None = None,
         init_bm: bool = True,
         lazy_init: bool = False,
         extra_config: dict[str, Any] | None = None,
     ):
         _inject_device_ub_qos(extra_config)
         _validate_device_ub_qos()
-        self.local_rank = local_rank if local_rank is not None else get_world_group().local_rank
+        self.device_id = torch.npu.current_device() if device_id is None else device_id
         self._init_bm = init_bm
         self._lazy_init = lazy_init and _is_device_sdma()
 
@@ -191,7 +191,7 @@ class MemcacheBackend(Backend):
             if self._store_initialized:
                 return
 
-            logger.info("Initializing Memcache store. local_rank=%d", self.local_rank)
+            logger.info("Initializing Memcache store. device_id=%d", self.device_id)
             self.store = self._setup_store()
             self._store_initialized = True
             self._register_buffers_if_needed()
@@ -206,10 +206,14 @@ class MemcacheBackend(Backend):
                 "to run vLLM with MemcacheConnector."
             ) from e
 
+        # Scheduler clients are metadata-only. Binding them with set_device()
+        # creates an otherwise unnecessary EngineCore NPU context.
+        if self._init_bm:
+            self.set_device()
         store = DistributedObjectStore()
 
         try:
-            res = store.init(self.local_rank, init_bm=self._init_bm)
+            res = store.init(self.device_id, init_bm=self._init_bm)
         except ValueError as e:
             logger.error("Configuration loading failed. error=%s. Check memcache config and environment.", e)
             raise
@@ -223,10 +227,11 @@ class MemcacheBackend(Backend):
 
     @classmethod
     def create_scheduler_client(cls, parallel_config: ParallelConfig):
-        # The scheduler is a single metadata client. It is initialized before
-        # the world group exists and must not initialize memcache storage, so
-        # keep the old device_id=0/init_bm=False behavior here.
-        return cls(parallel_config, local_rank=0, init_bm=False)
+        return cls(
+            parallel_config,
+            device_id=get_scheduler_device_id(parallel_config),
+            init_bm=False,
+        )
 
     def init_store(self, init_bm: bool = True):
         if self.store is not None:
@@ -237,8 +242,7 @@ class MemcacheBackend(Backend):
         self._register_buffers_if_needed()
 
     def set_device(self):
-        device = torch.device(f"npu:{self.local_rank}")
-        torch.npu.set_device(device)
+        torch.npu.set_device(self.device_id)
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):
         self._pending_buffers = (list(ptrs), list(sizes))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -12,7 +12,6 @@ import torch
 # Third Party
 from mooncake.store import ReplicateConfig  # type: ignore
 from vllm.config import ParallelConfig
-from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
@@ -23,6 +22,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base impor
     Backend,
     parse_qos_from_extra_config,
     require_aligned_batch_results,
+    set_scheduler_device,
 )
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.parallel_state import get_global_rank
@@ -194,6 +194,7 @@ class MooncakeBackend(Backend):
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
         _inject_store_qos(extra_config)
         _validate_store_qos()
+        self.device_id = torch.npu.current_device()
 
         self.store: Any | None = None
         self.local_seg: str | None = None
@@ -233,6 +234,7 @@ class MooncakeBackend(Backend):
                 "to run vLLM with MooncakeConnector."
             ) from e
 
+        self.set_device()
         store = MooncakeDistributedStore()
         local_hostname = get_ip()
         ssd_kwargs = _ssd_setup_kwargs(self.config)
@@ -300,13 +302,11 @@ class MooncakeBackend(Backend):
 
     @classmethod
     def create_scheduler_client(cls, parallel_config: ParallelConfig):
-        torch.npu.set_device(0)
+        set_scheduler_device(parallel_config)
         return cls(parallel_config, contribute_memory=False)
 
     def set_device(self):
-        local_rank = get_world_group().local_rank
-        device = torch.device(f"npu:{local_rank}")
-        torch.npu.set_device(device)
+        torch.npu.set_device(self.device_id)
 
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         if self._use_store_independent_te:


### PR DESCRIPTION
### What this PR does / why we need it?

KV pool clients can create NPU contexts on the wrong device when a worker's process-group local rank differs from its bound visible device, such as DP=2 / TP=4. Memcache's metadata-only scheduler client can also create an unnecessary EngineCore NPU context.

This combines #15968 (head `393ba9455ace8b4cd3aa6182088460fa5e213472`, by @Pz1116) with the additional Memcache scheduler-context fix into one commit, rebased onto main at `c5055c808`:

- Capture the owning worker's current device for Memcache and Mooncake initialization and transfer threads.
- Resolve scheduler device mapping from assigned physical IDs. Memcache passes the resolved device explicitly and skips `set_device()` when `init_bm=False`; Mooncake retains explicit scheduler binding.
- Preserve main's QoS configuration and batch-result validation, and update the affected constructor test.
- Add regression coverage for device mapping, backend setup, and the complete Memcache scheduler factory path.

Original author Pz1116 is credited with a `Co-authored-by` commit trailer. The original PR is left unchanged.

### Does this PR introduce _any_ user-facing change?

Fixes unintended NPU contexts in KV pooling without adding configuration flags. The internal MemcacheBackend constructor argument changes from `local_rank` to `device_id`.

The no-context scheduler path uses `assigned_physical_gpu_ids`; without assigned IDs, the existing `torch.npu.current_device()` fallback remains.

### How was this patch tested?

On the final submitted source tree, in an isolated Linux ARM64 container with a dedicated Python environment and the test suite's mocked heavy dependencies:

```bash
python -m pytest -q --confcutdir=tests/ut/distributed/ascend_store \
  tests/ut/distributed/ascend_store/test_backend.py
```

**102 passed.** The `--confcutdir` option isolates the self-contained backend tests from the parent conftest that requires an installed vLLM runtime. All 3,858 source-file SHA256 hashes matched the local staged source snapshot before testing.

Also passed: `git diff --check`, Ruff 0.14.0 lint and format checks for all five changed files, codespell, forbidden-import checks, boolean-context-manager checks, package `__init__.py` checks, and symbolic-meta checks.

Full `bash format.sh ci` was attempted. The archived script first required CRLF normalization for Bash; the equivalent normalized script then stalled fetching the ruff-pre-commit hook repository from GitHub and was terminated. The complete pre-commit suite is therefore **not verified** locally and remains for CI.

Prior hardware evidence (2026-09-08) applies specifically to #15968 at `393ba945` plus the original scheduler-context patch, before this rebase: A3 DP=2 / TP=4 startup completed, all eight workers appeared only on their assigned physical NPUs 8-15, four duplicate 113 MiB worker contexts disappeared, and neither EngineCore PID appeared in stable NPU process samples. This historical run was startup/context validation only; no inference requests or benchmarks were run. Hardware startup was not repeated on the rebased tree.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
