### PR TITLE
[BugFix][Attention] Isolate PCP global RoPE runtime buffers

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -1707,13 +1707,13 @@ def test_pcp_builders_keep_global_rope_separate_from_reused_local_metadata(monke
         )
         AscendDSAMetadataBuilder.build(builder, 0, common, common_ratio_to_sas_metadata=shared)
 
-    addresses = {}
+    addresses: dict[tuple[int | str, str], int] = {}
     for count in (4, 16, 6):
         global_pos, local_pos = torch.arange(count), torch.arange(count - 1) + 5
-        local_cache = {}
+        local_cache: dict[str, Any] = {}
         global_caches = []
         for index, builder in enumerate(builders):
-            global_cache = {}
+            global_cache: dict[str, Any] = {}
             build(builder._global_metadata_builder, global_pos, global_cache)
             global_caches.append(global_cache)
             build(builder, local_pos, local_cache)

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -53,6 +53,7 @@ from vllm_ascend.models.deepseek_v4.indexer import (
     AscendIndexerMetadata,
     IndexerOverlapPlan,
 )
+from vllm_ascend.ops import rope_dsv4
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataStage,
     DeviceMetadataTask,
@@ -1665,6 +1666,66 @@ def test_dsa_backend_selects_pcp_and_rejects_legacy_cp():
         ):
             with pytest.raises(ValueError, match="cannot be enabled at the same time"):
                 get_backend_cls()
+
+
+def test_pcp_builders_keep_global_rope_separate_from_reused_local_metadata(monkeypatch):
+    state = rope_dsv4.RopeGlobalState()
+    monkeypatch.setattr(rope_dsv4, "_ROPE_STATE", state)
+    angles = torch.arange(32 * 4, dtype=torch.float32).reshape(32, 1, 1, 4)
+    state.full_rope_cache["config"] = (angles.cos(), angles.sin())
+    state.registry_summary["config"] = {"default"}
+    state.layer_info["layer"] = ("config", ["default"])
+    state.runtime_buffer["config"] = {"default": (torch.empty(16, 1, 1, 4), torch.empty(16, 1, 1, 4))}
+    config = _make_vllm_config()
+    config.parallel_config.prefill_context_parallel_size = 2
+    with patch("vllm_ascend.attention.context_parallel.dsa_cp.get_pcp_group") as pcp_group:
+        pcp_group.return_value.rank_in_group = 0
+        builders = [
+            AscendDSAPCPMetadataBuilder(_make_kv_cache_spec(4), ["layer"], config, torch.device("cpu"))
+            for _ in range(2)
+        ]
+    for builder in builders:
+        builder.decode_threshold = builder._global_metadata_builder.decode_threshold = 16
+        monkeypatch.setattr(builder, "build_req_metadata", MagicMock())
+        monkeypatch.setattr(builder._global_metadata_builder, "build_req_metadata", MagicMock())
+
+    def build(builder, positions, shared):
+        offsets = torch.tensor([0, len(positions)], dtype=torch.int32)
+        common = SimpleNamespace(
+            num_reqs=1,
+            num_actual_tokens=len(positions),
+            num_input_tokens=len(positions),
+            max_query_len=len(positions),
+            context_parallel_metadata=None,
+            query_start_loc=offsets,
+            query_start_loc_cpu=offsets,
+            positions=positions,
+            seq_lens=torch.tensor([32]),
+            _seq_lens_cpu=torch.tensor([32]),
+            block_table_tensor=torch.tensor([[0]], dtype=torch.int32),
+            attn_state=MagicMock(),
+        )
+        AscendDSAMetadataBuilder.build(builder, 0, common, common_ratio_to_sas_metadata=shared)
+
+    addresses = {}
+    for count in (4, 16, 6):
+        global_pos, local_pos = torch.arange(count), torch.arange(count - 1) + 5
+        local_cache = {}
+        global_caches = []
+        for index, builder in enumerate(builders):
+            global_cache = {}
+            build(builder._global_metadata_builder, global_pos, global_cache)
+            global_caches.append(global_cache)
+            build(builder, local_pos, local_cache)
+            for key, full in zip(("cos", "sin"), state.full_rope_cache["config"]):
+                local = local_cache[key]["layer"]
+                torch.testing.assert_close(local, full[local_pos], rtol=0, atol=0)
+                assert local.data_ptr() == addresses.setdefault(("local", key), local.data_ptr())
+                for cached in global_caches:
+                    torch.testing.assert_close(cached[key]["layer"], full[global_pos], rtol=0, atol=0)
+                global_tensor = global_cache[key]["layer"]
+                assert global_tensor.data_ptr() != local.data_ptr()
+                assert global_tensor.data_ptr() == addresses.setdefault((index, key), global_tensor.data_ptr())
 
 
 def test_pcp_metadata_builds_from_manager_global_view():

