### PR TITLE
[CI][nightly] Add Qwen3-8B and Qwen3.8-27B spec decode nightly tests

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -179,6 +179,10 @@ a3:
         config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 2
+      - name: Qwen3.8-27B-Dflash2-A3
+        config_file_path: Qwen3.8_27B_dflash2_A3.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
+        size: 2
   single_node:
     test_config:
       - name: mtpx-deepseek-r1-0528-w8a8
@@ -265,6 +269,9 @@ a3:
       - name: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml
+      - name: Qwen3_8B_dflash_A3
+        os: linux-aarch64-a3-16
+        config_file_path: Qwen3_8B_dflash_A3.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.8_27B_dflash2_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.8_27B_dflash2_A3.yaml
@@ -1,0 +1,46 @@
+test_cases:
+  - name: "Qwen3.8-27B-Dflash2-A3"
+    model: "Qwen/Qwen3.8-27B"
+    envs:
+      MP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_TRANSFER_TIMEOUT: "600"
+      HCCL_EXEC_TIMEOUT: "3600"
+      HCCL_CONNECT_TIMEOUT: "3600"
+      HCCL_BUFFSIZE: "512"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      VLLM_USE_MODELSCOPE: "true"
+      SERVER_PORT: "DEFAULT_PORT"
+    server_cmd:
+      - "--tensor-parallel-size"
+      - "2"
+      - "--data-parallel-size"
+      - "1"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-model-len"
+      - "16384"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--max-num-seqs"
+      - 16"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--trust-remote-code"
+      - "--compilation-config"
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - "--additional-config"
+      - '{"enable_cpu_binding": true}'
+      - "--speculative-config"
+      - '{"method":"dflash", "model": "z-lab/Qwen3.8-27B-Dflash2", "num_speculative_tokens":8, "enforce_eager":true}'
+    benchmarks:
+      spec_decode:
+        case_type: spec_decode
+        dataset_path: vllm-ascend/gsm8k
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 8192
+        batch_size: 16
+        baseline: [0.94, 0.86, 0.79, 0.73, 0.66, 0.60, 0.55, 0.50]
+        threshold: 0.05

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3_8B_Dflash_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3_8B_Dflash_A3.yaml
@@ -1,0 +1,46 @@
+test_cases:
+  - name: "Qwen3-8B-DFlash-A3"
+    model: "Qwen/Qwen3-8B"
+    envs:
+      MP_PROC_BIND: "false"
+      OMP_NUM_THREADS: "1"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_TRANSFER_TIMEOUT: "600"
+      HCCL_EXEC_TIMEOUT: "3600"
+      HCCL_CONNECT_TIMEOUT: "3600"
+      HCCL_BUFFSIZE: "512"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      VLLM_USE_MODELSCOPE: "true"
+      SERVER_PORT: "DEFAULT_PORT"
+    server_cmd:
+      - "--tensor-parallel-size"
+      - "1"
+      - "--data-parallel-size"
+      - "1"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-model-len"
+      - "16384"
+      - "--max-num-batched-tokens"
+      - "8192"
+      - "--max-num-seqs"
+      - "16"
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--trust-remote-code"
+      - "--no-enable-prefix-caching"
+      - "--compilation_config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--speculative-config"
+      - '{"method":"dflash", "model": "z-lab/Qwen3-8B-Dflash-b16", "num_speculative_tokens":8, "enforce_eager": true}'
+    benchmarks:
+      spec_decode:
+        case_type: spec_decode
+        dataset_path: vllm-ascend/gsm8k
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 8192
+        batch_size: 16
+        temperature: 0
+        baseline: [0.86, 0.73, 0.61, 0.52, 0.45, 0.38, 0.33, 0.28]
+        threshold: 0.05


### PR DESCRIPTION
### What this PR does / why we need it?
Add nightly tests for Qwen3-8B and Qwen3.8-27B acceptance rate per position.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Nightly tests passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
