### PR TITLE
[BugFix][Spec Decode] Preserve prefill tails during speculative decoding

### DIFF
--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -814,17 +814,15 @@ def test_one_token_prefill_selection_respects_recurrent_state(
 
 
 @pytest.mark.parametrize(
-    ("seq_len", "expected_spec_decodes", "expected_prefills"),
+    "seq_len",
     [
-        pytest.param(4, 0, 1, id="first_chunk_stays_prefill"),
-        pytest.param(8, 1, 0, id="stateful_chunk_folds_into_spec"),
+        pytest.param(4, id="first_chunk_stays_prefill"),
+        pytest.param(8, id="stateful_chunk_stays_prefill"),
     ],
 )
-def test_spec_sized_prefill_fold_requires_recurrent_state(
+def test_spec_sized_prefill_stays_on_live_prefill_path(
     monkeypatch: pytest.MonkeyPatch,
     seq_len: int,
-    expected_spec_decodes: int,
-    expected_prefills: int,
 ):
     _patch_missing_runtime_cdiv(monkeypatch)
     common_attn_metadata = create_common_attn_metadata(
@@ -845,14 +843,10 @@ def test_spec_sized_prefill_fold_requires_recurrent_state(
         num_decode_draft_tokens_cpu=torch.full((1,), -1, dtype=torch.int32),
     )
 
-    assert attn_metadata.num_spec_decodes == expected_spec_decodes
-    assert attn_metadata.num_prefills == expected_prefills
-    if expected_spec_decodes:
-        assert attn_metadata.spec_sequence_masks.tolist() == [True]
-        assert attn_metadata.num_accepted_tokens.tolist() == [4]
-    else:
-        assert attn_metadata.spec_sequence_masks is None
-        assert attn_metadata.num_accepted_tokens is None
+    assert attn_metadata.num_spec_decodes == 0
+    assert attn_metadata.num_prefills == 1
+    assert attn_metadata.spec_sequence_masks is None
+    assert attn_metadata.num_accepted_tokens is None
 
 
 def test_full_graph_without_runtime_spec_resets_captured_spec_inputs():

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -474,42 +474,6 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         )
         return attn_metadata
 
-    def _fold_spec_sized_prefill_chunks_into_spec(
-        self,
-        common_attn_metadata: CommonAttentionMetadata,
-        spec_sequence_masks_cpu: torch.Tensor,
-        num_accepted_tokens: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """Advance stateful spec-width prompt chunks through live spec inputs."""
-        is_prefilling = common_attn_metadata.is_prefilling
-        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-        if is_prefilling is None or seq_lens_cpu is None or num_accepted_tokens is None:
-            return spec_sequence_masks_cpu, num_accepted_tokens
-
-        num_reqs = min(
-            spec_sequence_masks_cpu.numel(),
-            is_prefilling.numel(),
-            seq_lens_cpu.numel(),
-        )
-        is_prefilling = is_prefilling[:num_reqs]
-        seq_lens_cpu = seq_lens_cpu[:num_reqs]
-        query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)[:num_reqs]
-        fold = (
-            is_prefilling
-            & ~spec_sequence_masks_cpu
-            & (query_lens_cpu == self.num_spec + 1)
-            & (seq_lens_cpu > query_lens_cpu)
-        )
-        fold_indices = fold.nonzero(as_tuple=True)[0]
-        if fold_indices.numel() == 0:
-            return spec_sequence_masks_cpu, num_accepted_tokens
-
-        spec_sequence_masks_cpu = spec_sequence_masks_cpu.clone()
-        spec_sequence_masks_cpu[fold_indices] = True
-        num_accepted_tokens = num_accepted_tokens.clone()
-        num_accepted_tokens[fold_indices.to(num_accepted_tokens.device)] = self.num_spec + 1
-        return spec_sequence_masks_cpu, num_accepted_tokens
-
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -550,14 +514,13 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 )
             else:
                 # Dynamic speculative decoding can be enabled while this batch
-                # carries no draft tokens. Treat it as ordinary decode unless a
-                # stateful spec-width prompt chunk must use the spec branch.
+                # carries no draft tokens. Treat it as ordinary decode or
+                # prefill according to the live request metadata.
                 spec_sequence_masks_cpu.zero_()
-            spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
-                m,
-                spec_sequence_masks_cpu,
-                num_accepted_tokens,
-            )
+            # A spec-sized prefill tail must remain on the live prefill path.
+            # Folding it into spec metadata would force an all-token-accepted
+            # state commit and corrupt conv/recurrent state in concurrent
+            # batches.
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:
                 spec_sequence_masks = None


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Keep unfinished prompt chunks on the GDN prefill path even when their query length matches the speculative decode width. Remove the conversion to speculative metadata and its forced all-token acceptance, which can incorrectly commit convolution and recurrent state.

This is an independent GDN metadata fix. It contains no prerequisite commits and does not change the runner's graph dispatcher.

### Does this PR introduce _any_ user-facing change?

Yes. Short prefill tails retain their prefill state-update semantics when speculative decoding is enabled.

### How was this patch tested?

- Updated `tests/ut/ops/test_gdn_attn_builder.py` to cover first and stateful speculative-width prompt chunks, asserting that both remain prefill with no speculative acceptance metadata.
- GitHub pre-commit and CPU UT passed on the current head `7352e40f9` (4163 passed, 38 skipped). Device CI awaits a maintainer test label.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