--- a/tests/ut/ops/test_rope_dsv4.py
+++ b/tests/ut/ops/test_rope_dsv4.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm_ascend.ops import rope_dsv4
+
+
+@pytest.fixture
+def rope_state(monkeypatch):
+    state = rope_dsv4.RopeGlobalState()
+    monkeypatch.setattr(rope_dsv4, "_ROPE_STATE", state)
+    for config, width in (("small", 4), ("large", 8)):
+        angles = torch.arange(32 * width, dtype=torch.float32).reshape(32, 1, 1, width)
+        state.full_rope_cache[config] = (angles.cos(), angles.sin())
+        state.registry_summary[config] = {"default", "compressed"}
+        state.runtime_buffer[config] = {}
+        state.spec_runtime_buffer[config] = {}
+        for group in state.registry_summary[config]:
+            state.layer_info[f"{config}.{group}"] = (config, [group])
+            state.runtime_buffer[config][group] = (torch.empty(16, 1, 1, width), torch.empty(16, 1, 1, width))
+            state.spec_runtime_buffer[config][group] = (
+                [torch.empty(16, 1, 1, width)],
+                [torch.empty(16, 1, 1, width)],
+            )
+    return state
+
+
+def _assert_rope(state, result, positions):
+    for config, cache in state.full_rope_cache.items():
+        for group, pos in positions.items():
+            for proxy, full in zip(result, cache):
+                torch.testing.assert_close(proxy[f"{config}.{group}"], full[pos], rtol=0, atol=0)
+
+
+def test_global_local_rope_buffers_survive_interleaved_cache_groups(rope_state):
+    # Each PCP cache-group builder owns its global buffers, while local
+    # metadata reuses the first group's result for the rest of the step.
+    global_buffers = [{}, {}, {}]
+    addresses = {}
+    for count in (2, 16, 5, 16, 2):
+        global_pos = {"default": torch.arange(count), "compressed": torch.arange(count) + 1}
+        local_pos = {group: pos.flip(0)[: max(1, count - 1)] + 3 for group, pos in global_pos.items()}
+        global_results = []
+        for group_index, buffers in enumerate(global_buffers):
+            global_result = rope_dsv4.get_cos_and_sin_dsa(global_pos, use_cache=True, runtime_buffer=buffers)
+            global_results.append(global_result)
+            if group_index == 0:
+                local_result = rope_dsv4.get_cos_and_sin_dsa(local_pos, use_cache=True)
+            # A later global build must preserve the already-created local view.
+            _assert_rope(rope_state, local_result, local_pos)
+            for result in global_results:
+                _assert_rope(rope_state, result, global_pos)
+            for config, groups in buffers.items():
+                for group, pair in groups.items():
+                    for index, buf in enumerate(pair):
+                        default = rope_state.runtime_buffer[config][group][index]
+                        assert buf.shape == default.shape
+                        assert buf.data_ptr() != default.data_ptr()
+                        key = (group_index, config, group, index)
+                        assert buf.data_ptr() == addresses.setdefault(key, buf.data_ptr())
+        assert len(set(addresses.values())) == len(addresses)
+
+
+@pytest.mark.parametrize("draft_index", [None, 1])
+def test_uncached_rope_does_not_allocate_caller_buffers(rope_state, draft_index):
+    buffers = {}
+    positions = {"default": torch.tensor([3, 1, 7])}
+    result = rope_dsv4.get_cos_and_sin_dsa(positions, draft_index=draft_index, runtime_buffer=buffers)
+    _assert_rope(rope_state, result, positions)
+    assert buffers == {}
+
+
+def test_draft_rope_keeps_existing_speculative_buffers(rope_state):
+    buffers = {}
+    positions = {"default": torch.tensor([3, 1, 7])}
+    result = rope_dsv4.get_cos_and_sin_dsa(positions, use_cache=True, draft_index=1, runtime_buffer=buffers)
+    _assert_rope(rope_state, result, positions)
+    for config in rope_state.full_rope_cache:
+        for index, proxy in enumerate(result):
+            assert proxy[f"{config}.default"].data_ptr() == (
+                rope_state.spec_runtime_buffer[config]["default"][index][0].data_ptr()
+            )
+    assert buffers == {}

