### PR TITLE
[Feature][Spec Decode] Reuse the common proposer for auxiliary draft caches

### DIFF
--- a/tests/ut/spec_decode/test_auxiliary_cache_draft_metadata.py
+++ b/tests/ut/spec_decode/test_auxiliary_cache_draft_metadata.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Draft metadata with a full-history cache and auxiliary cache backends."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.spec_decode import get_spec_decode_method
+from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+MAIN, INDEXER, STATE = "draft.attention", "draft.indexer", "draft.state"
+
+
+def _specs(block_size=256):
+    return [SimpleNamespace(block_size=n) for n in (block_size, block_size, 8)]
+
+
+def _table(values, block_size):
+    return SimpleNamespace(get_device_tensor=lambda: values, block_size=block_size)
+
+
+def test_initialize_reuses_runner_groups_without_changing_target_builders():
+    main, indexer, state = _specs()
+    groups = [
+        AttentionGroup(Mock(), [name, "target." + name], spec, gid, [Mock()])
+        for name, spec, gid in [(STATE, state, 0), (INDEXER, indexer, 1), (MAIN, main, 1)]
+    ]
+    target_builders = [group.metadata_builders for group in groups]
+    proposer = object.__new__(AscendEagleProposer)
+    proposer.vllm_config, proposer.device = object(), torch.device("cpu")
+    proposer.num_speculative_tokens = 3
+    proposer._draft_attn_layer_names = {MAIN, INDEXER, STATE}
+    proposer.runner = SimpleNamespace(
+        attn_groups=[[groups[0]], groups[1:]],
+        input_batch=SimpleNamespace(block_table=[_table(None, 8), _table(None, 128)]),
+    )
+    layers = {
+        MAIN: SimpleNamespace(),
+        INDEXER: SimpleNamespace(cache_role="indexer"),
+        STATE: SimpleNamespace(cache_role="indexer_state"),
+    }
+
+    def create(group, config, device, **kwargs):
+        group.metadata_builders = [Mock() for _ in range(kwargs["num_metadata_builders"])]
+
+    with (
+        patch("vllm_ascend.spec_decode.llm_base_proposer.get_layers_from_vllm_config", return_value=layers),
+        patch.object(AttentionGroup, "create_metadata_builders", autospec=True, side_effect=create) as builders,
+    ):
+        proposer.initialize_attn_backend(object(), [128])
+    assert proposer.kv_cache_gid == 1
+    assert proposer.attn_layer_names[0] == MAIN
+    assert proposer.block_size == proposer.kernel_block_size == 128
+    assert len(proposer.draft_attn_groups) == 3
+    assert all(call.kwargs["kernel_block_size"] is None for call in builders.call_args_list)
+    for group in proposer.draft_attn_groups:
+        original = next(g for g in groups if group.layer_names[0] in g.layer_names)
+        assert group is not original
+        assert group.kv_cache_spec is original.kv_cache_spec
+        assert group.kv_cache_group_id == original.kv_cache_group_id
+        assert len(group.metadata_builders) == (1 if group.layer_names == [MAIN] else 3)
+        assert group.metadata_builders is not original.metadata_builders
+    assert [group.metadata_builders for group in groups] == target_builders
+    assert all(len(group.layer_names) == 2 for group in groups)
+
+
+def test_regular_draft_keeps_upstream_initialization():
+    proposer = object.__new__(AscendEagleProposer)
+    proposer.vllm_config = object()
+    proposer._draft_attn_layer_names = {MAIN}
+    config, sizes = object(), [128]
+    with (
+        patch(
+            "vllm_ascend.spec_decode.llm_base_proposer.get_layers_from_vllm_config",
+            return_value={MAIN: SimpleNamespace()},
+        ),
+        patch.object(SpecDecodeBaseProposer, "initialize_attn_backend") as initialize,
+    ):
+        proposer.initialize_attn_backend(config, sizes)
+    initialize.assert_called_once_with(config, sizes)
+
+
+@pytest.mark.parametrize("positions", [[6, 7, 8, 9, 0], [2, 3, 4, 5, 0]])
+def test_state_slots_follow_draft_positions_and_request_blocks_after_rollback(positions):
+    _, _, spec = _specs()
+    group = AttentionGroup(Mock(), [STATE], spec, 1)
+    state_table = torch.tensor([[9, 90], [3, 30]], dtype=torch.int32)
+    proposer = object.__new__(AscendEagleProposer)
+    proposer.kv_cache_gid = 0
+    proposer.runner = SimpleNamespace(input_batch=SimpleNamespace(block_table=[None, _table(state_table, 8)]))
+    common = SimpleNamespace(
+        num_reqs=2,
+        num_input_tokens=5,
+        num_actual_tokens=4,
+        positions=torch.tensor(positions),
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        block_table_tensor=torch.tensor([[100, 101], [200, 201]]),
+        slot_mapping=torch.tensor([1000, -1, 2000, 2001, -1]),
+    )
+    state_common = proposer._cache_group_common_metadata(common, group)
+    assert state_common is not common
+    result = state_common
+    torch.testing.assert_close(result.block_table_tensor, state_table)
+    torch.testing.assert_close(
+        result.slot_mapping,
+        torch.tensor(
+            [
+                9 * 8 + positions[0] % 8,
+                -1,
+                int(state_table[1, positions[2] // 8]) * 8 + positions[2] % 8,
+                int(state_table[1, positions[3] // 8]) * 8 + positions[3] % 8,
+                -1,
+            ]
+        ),
+    )
+    assert common.slot_mapping.tolist() == [1000, -1, 2000, 2001, -1]
+    state_table.copy_(state_table.flip(0))
+    reordered = proposer._cache_group_common_metadata(common, group)
+    assert reordered.slot_mapping[0] == 3 * 8 + positions[0] % 8
+    assert reordered.slot_mapping[2] == state_table[1, positions[2] // 8] * 8 + positions[2] % 8
+    assert reordered.slot_mapping.data_ptr() != result.slot_mapping.data_ptr()
+
+
+@pytest.mark.parametrize("rejected", [[0, 0], [2, 0], [3, 3]])
+@pytest.mark.parametrize("num_input_tokens, max_model_len", [(8, 128), (12, 128), (12, 24)])
+def test_base_propose_keeps_each_group_and_draft_step_at_the_accepted_endpoint(
+    rejected, num_input_tokens, max_model_len
+):
+    main, indexer, state = _specs()
+    groups = [
+        AttentionGroup(Mock(), [MAIN], main, 0),
+        AttentionGroup(Mock(), [INDEXER], indexer, 0),
+        AttentionGroup(Mock(), [STATE], state, 1),
+    ]
+
+    def metadata(common, *args, **kwargs):
+        return SimpleNamespace(
+            num_prefills=0,
+            seq_lens=common.seq_lens,
+            positions=common.positions,
+            slot_mapping=common.slot_mapping,
+        )
+
+    main_builder = Mock(
+        build=Mock(side_effect=lambda _, common, *args: metadata(common)), build_for_drafting=Mock(side_effect=metadata)
+    )
+    groups[0].metadata_builders = [main_builder]
+    for group in groups[1:]:
+        group.metadata_builders = [
+            Mock(
+                build=Mock(side_effect=lambda _, common, *args: metadata(common)),
+                build_for_drafting=Mock(side_effect=metadata),
+            )
+            for _ in range(3)
+        ]
+    proposer = object.__new__(AscendEagleProposer)
+    proposer.kv_cache_gid = 0
+    proposer.draft_attn_groups = groups
+    proposer.attn_layer_names = [MAIN, INDEXER, STATE]
+    state_table = torch.tensor([[9, 90, 900, 91], [3, 30, 300, 31]], dtype=torch.int32)
+    proposer.runner = SimpleNamespace(
+        get_model=Mock(return_value=None),
+        dcp_manager=None,
+        dynamic_eplb=False,
+        input_batch=SimpleNamespace(lora_id_to_lora_request={}, block_table=[None, _table(state_table, 8)]),
+        _sync_metadata_across_dp=Mock(return_value=(None, torch.tensor([num_input_tokens]), None)),
+    )
+    proposer.method = "mtp"
+    proposer.dcp_size = 1
+    proposer.dp_rank = 0
+    proposer.use_cuda_graph = proposer.uses_mrope = proposer.supports_mm_inputs = False
+    proposer.parallel_drafting = proposer.has_gdn = proposer.use_compress = False
+    proposer.draft_window_size = proposer.sliding_window = None
+    proposer.vllm_config = SimpleNamespace(model_config=SimpleNamespace(use_mla=True))
+    proposer.block_size = 128
+    proposer.max_model_len = max_model_len
+    proposer.arange = torch.arange(9, dtype=torch.int32)
+    proposer.token_arange_np = proposer.arange.numpy()
+    proposer.slot_mapping_group = [torch.full((num_input_tokens,), -1, dtype=torch.int32) for _ in range(3)]
+    proposer.seq_lens_group = [torch.zeros(2, dtype=torch.int32) for _ in range(3)]
+    proposer.query_start_loc_group = [torch.zeros(3, dtype=torch.int32) for _ in range(3)]
+    proposer.token_indices_to_sample = torch.zeros(2, dtype=torch.int32)
+    proposer._pad_draft_buffers = Mock()
+    # Reuse the same proposer for the next batch, with no retained rejection state.
+    for rejects in (rejected, [0, 0]):
+        for group in groups[1:]:
+            for builder in group.metadata_builders:
+                builder.build.reset_mock()
+                builder.build_for_drafting.reset_mock()
+        positions = torch.tensor([8, 9, 10, 11, 20, 21, 22, 23], dtype=torch.int32)
+        proposer.positions = torch.zeros(num_input_tokens, dtype=torch.int32)
+        proposer.positions[:8].copy_(positions)
+        indices = torch.tensor([3, 7]) - torch.tensor(rejects)
+        lengths = torch.tensor([12, 24], dtype=torch.int32)
+        common = SimpleNamespace(
+            batch_size=lambda: 2,
+            num_reqs=2,
+            num_actual_tokens=8,
+            num_input_tokens=8,
+            positions=proposer.positions,
+            seq_lens=lengths,
+            seq_lens_cpu=lengths.clone(),
+            _seq_lens_cpu=lengths.clone(),
+            num_computed_tokens_cpu=lengths.clone(),
+            query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
+            query_start_loc_cpu=torch.tensor([0, 4, 8], dtype=torch.int32),
+            block_table_tensor=torch.tensor([[4], [6]], dtype=torch.int32),
+            slot_mapping=torch.tensor([520, 521, 522, 523, 788, 789, 790, 791], dtype=torch.int32),
+        )
+        proposer.set_inputs_first_pass = Mock(return_value=(8, indices, common, None))
+        with (
+            patch(
+                "vllm_ascend.spec_decode.llm_base_proposer.set_ascend_forward_context",
+                side_effect=RuntimeError("metadata ready"),
+            ) as context,
+            pytest.raises(RuntimeError, match="metadata ready"),
+        ):
+            AscendSpecDecodeBaseProposer._propose(
+                proposer,
+                3,
+                target_token_ids=torch.ones(8, dtype=torch.int64),
+                target_positions=positions,
+                target_hidden_states=torch.ones(8, 2),
+                next_token_ids=torch.ones(2, dtype=torch.int64),
+                token_indices_to_sample=indices,
+                common_attn_metadata=common,
+                target_model_batch_desc=SimpleNamespace(uniform=True),
+                sampling_metadata=None,
+            )
+        steps = context.call_args.kwargs["draft_attn_metadatas"]
+        assert len(steps) == 3
+        for step, per_layer in enumerate(steps):
+            assert set(per_layer) == {MAIN, INDEXER, STATE}
+            assert len({id(value) for value in per_layer.values()}) == 3
+            raw_lengths = lengths - torch.tensor(rejects, dtype=lengths.dtype) + step
+            expected = lengths if step == 0 else (raw_lengths - 1) % max_model_len + 1
+            for value in per_layer.values():
+                torch.testing.assert_close(value.seq_lens, expected)
+                assert (value.slot_mapping[2 if step else 8 :] == -1).all()
+            if step:
+                expected_positions = torch.where(raw_lengths > max_model_len, 0, raw_lengths - 1)
+                torch.testing.assert_close(per_layer[MAIN].positions[:2], expected_positions)
+                for value in per_layer.values():
+                    assert (value.slot_mapping[:2][raw_lengths > max_model_len] == -1).all()
+        for group in groups[1:]:
+            group.metadata_builders[0].build.assert_called_once()
+            for builder in group.metadata_builders[1:]:
+                builder.build_for_drafting.assert_called_once()
+        for name in (MAIN, INDEXER, STATE):
+            assert len({step[name].slot_mapping.data_ptr() for step in steps}) == 3
+        torch.testing.assert_close(lengths, torch.tensor([12, 24], dtype=torch.int32))
+        assert not hasattr(proposer, "_num_rejected_tokens")
+
+
+def test_glm_mtp_uses_existing_eagle_proposer():
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=SimpleNamespace(model_type="glm5_next_text")),
+        speculative_config=SimpleNamespace(use_step3p5_mtp=lambda: False),
+    )
+    with patch("vllm_ascend.spec_decode.AscendEagleProposer") as proposer:
+        assert get_spec_decode_method("mtp", config, "cpu", None) is proposer.return_value
+    proposer.assert_called_once_with(config, "cpu", None)
+
+
+@pytest.mark.parametrize(
+    "table, positions, num_reqs",
+    [
+        ([], [0, 0, 0], 0),
+        ([[]], [0, 1, 2], 1),
+        ([[5, -1]], [-1, 8, 16], 1),
+    ],
+)
+def test_proposer_state_slots_mask_idle_and_invalid_pages(table, positions, num_reqs):
+    _, _, spec = _specs()
+    group = AttentionGroup(Mock(), [STATE], spec, 0)
+    state_table = torch.tensor(table, dtype=torch.int32).reshape(
+        num_reqs, 0 if not table or not table[0] else len(table[0])
+    )
+    proposer = object.__new__(AscendEagleProposer)
+    proposer.kv_cache_gid = 1
+    proposer.runner = SimpleNamespace(input_batch=SimpleNamespace(block_table=[_table(state_table, 8)]))
+    common = SimpleNamespace(
+        num_reqs=num_reqs,
+        num_input_tokens=3,
+        positions=torch.tensor(positions),
+        query_start_loc=torch.tensor([0, 3][: num_reqs + 1]),
+        slot_mapping=torch.tensor([0, 1, 2]),
+    )
+    metadata = proposer._cache_group_common_metadata(common, group)
+    assert metadata.slot_mapping.tolist() == [-1, -1, -1]
+    assert common.slot_mapping.tolist() == [0, 1, 2]

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -447,6 +447,62 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 else self.model.mask_hidden.view(self.hidden_size)
             )
 
+    def initialize_attn_backend(self, kv_cache_config, kernel_block_sizes=None):
+        layers = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
+        auxiliary_layers = {
+            name for name in self._draft_attn_layer_names if getattr(layers[name], "cache_role", "kv") != "kv"
+        }
+        if not auxiliary_layers:
+            return super().initialize_attn_backend(kv_cache_config, kernel_block_sizes)
+
+        # Reuse the runner's resolved backends/specs and cache group IDs. Only
+        # the metadata builders are private to the drafter; cache layout stays
+        # with the existing cache manager.
+        self.draft_attn_groups = []
+        for runner_groups in self.runner.attn_groups:
+            for runner_group in runner_groups:
+                names = sorted(self._draft_attn_layer_names.intersection(runner_group.layer_names))
+                if names:
+                    group = copy.copy(runner_group)
+                    group.layer_names = names
+                    group.create_metadata_builders(
+                        self.vllm_config,
+                        self.device,
+                        # Preserve storage pages, even when the block table is
+                        # split into smaller kernel blocks.
+                        kernel_block_size=None,
+                        num_metadata_builders=self.num_speculative_tokens if set(names) <= auxiliary_layers else 1,
+                    )
+                    self.draft_attn_groups.append(group)
+        self.draft_attn_groups.sort(key=lambda group: set(group.layer_names) <= auxiliary_layers)
+        self.attn_layer_names = [name for group in self.draft_attn_groups for name in group.layer_names]
+        assert set(self.attn_layer_names) == self._draft_attn_layer_names
+        self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
+        self.block_size = self.runner.input_batch.block_table[self.kv_cache_gid].block_size
+        self.kernel_block_size = self.block_size
+
+    def _cache_group_common_metadata(self, common, group):
+        if group.kv_cache_group_id == self.kv_cache_gid:
+            return common
+        group_common = copy.copy(common)
+        block_table = self.runner.input_batch.block_table[group.kv_cache_group_id]
+        table = block_table.get_device_tensor()[: common.num_reqs]
+        group_common.block_table_tensor = table
+        positions = common.positions[: common.num_input_tokens].long()
+        slots = torch.full_like(positions, PADDING_SLOT_ID)
+        if common.num_reqs and table.shape[1]:
+            rows = torch.arange(positions.numel(), device=positions.device)
+            request = torch.searchsorted(common.query_start_loc[1 : common.num_reqs + 1], rows, right=True)
+            page = positions // block_table.block_size
+            valid = (request < common.num_reqs) & (positions >= 0) & (page < table.shape[1])
+            valid &= common.slot_mapping[: positions.numel()] >= 0
+            physical = table[request.clamp(max=common.num_reqs - 1), page.clamp(0, table.shape[1] - 1)].long()
+            valid &= physical >= 0
+            slots = torch.where(valid, physical * block_table.block_size + positions % block_table.block_size, slots)
+        # Each draft keeps its own mapping, including after rejection/reordering.
+        group_common.slot_mapping = slots
+        return group_common
+
     def _maybe_share_embeddings(self, target_language_model: nn.Module) -> None:
         """
         Some draft models may not have their own embedding layers, and some may
@@ -1112,7 +1168,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # Copy the old attn_metadata and update
             for draft_index in range(1, self.num_speculative_tokens):
                 per_layer_attn_metadata = dict()
-                for attn_group in self.draft_attn_groups:
+                for group_index, attn_group in enumerate(self.draft_attn_groups):
                     common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
                         draft_index,
                         common_attn_metadata,
@@ -1122,8 +1178,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         aclgraph_runtime_mode,
                         **draft_cp_kwargs,
                         attn_group=attn_group,
+                        advance_common_metadata=group_index == 0,
                     )
-                    for layer_name in self.attn_layer_names:
+                    for layer_name in attn_group.layer_names:
                         per_layer_attn_metadata[layer_name] = attn_metadata
                 multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
@@ -1800,10 +1857,28 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         slot_indices=None,
         mtp_slot_mapping=None,
         attn_group=None,
+        advance_common_metadata=True,
     ):
         assert draft_index > 0
         assert attn_group is not None, "vllm-ascend v0.17.0rc1 requires attn_group"
+        if not advance_common_metadata:
+            builder_index = draft_index if len(attn_group.metadata_builders) > 1 else 0
+            metadata = attn_group.get_metadata_builder(builder_index).build_for_drafting(
+                self._cache_group_common_metadata(old_common_metadata, attn_group), draft_index
+            )
+            return old_common_metadata, metadata
         common_attn_metadata = self.shallow_copy_metadata(old_common_metadata)
+
+        if draft_index == 1 and len(self.draft_attn_groups) > 1 and not self.uses_mrope:
+            # Padded verification includes rejected tokens. All cache groups
+            # must resume drafting from the selected accepted endpoint.
+            common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
+            common_attn_metadata.seq_lens[:batch_size] = used_update_positions[:batch_size] + 1
+            common_attn_metadata.seq_lens_cpu = None
+            common_attn_metadata._seq_lens_cpu = None
+            common_attn_metadata.num_computed_tokens_cpu = None
+            common_attn_metadata._num_computed_tokens_cpu = None
+            common_attn_metadata._num_computed_tokens_cache = None
 
         if draft_index == 1:
             if aclgraph_runtime_mode == CUDAGraphMode.FULL:
@@ -2428,9 +2503,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if device_metadata_provider is not None:
                     device_metadata_tasks.extend(device_metadata_provider.take_device_metadata_tasks())
             else:
-                attn_metadata = builder.build(
-                    0, common_attn_metadata, self.runner.get_model(), **extra_attn_metadata_args
-                )
+                group_common = common_attn_metadata
+                if attn_group is not self.draft_attn_groups[0]:
+                    group_common = self._cache_group_common_metadata(common_attn_metadata, attn_group)
+                attn_metadata = builder.build(0, group_common, self.runner.get_model(), **extra_attn_metadata_args)
             if hasattr(attn_metadata, "causal") and not attn_metadata.causal:
                 attn_metadata.attn_mask = None
 


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Reuse the existing Eagle proposer for draft models with auxiliary attention caches. Initialize draft metadata builders from the runner's resolved attention groups, backends and cache specs, keep each draft step's buffers independent, and advance positions once per step from the accepted endpoint.

This is the common proposer part of GLM-5.3-Flash MTP support. Full-model validation also includes #16214 and the KeyPool integration in #16253 (with its dependencies). Prerequisite commits are excluded from this branch.

### Does this PR introduce _any_ user-facing change?

Yes. Models with auxiliary draft caches can use the existing MTP proposer path with consistent metadata across speculative steps. Cache allocation and grouping retain the existing contract.

### How was this patch tested?

- Added `tests/ut/spec_decode/test_auxiliary_cache_draft_metadata.py` for attention-group reuse, independent draft buffers, position advancement and accepted-token rollback.
- Previous integration validation at `733d5a65a61a34faaede500c97fffcd3394c5ca2`: 139 related CPU tests passed, 13 skipped; two CPU-input/NPU-only operator failures also reproduced on the baseline. Five additional checks with real metadata builders passed.
- A3, GLM-5.3-Flash-w8a8, TP8 with expert parallelism, MTP=3, target FULL_DECODE_ONLY: eight smoke cases passed and a single 3500-input/1500-output request completed.
- That integration used #16214 at `959a13d`; its newer runner revision still needs graph-mode revalidation. GitHub pre-commit and CPU UT passed on this branch (4180 passed, 38 skipped); device CI awaits a maintainer test label.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
