### PR TITLE
[BugFix] Allow DSA-CP SP prefill without full o_proj weight gathering

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1639,8 +1639,6 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             AscendAttentionState.DecodeOnly,
             AscendAttentionState.SpecDecoding,
         }
-        if need_gather_q_kv and self.tp_size > 1 and not is_decode and not self.enable_dsa_cp_full_o_proj:
-            raise RuntimeError("DSA-CP sequence-parallel prefill requires full o_proj weight gathering.")
         full_gather_wo_a_enabled = self.tp_size > 1 and self.enable_dsa_cp_full_o_proj and not is_decode
         local_attn_output = self._forward(
             layer_name,


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the fail-fast guard in `AscendDSACPImpl.forward` that aborted
sequence-parallel prefill with DSA-CP whenever the full o_proj weight
gathering optimization is off:

```text
RuntimeError: DSA-CP sequence-parallel prefill requires full o_proj weight gathering.
```

Without the guard, such prefills fall through to the sharded o_proj plus
`reduce_scatter` branch — the same branch decode already uses
(`full_gather_wo_a_enabled=False` → head all-to-all → sharded `wo_a` →
`sp_reduce_scatter`). This unblocks DSA-CP SP prefill on hardware
profiles or roles (e.g. KV-transfer consumers) where the temporary full
o_proj weight cannot be gathered.

### Does this PR introduce _any_ user-facing change?

Yes. Configurations that previously crashed at prefill now run via the
fallback branch. Prefill through this branch costs one extra head
all-to-all plus one o_proj `reduce_scatter` per layer compared to the
full-gather path, so TTFT may regress where the optimization is
unavailable; accuracy impact needs e2e validation.

### How was this patch tested?

- `ruff check` and `ruff format --check` pass on the touched file.
- Syntax verified with `ast.parse`.
- e2e validation (four-card context-parallel accuracy and dspark
  spec-decode acceptance) is left to CI / NPU runs.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