--- a/tests/ut/ops/test_rope_dsv4.py
+++ b/tests/ut/ops/test_rope_dsv4.py
@@ -36,8 +36,8 @@ def _assert_rope(state, result, positions):
 def test_global_local_rope_buffers_survive_interleaved_cache_groups(rope_state):
     # Each PCP cache-group builder owns its global buffers, while local
     # metadata reuses the first group's result for the rest of the step.
-    global_buffers = [{}, {}, {}]
-    addresses = {}
+    global_buffers: list[dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]]] = [{}, {}, {}]
+    addresses: dict[tuple[int, str, str, int], int] = {}
     for count in (2, 16, 5, 16, 2):
         global_pos = {"default": torch.arange(count), "compressed": torch.arange(count) + 1}
         local_pos = {group: pos.flip(0)[: max(1, count - 1)] + 3 for group, pos in global_pos.items()}
@@ -64,7 +64,7 @@ def test_global_local_rope_buffers_survive_interleaved_cache_groups(rope_state):
 
 @pytest.mark.parametrize("draft_index", [None, 1])
 def test_uncached_rope_does_not_allocate_caller_buffers(rope_state, draft_index):
-    buffers = {}
+    buffers: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] = {}
     positions = {"default": torch.tensor([3, 1, 7])}
     result = rope_dsv4.get_cos_and_sin_dsa(positions, draft_index=draft_index, runtime_buffer=buffers)
     _assert_rope(rope_state, result, positions)
@@ -72,7 +72,7 @@ def test_uncached_rope_does_not_allocate_caller_buffers(rope_state, draft_index)
 
 
 def test_draft_rope_keeps_existing_speculative_buffers(rope_state):
-    buffers = {}
+    buffers: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] = {}
     positions = {"default": torch.tensor([3, 1, 7])}
     result = rope_dsv4.get_cos_and_sin_dsa(positions, use_cache=True, draft_index=1, runtime_buffer=buffers)
     _assert_rope(rope_state, result, positions)

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -2161,6 +2161,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
             vllm_config,
             device,
             metadata_cls=dsa_v1.AscendDSAMetadata,
+            rope_runtime_buffer={},
         )
         self._pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         self._pcp_rank = get_pcp_group().rank_in_group

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -593,8 +593,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         device: torch.device,
         metadata_cls: type[AscendDSAMetadata] | None = None,
         supports_dcp_with_varlen: bool = False,
+        rope_runtime_buffer: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] | None = None,
     ):
         self.kv_cache_spec = kv_cache_spec
