### PR TITLE
[Test] Temporarily skip DeepSeek-V4 DSpark E2E test

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py
@@ -150,6 +150,7 @@ def test_deepseek_v4_dsa_pcp_mtp_full_decode_only() -> None:
     )
 
 
+@pytest.mark.skip(reason="Temporarily skip DSpark until the acceptance issue is resolved.")
 @pytest.mark.e2e_model(DSPARK_MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",


### PR DESCRIPTION
### What this PR does / why we need it?

Temporarily skip `test_deepseek_v4_dsa_pcp_dspark` while the DSpark acceptance issue is being investigated. The MTP test remains enabled.

### Does this PR introduce _any_ user-facing change?

No. This only skips the affected E2E test.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
