### PR TITLE
[CI] Disable backend autoload when building the C++ cache

### DIFF
--- a/.github/workflows/_build_csrc_cache.yaml
+++ b/.github/workflows/_build_csrc_cache.yaml
@@ -168,6 +168,8 @@ jobs:
         env:
           SOC_VERSION: ${{ fromJSON(inputs.target).soc_version }}
           MAX_JOBS: '16'
+          # CMake probes torch in build containers without an NPU runtime.
+          TORCH_DEVICE_BACKEND_AUTOLOAD: '0'
         run: |
           source /usr/local/Ascend/ascend-toolkit/set_env.sh
           source /usr/local/Ascend/nnal/atb/set_env.sh


### PR DESCRIPTION
### What this PR does / why we need it?

The A3 C++ cache build in #16241 fails while CMake locates PyTorch: `import torch` automatically loads `torch_npu`, which imports Triton and fails backend discovery in the build container.

Set `TORCH_DEVICE_BACKEND_AUTOLOAD=0` for the existing install/build step. Its editable-build and CMake subprocesses inherit the setting, so package discovery does not initialize a device backend. This follows the setting already used by CPU test jobs.

### Does this PR introduce _any_ user-facing change?

No. The setting is scoped to the CI C++ cache build step.

### How was this patch tested?

- Traced the failure in [the A3 cache build log](https://github.com/vllm-project/vllm-ascend/actions/runs/34473285907/job/102864106772) to `cmake/utils.cmake` importing Torch and triggering backend autoload. The exception explicitly recommends this environment setting.
- Parsed the workflow YAML and checked that the setting is the string `0` in the install/build step.
- `git diff --check` and Linux GitHub pre-commit passed on `5a021b2d2`. CPU CI is queued; an actual A3 cache rebuild is still required.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
