### PR TITLE
[Performance][Model] Reuse fused mHC operators for GLM-5.3-Flash

### DIFF
--- a/tests/ut/models/test_glm5next_mhc.py
+++ b/tests/ut/models/test_glm5next_mhc.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch_npu
+from torch import nn
+from vllm.model_executor.kernels.mhc.torch import mhc_post_torch, mhc_pre_torch
+
+from vllm_ascend.models.glm5next.model import Glm5NextDecoderLayer
+
+
+def _rms_norm(x, weight, epsilon):
+    xf = x.float()
+    return (xf * torch.rsqrt(xf.square().mean(-1, keepdim=True) + epsilon) * weight.float()).to(x.dtype)
+
+
+@pytest.mark.parametrize("post_scale", [2.0, 1.5])
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_mhc_native_ops_preserve_deferred_mixing_and_input_norm(monkeypatch, post_scale, with_norm):
+    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.n = 4
+    layer.mhc_sinkhorn_iterations = 20
+    layer.rms_norm_eps = 1e-6
+    layer.hc_eps = 1e-6
+    layer.mhc_post_mult_value = post_scale
+    torch.manual_seed(0)
+    residual = torch.randn(3, 4, 8).bfloat16()
+    original = residual.clone()
+    fn = torch.randn(24, 32) * 0.1
+    scale = torch.tensor([0.5, 0.6, 0.7])
+    base = torch.randn(24) * 0.1
+    weight = torch.linspace(0.5, 1.5, 8).bfloat16() if with_norm else None
+    norm_eps = 1e-5
+
+    def native_pre(x, fn, scale, base, hc_mult, iters, rms_eps, hc_eps):
+        assert hc_mult == 4
+        post, comb, y = mhc_pre_torch(x, fn, scale, base, rms_eps, hc_eps, hc_eps, 2.0, iters)
+        return y, post.squeeze(-1), comb
+
+    def native_post(x, residual, post, comb):
+        assert post.ndim == 3 and residual.ndim == 4
+        return mhc_post_torch(x, residual, post.unsqueeze(-1), comb)
+
+    monkeypatch.setattr(torch.ops._C_ascend, "npu_hc_pre_v2", native_pre, raising=False)
+    monkeypatch.setattr(torch.ops._C_ascend, "npu_hc_post", native_post, raising=False)
+    monkeypatch.setattr(torch_npu, "npu_rms_norm", lambda x, weight, epsilon: (_rms_norm(x, weight, epsilon), None))
+
+    expected_post, expected_comb, expected_y = mhc_pre_torch(
+        residual, fn, scale, base, layer.rms_norm_eps, layer.hc_eps, layer.hc_eps, post_scale, 20
+    )
+    if with_norm:
+        expected_y = _rms_norm(expected_y, weight, norm_eps)
+    post, comb, y = layer.hc_pre(residual, fn, scale, base, norm_weight=weight, norm_eps=norm_eps)
+    for actual, expected in zip((post, comb, y), (expected_post, expected_comb, expected_y)):
+        torch.testing.assert_close(actual, expected)
+
+    mixed = mhc_post_torch(expected_y, residual, expected_post, expected_comb)
+    next_post, next_comb, next_y = mhc_pre_torch(
+        mixed, fn, scale, base, layer.rms_norm_eps, layer.hc_eps, layer.hc_eps, post_scale, 20
+    )
+    if with_norm:
+        next_y = _rms_norm(next_y, weight, norm_eps)
+    actual = layer.hc_post_pre(y, residual, post, comb, fn, scale, base, norm_weight=weight, norm_eps=norm_eps)
+    for value, expected in zip(actual, (mixed, next_post, next_comb, next_y)):
+        torch.testing.assert_close(value, expected)
+    torch.testing.assert_close(residual, original)

--- a/vllm_ascend/models/glm5next/model.py
+++ b/vllm_ascend/models/glm5next/model.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any, ClassVar, Literal
 
 import torch
