### PR TITLE
[BugFix][Attention] Avoid A2 head-256 paged FIA non-finite output

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -484,6 +484,84 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.impl.forward_fused_infer_attention.assert_called_once()
         self.assertIs(result, output)
 
+    def test_w8a8_head_256_chunked_prefill_gathers_paged_kv(self):
+        impl = AscendAttentionBackendImpl(
+            num_heads=4,
+            head_size=256,
+            scale=1.0,
+            num_kv_heads=2,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            logits_soft_cap=None,
+            attn_type=self.attention_type.DECODER,
+            kv_sharing_target_layer_name=None,
+        )
+        impl._use_dense_kv_for_w8a8_head_256_prefill = True
+        impl.key_cache = torch.randn(4, 128, 2, 256)
+        impl.value_cache = torch.randn_like(impl.key_cache)
+        query = torch.randn(2, 4, 256)
+        current_key = torch.randn(2, 2, 256)
+        current_value = torch.randn_like(current_key)
+        output = torch.empty_like(query)
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        metadata.actual_seq_lengths_q = [2]
+        metadata.seq_lens_list = [130]
+        metadata.block_tables = torch.tensor([[0, 1]])
+        metadata.attn_mask = None
+        metadata.causal = True
+        metadata.num_decodes = 0
+        metadata.num_prefills = 1
+        dense_key = torch.randn(130, 2, 256)
+        dense_value = torch.randn_like(dense_key)
+
+        with (
+            patch(
+                "vllm_ascend.ascend_forward_context.get_forward_context",
+                return_value=MagicMock(capturing=False),
+            ),
+            patch.object(
+                attn_module.device_utils,
+                "get_dense_prefill_kv",
+                return_value=(dense_key, dense_value, [130]),
+            ) as gather_kv,
+            patch.object(
+                attn_module.DeviceOperator,
+                "npu_fused_infer_attention_score",
+                return_value=(torch.ones_like(query), None),
+            ) as fused_attention,
+        ):
+            result = impl.forward_fused_infer_attention(
+                query,
+                current_key,
+                current_value,
+                metadata,
+                output,
+                (impl.key_cache, impl.value_cache),
+            )
+
+        gather_kv.assert_called_once()
+        call_kwargs = fused_attention.call_args.kwargs
+        self.assertIsNone(call_kwargs["block_table"])
+        self.assertEqual(call_kwargs["actual_seq_lengths_kv"], [130])
+        self.assertIs(call_kwargs["key"], dense_key)
+        self.assertIs(call_kwargs["value"], dense_value)
+        self.assertTrue(torch.equal(result, torch.ones_like(query)))
+
+    def test_fia_params_rejects_incomplete_kv_cache(self):
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        self.impl.key_cache = torch.empty(1, 1, 1, 1)
+        self.impl.value_cache = None
+
+        with self.assertRaisesRegex(RuntimeError, "KV cache is not fully initialized"):
+            self.impl._get_fia_params(
+                torch.empty(1, 1, 1),
+                torch.empty(1, 1, 1),
+                metadata,
+            )
+
     @patch("vllm_ascend.attention.attention_v1.using_paged_attention", return_value=True)
     def test_decode_uses_paged_attention(self, mock_using_pa):
         query = torch.randn(2, 8, FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE)

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -45,7 +45,11 @@ _STANDARD_CAPABILITIES = frozenset(
 )
 
 _EXPECTED_CAPABILITIES = {
-    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.FIA_HEAD_256_PAGED_PREFILL_WORKAROUND,
+        HardwareCapability.NPU_TOP_K_TOP_P,
+    },
     AscendDeviceType.A3: _STANDARD_CAPABILITIES
     | {
         HardwareCapability.CANN_MEGAMOE,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -60,6 +60,7 @@ from vllm_ascend.compilation.acl_graph import (
     update_draft_graph_params_workspaces,
     update_graph_params_workspaces,
 )
+from vllm_ascend.device import utils as device_utils
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
@@ -506,6 +507,13 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self._use_layer_aware_fia_graph_replay = needs_layer_aware_fia_graph_replay()
         self._use_max_workspace_for_fia_graph = self._use_layer_aware_fia_graph_replay
         self.sinks = sinks
+        quant_description = getattr(self.vllm_config.quant_config, "quant_description", None)
+        self._use_dense_kv_for_w8a8_head_256_prefill = (
+            self.head_size == device_utils.FIA_TND_W8A8_PAGED_PREFILL_FALLBACK_HEAD_SIZE
+            and isinstance(quant_description, dict)
+            and "W8A8_DYNAMIC" in quant_description.values()
+            and get_current_hardware_profile().supports(HardwareCapability.FIA_HEAD_256_PAGED_PREFILL_WORKAROUND)
+        )
         self.layerIndex = 0
         # Some mixed-attention models cannot rely on the iteration order of
         # attn_metadata during graph replay. Record the captured layer name only
@@ -1304,9 +1312,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 ):
                     self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
 
