### PR TITLE
[Ops][Feature] Support sequence parallel for Kimi K3 dense MLP and update KV cache tensor layer retrieval

### DIFF
--- a/tests/ut/kv_offload/mooncake_v2/test_base_worker.py
+++ b/tests/ut/kv_offload/mooncake_v2/test_base_worker.py
@@ -22,6 +22,19 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake.stats import MooncakeKV
 from .helpers import make_full_spec, make_sfa_indexer_spec, make_sliding_spec
 
 
+def make_kv_cache_tensor(*, size: int, layers: list[str], layer_stride: int, block_stride: int) -> KVCacheTensor:
+    """Build descriptors across the vLLM 0.28 and main field names."""
+    try:
+        return KVCacheTensor(
+            size=size,
+            layers=layers,
+            layer_stride=layer_stride,
+            block_stride=block_stride,
+        )
+    except TypeError:
+        return KVCacheTensor(size=size, shared_by=layers)
+
+
 def test_build_spec_mappings_expands_uniform_group_by_layer_spec() -> None:
     full = make_full_spec()
     sliding = make_sliding_spec()
@@ -48,7 +61,7 @@ def test_register_kv_caches_uses_config_order_and_publishes_tensor_metadata(monk
     config = KVCacheConfig(
         num_blocks=2,
         kv_cache_tensors=[
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=k_cache.nbytes + v_cache.nbytes,
                 layers=["layer.0"],
                 layer_stride=k_cache.nbytes + v_cache.nbytes,
@@ -97,7 +110,7 @@ def test_register_kv_caches_collapses_views_packed_in_one_page(monkeypatch) -> N
     config = KVCacheConfig(
         num_blocks=4,
         kv_cache_tensors=[
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=raw_cache.nbytes,
                 layers=["layer.0"],
                 layer_stride=raw_cache.nbytes,
@@ -152,7 +165,7 @@ def test_register_kv_caches_publishes_sfa_indexer_virtual_block_size(monkeypatch
     config = KVCacheConfig(
         num_blocks=2,
         kv_cache_tensors=[
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=cache.nbytes,
                 layers=["layer.0.indexer"],
                 layer_stride=cache.nbytes,
@@ -194,7 +207,7 @@ def test_register_kv_caches_rejects_missing_and_unconfigured_layers() -> None:
     config = KVCacheConfig(
         num_blocks=2,
         kv_cache_tensors=[
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=64,
                 layers=["layer.0"],
                 layer_stride=64,

--- a/tests/ut/models/test_kimi_k3_dense_sp.py
+++ b/tests/ut/models/test_kimi_k3_dense_sp.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+
+from vllm_ascend.models import kimi_k3
+
+
+@pytest.mark.parametrize("rank", range(16))
+@pytest.mark.parametrize("sequence_parallel", [False, True])
+def test_dense_adapter_preserves_token_rows(rank, sequence_parallel):
+    x = torch.arange(16 * 8, dtype=torch.float64).view(16, 8)
+    calls = []
+
+    def init(module, **kwargs):
+        nn.Module.__init__(module)
+        assert kwargs == {}
+
+    def upstream(module, value):
+        calls.append("tp_mlp")
+        return value.square() + 2
+
+    def gather(local):
+        calls.append("gather")
+        assert torch.equal(local, x[rank : rank + 1])
+        return x
+
+    def shard(value):
+        calls.append("shard")
+        return value[rank : rank + 1]
+
+    with (
+        patch.object(kimi_k3.KimiMLP, "__init__", init),
+        patch.object(kimi_k3.KimiMLP, "forward", upstream),
+        patch.object(kimi_k3, "sp_all_gather", gather),
+        patch.object(kimi_k3, "sp_shard", shard),
+    ):
+        model = kimi_k3.AscendKimiMLP(use_sequence_parallel=sequence_parallel)
+        given = x[rank : rank + 1] if sequence_parallel else x
+        result = model(given)
+        assert torch.equal(result, given.square() + 2)
+        assert calls == (["gather", "tp_mlp", "shard"] if sequence_parallel else ["tp_mlp"])

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -12,6 +12,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheTensor,
     MambaSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
@@ -21,6 +22,7 @@ from vllm_ascend.worker.v2.attn_utils import (
     _allocate_kv_cache,
     _reshape_kv_cache_v2,
     get_kv_cache_spec,
+    normalize_mamba_kv_cache_config,
 )
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
@@ -86,6 +88,56 @@ def _group(spec: MambaSpec):
         kv_cache_spec=spec,
         layer_names=["linear_attn"],
     )
+
+
+def test_normalize_uniform_mamba_groups_for_upstream_model_state():
+    spec = _mamba_spec()
+    layer_specs = {"mamba.0": spec, "mamba.1": spec}
+    wrapped = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+    assert wrapped is not None
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=list(layer_specs),
+                kv_cache_spec=wrapped,
+            )
+        ],
+    )
+
+    normalized = normalize_mamba_kv_cache_config(config)
+
+    assert normalized is not config
+    assert normalized.kv_cache_groups[0].kv_cache_spec == spec
+    assert config.kv_cache_groups[0].kv_cache_spec is wrapped
+
+
+def test_normalize_preserves_distinct_mamba_layouts():
+    specs = {
+        "mamba.0": _mamba_spec(),
+        "mamba.1": MambaSpec(
+            block_size=16,
+            shapes=((4, 3), (2, 2)),
+            dtypes=(torch.float16, torch.float32),
+        ),
+    }
+    wrapped = UniformTypeKVCacheSpecs.from_specs(specs)
+    assert wrapped is not None
+    config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=list(specs),
+                kv_cache_spec=wrapped,
+            )
+        ],
+    )
+
+    normalized = normalize_mamba_kv_cache_config(config)
+
+    assert normalized.kv_cache_groups[0].kv_cache_spec is wrapped
 
 
 def test_mamba_model_state_inherits_upstream_state_management():

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -100,7 +100,7 @@ class AscendMLABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         return num_blocks, block_size, num_kv_heads, head_size
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/base_worker.py
@@ -53,6 +53,7 @@ from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
     get_decode_context_model_parallel_world_size,
 )
+from vllm_ascend.utils import get_kv_cache_tensor_layers
 
 if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -221,7 +222,7 @@ class MooncakeBaseConnectorWorker:
         configured_layer_names: set[str] = set()
 
         for tensor_config in self.kv_cache_config.kv_cache_tensors:
-            for layer_name in tensor_config.layers:
+            for layer_name in get_kv_cache_tensor_layers(tensor_config):
                 if layer_name in configured_layer_names:
                     raise ValueError(f"Layer {layer_name!r} is referenced by more than one configured KV cache tensor.")
                 if layer_name not in self.layer_name_to_group_index:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/utils.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake/utils.py
@@ -22,6 +22,7 @@ from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
     tensor_storage_key,
 )
+from vllm_ascend.utils import get_kv_cache_tensor_layers
 
 if TYPE_CHECKING:
     from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -104,11 +105,12 @@ def collect_configured_register_regions(
             )
 
     for tensor_config in kv_cache_config.kv_cache_tensors:
-        if not tensor_config.layers:
+        layer_names = get_kv_cache_tensor_layers(tensor_config)
+        if not layer_names:
             continue
 
         cache_tensors: list[torch.Tensor] = []
-        for layer_name in tensor_config.layers:
+        for layer_name in layer_names:
             cache_tensors.extend(as_kv_cache_tensors(kv_caches.get(layer_name)))
 
         caches_by_storage: dict[int, list[torch.Tensor]] = {}

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -125,6 +125,24 @@ def _apply_ascend_attn_res(
     return torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
 
 
+class AscendKimiMLP(KimiMLP):
+    """Keep dense TP projections on replicated token rows under model SP."""
+
+    def __init__(self, *args, use_sequence_parallel: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_sequence_parallel = use_sequence_parallel
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_sequence_parallel:
+            hidden_states = sp_all_gather(hidden_states)
+        # KimiMLP.down_proj already all-reduces TP partial sums. Shard that
+        # completed result; reduce-scatter here would reduce it a second time.
+        hidden_states = super().forward(hidden_states)
+        if self.use_sequence_parallel:
+            hidden_states = sp_shard(hidden_states)
+        return hidden_states
+
+
 class AscendKimiMoE(nn.Module):
     """Kimi K3 MoE assembled from the standard vLLM MoE interfaces."""
 
@@ -416,7 +434,7 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
             )
             self.mlp = self.block_sparse_moe
         else:
-            self.mlp = KimiMLP(
+            self.mlp = AscendKimiMLP(
                 hidden_size=self.hidden_size,
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
@@ -424,6 +442,7 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
                 prefix=f"{prefix}.mlp",
                 activation_situ_beta=config.activation_situ_beta,
                 activation_situ_linear_beta=config.activation_situ_linear_beta,
+                use_sequence_parallel=use_sequence_parallel,
             )
         self.input_layernorm = RMSNorm(
             config.hidden_size,

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -71,6 +71,24 @@ if TYPE_CHECKING:
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
 
 
+def normalize_mamba_kv_cache_config(kv_cache_config: KVCacheConfig) -> KVCacheConfig:
+    """Expose identical Mamba specs to upstream MRV2 state handling."""
+    groups = []
+    for group in kv_cache_config.kv_cache_groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            inner_specs = list(spec.kv_cache_specs.values())
+            if (
+                inner_specs
+                and isinstance(inner_specs[0], MambaSpec)
+                and all(inner == inner_specs[0] for inner in inner_specs)
+            ):
+                group = replace(group, kv_cache_spec=inner_specs[0])
+        groups.append(group)
+    # Do not mutate the scheduler/connector copy of the cache configuration.
+    return replace(kv_cache_config, kv_cache_groups=groups)
+
+
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
     """Build Ascend-specific KV cache specs for v2 worker patching."""
     from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -60,7 +60,10 @@ from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_version_is
 from vllm_ascend.worker.utils import disable_compilation
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
-from vllm_ascend.worker.v2.attn_utils import build_attn_state
+from vllm_ascend.worker.v2.attn_utils import (
+    build_attn_state,
+    normalize_mamba_kv_cache_config,
+)
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -240,6 +243,9 @@ class NPUModelRunner(GPUModelRunner):
         return output
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        # vLLM 0.28 model-state code recognizes bare MambaSpec groups, while
+        # Ascend's hybrid cache planner retains per-layer uniform wrappers.
+        kv_cache_config = normalize_mamba_kv_cache_config(kv_cache_config)
         with graph_manager_wrapper(self):
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:


### PR DESCRIPTION
## What this PR does / why we need it

This is a target-only split from #16172.

- Fixes Kimi K3 dense MLP execution under model sequence parallelism by gathering token rows before the tensor-parallel MLP and sharding the already all-reduced output afterwards.
- Makes MooncakeConnectorV2 consume KV cache layer ownership through the existing descriptor-normalization helper, supporting the vLLM 0.28 `shared_by` representation and the current-main `layers` representation.
- Adds focused regression coverage for both changes.

This PR intentionally contains no speculative decoding, DSpark, draft-model graph, reduced-layer, or reduced-expert changes.

## Does this PR introduce any user-facing change?

Yes. Kimi K3 MRV2 target-only eager and FULL_DECODE_ONLY executions use the same dense TP/SP token layout, and MooncakeConnectorV2 can register vLLM 0.28 KV cache descriptors in 1P1D deployments.

## How was this patch tested?

On Ascend container with vLLM 0.28.0:

- `tests/ut/models/test_kimi_k3_dense_sp.py`: 32 passed
- `tests/ut/models/test_kimi_k3_adapter.py`: 11 passed
- `tests/ut/kv_offload/mooncake_v2/test_base_worker.py`: 13 passed
- Ruff check and Ruff format passed for all touched files.

Two-node target-only eager/FULL_DECODE_ONLY accuracy validation will be added after the deployment run.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
