### PR TITLE
[BugFix][KVCache] Allow external lookup below two retention intervals

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -149,23 +149,28 @@ class TestKVPoolScheduler(unittest.TestCase):
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_retention_interval_does_not_skip_external_lookup(self, mock_client_cls):
         """A retained checkpoint can be reused before two retention intervals."""
-        for token_count, lookup_hit in [(5083, 4096), (4083, 0), (8275, 4096)]:
-            with self.subTest(token_count=token_count):
-                mock_client_cls.reset_mock()
-                mock_client_cls.return_value.lookup.return_value = lookup_hit
-                scheduler = KVPoolScheduler(self._make_config(block_size=32), use_layerwise=False)
-                scheduler.retention_interval = 4096
-                request = MagicMock(
-                    prompt_token_ids=list(range(token_count)),
-                    num_tokens=token_count,
-                    request_id="retained-prefix",
-                    block_hashes=[b"h"] * (token_count // 32),
-                )
+        for use_eagle in (False, True):
+            for token_count, lookup_hit in [(5083, 4096), (5083, 0), (4083, 0), (8275, 4096)]:
+                with self.subTest(token_count=token_count, use_eagle=use_eagle):
+                    mock_client_cls.reset_mock()
+                    mock_client_cls.return_value.lookup.return_value = lookup_hit
+                    scheduler = KVPoolScheduler(self._make_config(block_size=4096), use_layerwise=False)
+                    scheduler.retention_interval = 4096
+                    scheduler.use_eagle = use_eagle
+                    request = MagicMock(
+                        prompt_token_ids=list(range(token_count)),
+                        num_tokens=token_count,
+                        request_id="retained-prefix",
+                        block_hashes=[b"h"] * (token_count // 4096),
+                    )
 
-                self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (lookup_hit, False))
-                mock_client_cls.return_value.lookup.assert_called_once()
-                if lookup_hit:
-                    self.assertEqual(scheduler.load_specs[request.request_id].kvpool_cached_tokens, lookup_hit)
+                    self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (lookup_hit, False))
+                    if token_count < scheduler.cache_transfer_granularity:
+                        mock_client_cls.return_value.lookup.assert_not_called()
+                    else:
+                        mock_client_cls.return_value.lookup.assert_called_once()
+                    if lookup_hit:
+                        self.assertEqual(scheduler.load_specs[request.request_id].kvpool_cached_tokens, lookup_hit)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_mtp_retains_interior_hit_and_recomputes_prompt_tail(self, mock_client_cls):

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -147,6 +147,55 @@ class TestKVPoolScheduler(unittest.TestCase):
                 self.assertEqual("r1" in scheduler.load_specs, expected > 0)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_retention_interval_does_not_skip_external_lookup(self, mock_client_cls):