+import torch_npu
 from torch import nn
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (
@@ -31,11 +32,6 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFuncCalculator,
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
-)
-from vllm.model_executor.layers.mhc import (
-    MHCFusedPostPreOp,
-    MHCPostOp,
-    MHCPreOp,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -374,10 +370,6 @@ class Glm5NextDecoderLayer(nn.Module):
             self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
             self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
 
-            self.mhc_pre_op = MHCPreOp()
-            self.mhc_post_op = MHCPostOp()
-            self.mhc_fused_post_pre_op = MHCFusedPostPreOp()
-
     def forward(
         self,
         positions: torch.Tensor,
@@ -412,9 +404,8 @@ class Glm5NextDecoderLayer(nn.Module):
             return hidden_states, residual, None, None
 
         # mHC start. `post`/`comb` carry the previous layer's deferred
-        # hc_post inputs (its ffn-pre outputs); when present, fuse that
-        # hc_post with this layer's attn hc_pre into one kernel (inter-layer
-        # fusion). Layer 0 has no incoming state -> standalone hc_pre.
+        # hc_post inputs (its ffn-pre outputs); apply the existing HcPost and
+        # HcPre kernels before attention. Layer 0 has no incoming state.
         x = hidden_states
         if post is None:
             if self.layer_idx == 0:
@@ -429,7 +420,7 @@ class Glm5NextDecoderLayer(nn.Module):
                 norm_eps=self.input_layernorm.variance_epsilon,
             )
         else:
-            residual, post, comb, x = self.hc_fused_post_pre(
+            residual, post, comb, x = self.hc_post_pre(
                 x,
                 residual,
                 post,
@@ -454,8 +445,8 @@ class Glm5NextDecoderLayer(nn.Module):
         if self.is_sequence_parallel:
             x = sp_reduce_scatter(x)
 
-        # Fuse post-attn hc_post + pre-FFN hc_pre (+ RMSNorm) into one kernel.
-        residual, post, comb, x = self.hc_fused_post_pre(
+        # Apply post-attention mixing, pre-FFN mixing, then input RMSNorm.
+        residual, post, comb, x = self.hc_post_pre(
             x,
             residual,
             post,
@@ -475,7 +466,7 @@ class Glm5NextDecoderLayer(nn.Module):
 
         # mHC end. The last mHC layer materializes its final hc_post (nothing
         # to fuse with) then contracts; every other layer defers its hc_post to
-        # the next layer's fused pre, returning the state.
+        # the next layer's pre, returning the state.
         if self.layer_idx == self.num_hidden_layers - 1:
             x = self.hc_post(x, residual, post, comb)
             x = hc_contract(x, self.n)
@@ -492,20 +483,22 @@ class Glm5NextDecoderLayer(nn.Module):
         norm_weight: torch.Tensor | None = None,
         norm_eps: float = 0.0,
     ):
-        post_mix, res_mix, layer_input = self.mhc_pre_op(
-            residual=x,
-            fn=hc_fn,
-            hc_scale=hc_scale,
-            hc_base=hc_base,
-            rms_eps=self.rms_norm_eps,
-            hc_pre_eps=self.hc_eps,
-            hc_sinkhorn_eps=self.hc_eps,
-            hc_post_mult_value=self.mhc_post_mult_value,
-            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
-            norm_weight=norm_weight,
-            norm_eps=norm_eps,
+        layer_input, post_mix, res_mix = torch.ops._C_ascend.npu_hc_pre_v2(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            self.n,
+            self.mhc_sinkhorn_iterations,
+            self.rms_norm_eps,
+            self.hc_eps,
         )
-        return post_mix, res_mix, layer_input
+        # HcPre uses 2 * sigmoid for post mixing; retain the model's scale.
+        if self.mhc_post_mult_value != 2.0:
+            post_mix = post_mix * (self.mhc_post_mult_value / 2.0)
+        if norm_weight is not None:
+            layer_input = torch_npu.npu_rms_norm(layer_input, norm_weight, epsilon=norm_eps)[0]
+        return post_mix.unsqueeze(-1), res_mix, layer_input
 
     def hc_post(
         self,
@@ -514,9 +507,11 @@ class Glm5NextDecoderLayer(nn.Module):
         post: torch.Tensor,
         comb: torch.Tensor,
     ):
-        return self.mhc_post_op(x, residual, post, comb)
+        return torch.ops._C_ascend.npu_hc_post(
+            x.unsqueeze(0), residual.unsqueeze(0), post.squeeze(-1).unsqueeze(0), comb.unsqueeze(0)
+        ).squeeze(0)
 
-    def hc_fused_post_pre(
+    def hc_post_pre(
         self,
         x: torch.Tensor,
         residual: torch.Tensor,
@@ -528,24 +523,16 @@ class Glm5NextDecoderLayer(nn.Module):
         norm_weight: torch.Tensor | None = None,
         norm_eps: float = 0.0,
     ):
-        return self.mhc_fused_post_pre_op(
-            x=x,
-            residual=residual,
-            post_layer_mix=post,
-            comb_res_mix=comb,
-            fn=hc_fn,
-            hc_scale=hc_scale,
-            hc_base=hc_base,
-            rms_eps=self.rms_norm_eps,
-            hc_pre_eps=self.hc_eps,
-            hc_sinkhorn_eps=self.hc_eps,
-            hc_post_mult_value=self.mhc_post_mult_value,
-            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
-            n_splits=1,
-            tile_n=1,
+        residual = self.hc_post(x, residual, post, comb)
+        post, comb, layer_input = self.hc_pre(
+            residual,
+            hc_fn,
+            hc_scale,
+            hc_base,
             norm_weight=norm_weight,
             norm_eps=norm_eps,
         )
+        return residual, post, comb, layer_input
 
 
 class Glm5NextModel(nn.Module):


### PR DESCRIPTION
### What this PR does / why we need it?

Refs #15665

Replace decomposed PyTorch mHC reductions with the existing Ascend `npu_hc_pre_v2` and `npu_hc_post` operators for GLM-5.3-Flash. Preserve post-mixing scale, optional input RMSNorm, output shapes, and deferred residual mixing across layers.

The model and native operators are already in main. This PR has no pending Flash source dependency; full-model validation combines the other Flash integration PRs and their prerequisites.

### Does this PR introduce _any_ user-facing change?

Yes. GLM-5.3-Flash uses native fused mHC operators on Ascend, reducing decomposed operator launches without changing serving options.

### How was this patch tested?

- Four cases in `tests/ut/models/test_glm5next_mhc.py` cover optional RMSNorm, post-mixing scales, deferred mixing, and preservation of the input residual. All 182 focused regression tests passed in the integrated tree.
- A3 numerical comparisons against the original Torch path used actual GLM mHC weights and BF16 inputs at 1, 4, 17, and 3500 tokens. All 16 output comparisons passed; maximum NRMSE was 2.674e-5.
- GLM-5.3-Flash-w8a8 passed eight smoke cases on A3 with TP8, expert parallelism, MTP=3, and FULL_DECODE_ONLY, including a 5264-token chunked prefill. A 3500-input/1500-output request also completed.
- Profiling confirmed HcPre/HcPost execution during prefill and decode.
- GitHub pre-commit, CPU unit tests, and the CI gate passed. Selected device jobs were skipped in that CI run.

Hardware validation covers the GLM BF16 configuration with hc_mult=4 and hidden_size=4096. These results do not establish an end-to-end speedup or a full GSM8K result.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