+        self.rope_runtime_buffer = rope_runtime_buffer
         self.metadata_cls = metadata_cls if metadata_cls is not None else AscendDSAMetadata
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -842,6 +844,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             cos, sin = get_cos_and_sin_dsa(
                 input_positions,
                 use_cache=self.num_prefills == 0,
+                runtime_buffer=self.rope_runtime_buffer,
             )
             self.common_ratio_to_sas_metadata["cos"] = cos
             self.common_ratio_to_sas_metadata["sin"] = sin

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -84,6 +84,7 @@ def get_cos_and_sin_dsa(
     positions: torch.Tensor | dict[str, torch.Tensor],
     use_cache: bool = False,
     draft_index: int | None = None,
+    runtime_buffer: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] | None = None,
 ):
     if isinstance(positions, torch.Tensor):
         pos_map = {"default": positions}
@@ -112,6 +113,20 @@ def get_cos_and_sin_dsa(
 
                 if group_buffers is None:
                     continue
+
+                # PCP's global KV update and rank-local attention use different
+                # positions in the same step. Keep caller-owned buffers stable
+                # for graph replay without aliasing the default local cache.
+                if runtime_buffer is not None and draft_index is None:
+                    isolated_groups = runtime_buffer.setdefault(config_key, {})
+                    if group_name not in isolated_groups:
+                        # Allocate the full registered capacity even when the
+                        # first call is a small warmup/capture batch.
+                        isolated_groups[group_name] = (
+                            torch.empty_like(group_buffers[0]),
+                            torch.empty_like(group_buffers[1]),
+                        )
+                    group_buffers = isolated_groups[group_name]
 
                 buf_cos, buf_sin = group_buffers
                 num_tokens = pos_tensor.size(0)


### PR DESCRIPTION
### What this PR does / why we need it?

Fix RoPE runtime-buffer aliasing between PCP's canonical global KV-update metadata and rank-local attention metadata.

With DSpark verification, short query rows can put both builds on the cached RoPE path even though their positions differ. Each PCP cache-group builder constructs global metadata, then local metadata. Local RoPE proxies are reused through the step's shared metadata, but a later cache group's global build writes the same process-wide runtime buffers again. The local proxy can then contain global-position values, corrupting target hidden states, generated tokens and speculative acceptance.

Each PCP global metadata builder now owns a persistent RoPE buffer map keyed by configuration and group. Each cos/sin pair is allocated once at the full registered capacity; subsequent calls use the existing in-place gather. Addresses remain stable from small warmup/capture batches through larger replay batches. Local/default, uncached prefill and speculative draft-buffer behavior is preserved; no global cache disabling, per-step cloning or version-specific branch is needed.

Buffer lifetime follows the global builder. Extra storage per requested configuration/group per global builder is `2 * max_num_batched_tokens * rotary_dim * element_size`; the global Tensor-position path requests only the default group. Distinct PCP cache-group builders own separate maps. Non-PCP paths allocate no extra buffers.

This independent fix branch starts from upstream main `f4b6bd05f05717e10e4521a78f4b3beba5bb5a99`. It is separate from main2main PR #16009 and changes none of #16009, #15627, #15965 or #16216. The PR-wide diff contains only three production files and two UT files; pins, release tags, skips, thresholds, golden data and e2e sources are unchanged. The shared-buffer structure predates the historical upgrade experiment; there is no evidence that #16009 or `6f3c34a` introduced it.

### Does this PR introduce _any_ user-facing change?

Correct position encodings and generation/acceptance behavior for affected PCP + DSpark batches. No configuration or public API change.

### How was this patch tested?

**Current branch validation — actual pytest logs inspected:**

| Validation | vLLM main `b2f685834a6456197e7033966fdef52a23f1abcd` | release `v0.28.0` / `2cf0a6915ce544dc493a0990f2ea38d81601128a` |
|---|---|---|
| RoPE + DSA unit suites | 56 passed | 56 passed |
| Original four-card PCP DSpark e2e | [1 passed, 525.72 s](https://github.com/vllm-project/vllm-ascend/actions/runs/34554944313/job/103126093187) | [1 passed, 524.02 s](https://github.com/vllm-project/vllm-ascend/actions/runs/34554944313/job/103126093201) |

The e2e run was triggered once with the repository's supported comment syntax:
```
/e2e tests/e2e/pull_request/four_card/context_parallel/test_deepseek_v4.py::test_deepseek_v4_dsa_pcp_dspark
```
The logs confirm the exact pytest node, model, version checkouts, full graph capture and final passing pytest summaries. Original model, prompts, parameters, prefix assertions, acceptance thresholds and 0.03 tolerance remain intact. No probes, controlled admission, extra test plugins or assertion changes were committed. The passing test does not print final aggregate acceptance rates; periodic metric-log rates are not substituted for the assertion's aggregate metrics.

**Commit provenance:** the e2e workflow pins fix commit `c14993202b111e5c496dc4ffa8ce946e226f4fe7` and rebases it on fixed upstream snapshot `fa9f8a7f3d57d28122109dd51a50d91d9f53a805`. Final head `ca169f36aef921203a9857cb15cbf12a4ef695a1` only adds UT dictionary annotations required by mypy. All production files and the original e2e source are byte-identical between these commits; this is not presented as a final-head e2e invocation. The two 56-test suites were rerun after that annotation follow-up, and the remote tested tracked tree was verified against the final signed commit.

The new numerical builder regression fails on an independent, unmodified upstream-base checkout: 12/16 elements differ after global/local builds (maximum absolute difference 1.088031530380249). It passes with the fix. Coverage includes global → local → next global cache-group builds, preservation of both outputs, repeated calls, full-capacity growth, address stability, multiple RoPE configurations/groups, and unchanged uncached/draft paths.

```bash
pytest -q tests/ut/ops/test_rope_dsv4.py \
  tests/ut/attention/test_dsa_v1.py tests/ut/attention/test_dsa_cp.py
```

Final-head repository CI:
- [CPU UT](https://github.com/vllm-project/vllm-ascend/actions/runs/34555534152/job/103128256661): **4190 passed, 38 existing skips**, actual pytest summary inspected.
- [Pre-commit](https://github.com/vllm-project/vllm-ascend/actions/runs/34555534152/job/103127322490): all hooks passed; full production/example/test mypy checks passed for Python 3.10, 3.11 and 3.12.
- Standalone Gitleaks also passed. The initial seven missing test dictionary annotations were fixed before the successful final-head checks.

**Historical causal evidence, distinct from this branch's CI:** an earlier isolated Ascend experiment with vLLM `a97dacb7106ee49f39f3d1fc6ae1800ff724e01d` reproduced third-position acceptance **0.4933095450490633**, matching the failing CI's complete outputs. With fixed diagnostic admission conditions in the same directory, the ownership fix passed, reverting it restored the exact failure, and reapplying it passed with identical tokens/counts to the first fixed run. Two subsequent original uninstrumented main singletons passed; historical release attempts were resource-blocked. Immutable causal archive SHA256: `da75a996eba465e79837c834a5b21d72e9f4b0ae811163593c5eb6ba1f4484f6`. The same Triton disk-cache seed produced both passes and failures, so cache contents are not claimed as the root cause.

The separate local four-card attempt on this branch did **not** complete: main stopped before generation because ModelScope tried to write `.mdl` through a read-only model-cache link; release was blocked before pytest by external device occupancy. Writable private metadata was prepared without downloading/modifying weights, and no external processes were stopped. These local attempts are not counted as passes or precision failures; the completed current-version device results above come from CI.

**Remaining merge gate:** `ci-gate` requires a maintainer to add `ready-precise` or `ready-all` for the repository's broader selected/full suite. The targeted dual-version `/e2e` run does not automatically satisfy that label-controlled gate. No merge is requested by this task.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