+        """A retained checkpoint can be reused before two retention intervals."""
+        for token_count, lookup_hit in [(5083, 4096), (4083, 0), (8275, 4096)]:
+            with self.subTest(token_count=token_count):
+                mock_client_cls.reset_mock()
+                mock_client_cls.return_value.lookup.return_value = lookup_hit
+                scheduler = KVPoolScheduler(self._make_config(block_size=32), use_layerwise=False)
+                scheduler.retention_interval = 4096
+                request = MagicMock(
+                    prompt_token_ids=list(range(token_count)),
+                    num_tokens=token_count,
+                    request_id="retained-prefix",
+                    block_hashes=[b"h"] * (token_count // 32),
+                )
+
+                self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (lookup_hit, False))
+                mock_client_cls.return_value.lookup.assert_called_once()
+                if lookup_hit:
+                    self.assertEqual(scheduler.load_specs[request.request_id].kvpool_cached_tokens, lookup_hit)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_mtp_retains_interior_hit_and_recomputes_prompt_tail(self, mock_client_cls):
+        cases = [
+            (4096, 4096, 0),
+            (4097, 4096, 4096),
+            (5083, 4096, 4096),
+            (8192, 8192, 4096),
+            (8193, 8192, 8192),
+            (9083, 8192, 8192),
+        ]
+        for token_count, lookup_hit, expected in cases:
+            with self.subTest(token_count=token_count):
+                mock_client_cls.reset_mock()
+                mock_client_cls.return_value.lookup.return_value = lookup_hit
+                scheduler = KVPoolScheduler(self._make_config(block_size=4096), use_layerwise=False)
+                scheduler.use_eagle = True
+                request = MagicMock(
+                    prompt_token_ids=list(range(token_count)),
+                    num_tokens=token_count,
+                    request_id="mtp-prefix",
+                    block_hashes=[b"h"] * (token_count // 4096),
+                )
+
+                self.assertEqual(scheduler.get_num_new_matched_tokens(request, 0), (expected, False))
+                if expected:
+                    self.assertEqual(scheduler.load_specs[request.request_id].kvpool_cached_tokens, expected)
+                    self.assertEqual(scheduler.load_specs[request.request_id].kvpool_store_skip_tokens, lookup_hit)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_all_hit(self, mock_client_cls):
         config = self._make_config(block_size=16)
         scheduler = KVPoolScheduler(config, use_layerwise=False)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -645,13 +645,6 @@ class KVPoolScheduler:
             return 0, False
 
         prompt_token_len = len(request.prompt_token_ids)
-        if (
-            self.retention_interval is not None
-            and not self.use_layerwise
-            and prompt_token_len < 2 * self.retention_interval
-        ):
-            return 0, False
-
         if self.use_block_key_layerwise:
             token_len = self._floor_to_cache_transfer_granularity(prompt_token_len)
             if token_len < self.cache_transfer_granularity:
@@ -690,26 +683,14 @@ class KVPoolScheduler:
 
         store_skip_tokens = num_external_hit_tokens
         if self.use_eagle:
-            # Keep the draft model's recomputation zone intact: the
-            # generation-point hidden states must be freshly computed, and the
-            # local prefix-cache path already drops its trailing block
-            # (drop_eagle_block). Only trim the external hit when it reaches
-            # into the prompt's final granularity block, so that (local +
-            # external) never covers the last block whose KV the engine will
-            # rewrite during MTP draft/verify steps. Partial hits that stop on
-            # an interior block boundary carry a valid mamba state snapshot
-            # at that boundary and can be loaded as-is.
-            # The final granularity block starts at the lcm-aligned boundary
-            # containing the last token; num_tokens - lcm_block_size equals
-            # that boundary only for lcm-aligned prompts and over-trims
-            # unaligned prompts whose hit stops exactly on the boundary.
-            final_block_start = (request.num_tokens - 1) // self.lcm_block_size * self.lcm_block_size
-            hit_reaches_final_block = num_external_hit_tokens > final_block_start
-            if hit_reaches_final_block:
-                num_external_hit_tokens = max(
-                    num_computed_tokens,
-                    num_external_hit_tokens - self.lcm_block_size,
-                )
+            # Recompute the generation-point hidden state. Round the remaining
+            # prefix down after reserving a token; an interior aligned hit does
+            # not require dropping another complete transfer block.
+            max_cacheable_tokens = self._floor_to_cache_transfer_granularity(request.num_tokens - 1)
+            num_external_hit_tokens = min(
+                num_external_hit_tokens,
+                max(num_computed_tokens, max_cacheable_tokens),
+            )
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -683,14 +683,26 @@ class KVPoolScheduler:
 
         store_skip_tokens = num_external_hit_tokens
         if self.use_eagle:
-            # Recompute the generation-point hidden state. Round the remaining
-            # prefix down after reserving a token; an interior aligned hit does
-            # not require dropping another complete transfer block.
-            max_cacheable_tokens = self._floor_to_cache_transfer_granularity(request.num_tokens - 1)
-            num_external_hit_tokens = min(
-                num_external_hit_tokens,
-                max(num_computed_tokens, max_cacheable_tokens),
-            )
+            # Keep the draft model's recomputation zone intact: the
+            # generation-point hidden states must be freshly computed, and the
+            # local prefix-cache path already drops its trailing block
+            # (drop_eagle_block). Only trim the external hit when it reaches
+            # into the prompt's final granularity block, so that (local +
+            # external) never covers the last block whose KV the engine will
+            # rewrite during MTP draft/verify steps. Partial hits that stop on
+            # an interior block boundary carry a valid mamba state snapshot
+            # at that boundary and can be loaded as-is.
+            # The final granularity block starts at the lcm-aligned boundary
+            # containing the last token; num_tokens - lcm_block_size equals
+            # that boundary only for lcm-aligned prompts and over-trims
+            # unaligned prompts whose hit stops exactly on the boundary.
+            final_block_start = (request.num_tokens - 1) // self.lcm_block_size * self.lcm_block_size
+            hit_reaches_final_block = num_external_hit_tokens > final_block_start
+            if hit_reaches_final_block:
+                num_external_hit_tokens = max(
+                    num_computed_tokens,
+                    num_external_hit_tokens - self.lcm_block_size,
+                )
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 


### PR DESCRIPTION
### What this PR does / why we need it?

Allow external cache lookup for prompts shorter than two retention intervals. With a retention interval and transfer granularity of 4096, a 5083-token prompt can reuse an existing 4096-token checkpoint. The current early return reports zero without querying the cache.

The production change only removes this seven-line retention-length guard. Existing checks for requests shorter than one transfer unit, actual cache availability, and MTP tail recomputation remain unchanged. Requests previously excluded by the guard can now incur a lookup even when the cache is empty.

The MTP implementation is identical to the upstream base, including its aligned `final_block_start` calculation. MTP boundary tests confirm existing behavior; they are not evidence of another newly fixed MTP bug.

### Does this PR introduce _any_ user-facing change?

Yes. Requests shorter than two retention intervals can reuse valid external checkpoints instead of being forced to miss. No API or configuration changes.

### How was this patch tested?

- **Unit tests:** 50 passed in `tests/ut/distributed/ascend_store/test_pool_scheduler.py`. The retention regression covers MTP enabled/disabled, stored and missing checkpoints, and the existing early return below one transfer unit. Additional boundary coverage confirms the unchanged MTP behavior.
- **Baseline control:** On the upstream base without this fix, the retention lookup regression fails (0 instead of 4096), while the added MTP boundary test already passes.
- **Static checks:** Ruff check, Ruff format check, and `git diff --check` pass for the changed files. The full `bash format.sh ci` hook suite could not run because the runtime lacks `pre-commit`.
- **NPU experiments rerun with upstream MTP logic:** DeepSeek-V4-Flash-w8a8-mtp, TP4 × DP2, MTP=1, retention interval 4096. The runtime uses the upstream MTP block verbatim and removes the retention guard. Five frozen AISBench inputs were replayed with four warmup requests and four serial measured requests per length, one output token per request. Measured external hits/queries and outputs match both the previous implementation and the previously measured local-prefix-only mode.

| AISBench input_len | Actual prompt tokens/request | External hits/queries | Previously measured local prefix hits/queries | Hit rate |
| --- | --- | --- | --- | --- |
| 4096 | 4179 | 16384/16716 | 16384/16716 | 98.01% |
| 5000 | 5083 | 16384/20332 | 16384/20332 | 80.58% |
| 5004 | 5087 | 16384/20348 | 16384/20348 | 80.52% |
| 8192 | 8275 | 32768/33100 | 32768/33100 | 99.00% |
| 9000 | 9083 | 32768/36332 | 32768/36332 | 90.19% |

The chat template adds 83 tokens in this setup. Counts exclude warmup. Direct AISBench commands were also rerun for all five lengths, with four successful requests and zero failures in both warmup and measured stages:

```bash
python3 aisbench_test.py --input_len 5000 --output_len 1 --data_num 4 \
  --concurrency 1 --request_rate 0 --dataset_type prefix_cache \
  --repeat_rate 1.0 --prefix_test --dp 4
```

Token-ID input tests reconfirmed that actual lengths 4096/5004/8192/9000 reuse 0/4096/4096/8192 tokens per request. A separate 5083-token input produced identical 64-token output for an external miss and subsequent hit.

**Validation limitations:** Clean-checkout unit tests use the directory's existing `_mock_deps` stubs and `--confcutdir=tests/ut/distributed/ascend_store`; the runtime's parent conftest has an unavailable `vllm.v1.attention.ops.pcp` dependency. The NPU runtime is the existing `bdab8bde86aad5eba3b362f923a3ff03b2c0e772` deployment with the upstream aligned MTP block and the retention guard removed, retaining its existing memcache backend changes; it is not a full deployment of the latest main. Cold concurrent warmup can differ between local and external caching due to publication timing and DP cache scope. These checks do not establish general model accuracy, lookahead KV safety for different continuations, graph-mode coverage, or statistical performance equivalence. This PR leaves upstream MTP handling unchanged.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