-            if self.key_cache is None:
+            if self.key_cache is None or self.value_cache is None:
                 raise RuntimeError(
-                    f"key_cache is None in _get_fia_params for mode {attn_metadata.attn_state}. kv_cache={kv_cache}"
+                    f"KV cache is not fully initialized for mode {attn_metadata.attn_state}: "
+                    f"key_cache={self.key_cache is not None}, value_cache={self.value_cache is not None}"
                 )
 
         if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
@@ -1464,6 +1473,26 @@ class AscendAttentionBackendImpl(AttentionImpl):
                     return self._forward_fia_chunked_prefill_split(
                         query, key, value, key, passed_value, block_size, block_table, attn_metadata, output
                     )
+                if (
+                    self._use_dense_kv_for_w8a8_head_256_prefill
+                    and attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill
+                    and block_table is not None
+                ):
+                    # A2 FIA can return non-finite values for a short continuation
+                    # prefill with ModelSlim W8A8_DYNAMIC and 256-wide heads. The
+                    # dense TND path is numerically stable for the same Q/K/V.
+                    key, value, actual_seq_lengths_kv = device_utils.get_dense_prefill_kv(
+                        key,
+                        value,
+                        attn_metadata,
+                        num_tokens,
+                        self.key_cache,
+                        self.value_cache,
+                        self.num_kv_heads,
+                        self.head_size,
+                        False,
+                    )
+                    block_table = None
                 attn_output, _ = DeviceOperator.npu_fused_infer_attention_score(
                     query=query,
                     key=key,

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -29,6 +29,7 @@ class HardwareCapability(Enum):
     DSV4_COMPRESSED_CACHE = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
     DYNAMIC_MX_QUANT_SCALE_ALG_ONE = auto()
+    FIA_HEAD_256_PAGED_PREFILL_WORKAROUND = auto()
     FP8_ATTENTION = auto()
     FUSED_MOE_COMPATIBILITY = auto()
     FUSED_SWIGLU_TUNING_ARGS = auto()
@@ -166,7 +167,11 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
             moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
             quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.NPU_TOP_K_TOP_P},
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.FIA_HEAD_256_PAGED_PREFILL_WORKAROUND,
+                HardwareCapability.NPU_TOP_K_TOP_P,
+            },
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,

--- a/vllm_ascend/device/utils.py
+++ b/vllm_ascend/device/utils.py
@@ -21,6 +21,7 @@ import torch
 import torch_npu
 
 FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE = 512
+FIA_TND_W8A8_PAGED_PREFILL_FALLBACK_HEAD_SIZE = 256
 SWA_INT_MAX = 2147483647
 
 
@@ -42,7 +43,7 @@ def npu_large_head_prefill_attention(
     # cases on an NPU attention op instead of falling back to Python.
     num_tokens = attn_metadata.actual_seq_lengths_q[-1]
     query = query[:num_tokens]
-    key, value, actual_seq_lengths_kv = _get_large_head_prefill_kv(
+    key, value, actual_seq_lengths_kv = get_dense_prefill_kv(
         key,
         value,
         attn_metadata,
@@ -76,7 +77,7 @@ def npu_large_head_prefill_attention(
     return attn_output, None
 
 
-def _get_large_head_prefill_kv(
+def get_dense_prefill_kv(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_metadata: Any,
@@ -87,6 +88,7 @@ def _get_large_head_prefill_kv(
     head_size: int,
     is_prefill_no_cache: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Return dense TND KV and cumulative lengths for a prefill call."""
     # PrefillNoCache already has dense TND key/value tensors. Chunked prefill
     # may need historical paged KV cache gathered back to dense TND.
     if is_prefill_no_cache or key_cache is None or value_cache is None:
@@ -120,6 +122,7 @@ def _gather_paged_kv_to_dense(
     num_kv_heads: int,
     head_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather valid tokens from paged KV cache into dense TND tensors."""
     # npu_fusion_attention consumes dense TND KV, while cached prefill KV is
     # stored by blocks. Gather only valid tokens from the block table.
     block_size = key_cache.shape[1]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR is the Dense FIA correctness fix split out of #16013 so that the segmented Hybrid KV Cache COW fix and this operator-path workaround can be reviewed and merged independently.

On Ascend 910B3/A2, paged FIA can return non-finite values for a continuation-prefill path with:

- attention head size 256;
- `AscendAttentionState.ChunkedPrefill`;
- an existing paged KV cache represented by a non-null block table.

The failure was reproduced with a Qwen3.6-27B ModelSlim `W8A8_DYNAMIC` checkpoint, but the implementation does not inspect `quant_description`: that field is quantizer-specific metadata rather than a reliable description of the failing FIA execution path.

The problem is not dependent on prefix caching or `prefix_match_unit`. It can be reproduced with prefix caching disabled when a prompt is split by `--max-num-batched-tokens`: the later chunk becomes continuation prefill and reads historical KV through the paged FIA path.

The numerical probe isolated the failure to that FIA invocation. Q/K/V were finite, paged cache contents were finite, and the same effective tensors produced finite output through dense-TND FIA. This PR therefore gathers only the valid paged KV tokens into dense TND and calls FIA without a block table for the affected path.

The fallback is deliberately gated twice:

1. At backend initialization: A2 hardware capability and head size 256.
2. At runtime: `ChunkedPrefill` with a non-null block table.

All other hardware, head sizes, decode calls, and prefill-without-cache calls retain the existing path. No new environment variable or public option is introduced.

The existing paged-to-dense helper is exposed as `get_dense_prefill_kv` because it now serves both the large-head fallback and this attention backend path. Its internal `_gather_paged_kv_to_dense` implementation remains private. The gather supports both NHD and the newly added HND/BNSD KV cache layouts.

### Does this PR introduce _any_ user-facing change?

Yes. Affected A2 head-size-256 requests no longer produce non-finite attention output and degenerate text during continuation prefill.

The fallback adds a paged-KV gather and temporary dense KV tensors only on affected continuation-prefill calls. It can increase TTFT and temporary HBM use for those requests, but it does not change decode performance or unaffected configurations.

### How was this patch tested?

#### Unit coverage

```bash
python -m pytest -q \
  tests/ut/attention/test_attention_v1.py \
  tests/ut/device/test_hardware_profile.py
```

The tests verify that the head-256/chunked-prefill path gathers dense KV, removes the block table before FIA, passes corrected cumulative KV lengths, supports both NHD and HND/BNSD cache layouts, and enables the workaround capability only for A2.

The same core implementation and unit tests previously passed the complete #16013 CI matrix on A2, A3, and 310P. This independent PR is rebased onto the latest `origin/main`, and its CI validates the updated five-file change set.

Local `py_compile` and `git diff --check` pass. The current macOS checkout does not contain the NPU pytest dependencies, so hardware results below are from the Ascend development container.

#### Real-weight A2 reproduction

Hardware: 2 x Ascend 910B3 (A2), TP=2  
Checkpoint: Qwen3.6-27B ModelSlim W8A8_DYNAMIC

With prefix caching disabled and `--max-num-batched-tokens 1296`, an exact 1309-token prompt forces continuation prefill independently of fine-grained prefix matching.

| Build | Serial result | Concurrent result |
| --- | --- | --- |
| Before | 3/3 returned degenerate `!!!!!!!!` output | 1/8 returned degenerate output |
| After | 5/5 identical normal output | 8/8 identical normal output |

Additional probes confirmed that the paged cache was finite and bitwise stable while paged FIA produced non-finite output; dense-TND FIA over the same effective KV remained finite.

After the fix, warm serial smoke-test latency was approximately 1.59-1.72 s and the eight-request concurrent run was approximately 1.88-2.10 s per request. These are correctness smoke measurements rather than a formal performance benchmark.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
