### PR TITLE
[BugFix][MRV2] Fix replicated DCP indexer cache metadata

### DIFF
--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -13,6 +13,7 @@ from vllm_ascend.attention.indexer import (
     AscendSFAIndexerMetadata,
     AscendSFAIndexerMetadataBuilder,
 )
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
 
 _KERNEL_BLOCK_SIZE = 128
 
@@ -66,6 +67,49 @@ def test_sfa_indexer_backend_contract():
         160,
     )
     assert AscendSFAIndexerBackend.get_supported_kernel_block_sizes() == [128]
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_replicated_indexer_builds_own_full_addresses(mock_cos_sin, mock_get_ascend_config):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (torch.zeros(6, 1, 1, 8), torch.zeros(6, 1, 1, 8))
+    spec = AscendSFAIndexerCacheSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=160,
+        dtype=torch.uint8,
+        sfa_dcp_replicated_indexer_size=8,
+    )
+    config = MagicMock()
+    config.parallel_config.prefill_context_parallel_size = 1
+    config.scheduler_config.max_num_seqs = 2
+    config.scheduler_config.max_num_batched_tokens = 8
+    config.model_config.max_model_len = 2048
+    with patch("vllm_ascend.attention.indexer.select_common_block_size", return_value=128):
+        builder = AscendSFAIndexerMetadataBuilder(spec, ["indexer.k_cache"], config, torch.device("cpu"))
+    common = _make_common_metadata()
+    common.num_actual_tokens = 5
+    common.num_input_tokens = 6
+    common.positions = torch.tensor([0, 127, 128, 1023, 1024, 0])
+    common.query_start_loc = torch.tensor([0, 5, 6])
+    common.seq_lens = torch.tensor([1025, 0])
+    common.block_table_tensor = torch.tensor([[3, 7], [0, 0]], dtype=torch.int32)
+    common.slot_mapping = torch.tensor([384, 511, -1, -1, 896, -1], dtype=torch.int32)
+    original_table = common.block_table_tensor
+    original_slots = common.slot_mapping
+
+    metadata = builder.build(0, common)
+
+    assert metadata.block_table.tolist() == [list(range(24, 32)) + list(range(56, 64)), [0] * 16]
+    assert metadata.slot_mapping.tolist() == [3072, 3199, 3200, 4095, 7168, -1]
+    assert common.block_table_tensor is original_table
+    assert common.slot_mapping is original_slots
+    assert original_table.tolist() == [[3, 7], [0, 0]]
+    assert original_slots.tolist() == [384, 511, -1, -1, 896, -1]
+    repeated = builder.build(0, common)
+    assert repeated.block_table.data_ptr() == metadata.block_table.data_ptr()
+    assert repeated.slot_mapping.data_ptr() == metadata.slot_mapping.data_ptr()
 
 
 @patch("vllm_ascend.attention.indexer.get_ascend_config")

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -3,8 +3,12 @@ from typing import Any
 import torch
 import torch.distributed as dist
 import torch_npu
+from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group
+from vllm.utils.math_utils import cdiv
+from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
 
 
@@ -27,6 +31,166 @@ def get_dcp_local_seq_lens(
         0,
         interleave_size,
     )
+
+
+class ReplicatedKVMetadataMixin:
+    """Build full-cache addresses using the consumer's own spec and buffers."""
+
+    def _init_replicated_view(
+        self,
+        kv_cache_spec: AttentionSpec,
+        kernel_block_size: int,
+        dcp_size: int,
+        max_num_reqs: int,
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        self.dcp_size = dcp_size
+        self.device = device
+        self.replicated_view_block_size = kernel_block_size
+        if kv_cache_spec.block_size % self.replicated_view_block_size != 0:
+            raise RuntimeError(
+                "SFA replicated view requires the KV cache block size "
+                f"({kv_cache_spec.block_size}) to be divisible by "
+                f"{self.replicated_view_block_size}."
+            )
+        self.blocks_per_phys_block = kv_cache_spec.block_size // self.replicated_view_block_size
+        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_model_len = vllm_config.model_config.max_model_len
+        total_cp_size = self.dcp_size
+        # The generic vLLM BlockTable may expose global-width storage, while
+        # the DCP physical KV layout only populates rank-local block columns.
+        self.max_local_block_table_cols = (
+            cdiv(max_model_len, kv_cache_spec.block_size * total_cp_size) * self.blocks_per_phys_block
+        )
+        max_replicated_block_table_cols = self.max_local_block_table_cols * total_cp_size
+        self.block_table_replicated_view_buf: torch.Tensor = torch.empty(
+            (max_num_reqs, max_replicated_block_table_cols),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.arange_buffer: torch.Tensor = torch.arange(
+            max_replicated_block_table_cols,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.slot_mapping_replicated_view_buf: torch.Tensor = torch.empty(
+            (max_num_input_tokens,),
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def _get_dcp_local_block_table(self, block_table: torch.Tensor, num_reqs: int) -> torch.Tensor:
+        local_cols = min(block_table.shape[1], self.max_local_block_table_cols)
+        return block_table[:num_reqs, :local_cols]
+
+    def _ensure_replicated_view_buffers(
+        self,
+        num_reqs: int,
+        num_input_tokens: int,
+        local_block_table_cols: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        block_table_cols = local_block_table_cols * self.dcp_size
+        if (
+            self.block_table_replicated_view_buf.shape[0] < num_reqs
+            or self.block_table_replicated_view_buf.shape[1] < block_table_cols
+        ):
+            raise RuntimeError(
+                f"Replicated view buffer is too small: "
+                f"block_table_replicated_view_buf.shape={self.block_table_replicated_view_buf.shape}, "
+                f"num_reqs={num_reqs}, block_table_cols={block_table_cols}"
+            )
+        if self.slot_mapping_replicated_view_buf.shape[0] < num_input_tokens:
+            raise RuntimeError(
+                f"Replicated view buffer is too small: "
+                f"slot_mapping_replicated_view_buf.shape={self.slot_mapping_replicated_view_buf.shape}, "
+                f"num_input_tokens={num_input_tokens}"
+            )
+        return (
+            self.block_table_replicated_view_buf[:num_reqs, :block_table_cols],
+            self.arange_buffer[:block_table_cols],
+            self.slot_mapping_replicated_view_buf[:num_input_tokens],
+        )
+
+    def _build_block_table_replicated_view(
+        self,
+        dcp_block_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        num_reqs = dcp_block_table.shape[0]
+        local_block_table_cols = dcp_block_table.shape[1]
+        block_table_replicated_view, replicated_col_idx, _ = self._ensure_replicated_view_buffers(
+            num_reqs,
+            0,
+            local_block_table_cols,
+        )
+
+        total_cp_size = self.dcp_size
+        blocks_per_phys_block = self.blocks_per_phys_block
+        local_col_idx = (
+            replicated_col_idx // (total_cp_size * blocks_per_phys_block) * blocks_per_phys_block
+            + replicated_col_idx % blocks_per_phys_block
+        )
+        rank_in_replicated_view = (replicated_col_idx // blocks_per_phys_block) % total_cp_size
+
+        local_logical_blocks = torch.index_select(dcp_block_table, 1, local_col_idx)
+        if blocks_per_phys_block == 1:
+            replicated_blocks = local_logical_blocks * total_cp_size + rank_in_replicated_view
+        else:
+            local_sub_blocks = local_logical_blocks % blocks_per_phys_block
+            local_phys_blocks = local_logical_blocks // blocks_per_phys_block
+            replicated_blocks = (
+                local_phys_blocks * total_cp_size + rank_in_replicated_view
+            ) * blocks_per_phys_block + local_sub_blocks
+
+        valid_req_mask = (seq_lens[:num_reqs].to(device=self.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
+        replicated_blocks = replicated_blocks * valid_req_mask
+        block_table_replicated_view.copy_(replicated_blocks)
+        return block_table_replicated_view
+
+    def _build_slot_mapping_replicated_view(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        block_table_replicated_view: torch.Tensor,
+    ) -> torch.Tensor:
+        num_reqs = common_attn_metadata.num_reqs
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        num_actual_tokens = min(common_attn_metadata.num_actual_tokens, num_input_tokens)
+        local_block_table_cols = block_table_replicated_view.shape[1] // self.dcp_size
+        _, _, slot_mapping_replicated_view = self._ensure_replicated_view_buffers(
+            num_reqs,
+            num_input_tokens,
+            local_block_table_cols,
+        )
+        slot_mapping_replicated_view.fill_(-1)
+        if num_actual_tokens == 0:
+            return slot_mapping_replicated_view
+
+        query_lens = (
+            common_attn_metadata.query_start_loc[1 : num_reqs + 1] - common_attn_metadata.query_start_loc[:num_reqs]
+        )
+        req_indices = torch.repeat_interleave(
+            torch.arange(num_reqs, dtype=torch.int32, device=self.device),
+            query_lens.to(device=self.device),
+            output_size=num_input_tokens,
+        )[:num_actual_tokens]
+        if req_indices.numel() == 0:
+            return slot_mapping_replicated_view
+
+        num_actual_tokens = min(num_actual_tokens, req_indices.shape[0])
+        req_indices = req_indices[:num_actual_tokens]
+        positions = common_attn_metadata.positions[:num_actual_tokens].to(
+            device=self.device,
+            dtype=torch.int32,
+        )
+        logical_block_idx = positions // self.replicated_view_block_size
+        block_offsets = positions % self.replicated_view_block_size
+        block_table_indices = req_indices * block_table_replicated_view.shape[1] + logical_block_idx
+        block_numbers = block_table_replicated_view.flatten()[block_table_indices]
+        slot_mapping_replicated_view[:num_actual_tokens] = (
+            block_numbers * self.replicated_view_block_size + block_offsets
+        )
+        return slot_mapping_replicated_view
 
 
 class DCPMetadataBuilderMixin:

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -8,7 +8,6 @@ from torch import nn
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON
-from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 import vllm_ascend.ops.triton.sfa_cp  # noqa: F401
@@ -16,6 +15,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
+    ReplicatedKVMetadataMixin,
     get_dcp_local_seq_lens,
 )
 from vllm_ascend.attention.sfa_v1 import (
@@ -609,6 +609,7 @@ class AscendSFADSACPImpl(OProjWeightSwitchMixin, AscendSFAImpl):
 # - The replicated view uses the same logical/kernel block size as BlockTable,
 #   including hybrid block splitting.
 class AscendSFADCPMetadataBuilder(
+    ReplicatedKVMetadataMixin,
     DCPMetadataBuilderMixin,
     AscendSFAMetadataBuilder,
 ):
@@ -648,32 +649,8 @@ class AscendSFADCPMetadataBuilder(
             dtype=torch.int32,
             device=device,
         )
-        self.replicated_view_block_size = self.kernel_block_size
-        if kv_cache_spec.block_size % self.replicated_view_block_size != 0:
-            raise RuntimeError(
-                "SFA replicated view requires the KV cache block size "
-                f"({kv_cache_spec.block_size}) to be divisible by "
-                f"{self.replicated_view_block_size}."
-            )
-        self.blocks_per_phys_block = kv_cache_spec.block_size // self.replicated_view_block_size
-        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        max_model_len = vllm_config.model_config.max_model_len
-        total_cp_size = self.dcp_size
-        # The generic vLLM BlockTable may expose global-width storage, while
-        # the DCP physical KV layout only populates rank-local block columns.
-        self.max_local_block_table_cols = (
-            cdiv(max_model_len, kv_cache_spec.block_size * total_cp_size) * self.blocks_per_phys_block
-        )
-        max_replicated_block_table_cols = self.max_local_block_table_cols * total_cp_size
-        self.block_table_replicated_view_buf: torch.Tensor = torch.empty(
-            (max_num_reqs, max_replicated_block_table_cols),
-            dtype=torch.int32,
-            device=device,
-        )
-        self.arange_buffer: torch.Tensor = torch.arange(
-            max_replicated_block_table_cols,
-            dtype=torch.int32,
-            device=device,
+        self._init_replicated_view(
+            kv_cache_spec, self.kernel_block_size, self.dcp_size, max_num_reqs, vllm_config, device
         )
         dcp_group = get_dcp_group()
         collective_ranks = sorted(dcp_group.ranks)
@@ -691,11 +668,6 @@ class AscendSFADCPMetadataBuilder(
             dtype=torch.int32,
             device=device,
         )
-        self.slot_mapping_replicated_view_buf: torch.Tensor = torch.empty(
-            (max_num_input_tokens,),
-            dtype=torch.int32,
-            device=device,
-        )
 
     def _get_dcp_local_seq_lens(self, seq_lens: torch.Tensor) -> torch.Tensor:
         return get_dcp_local_seq_lens(
@@ -703,118 +675,6 @@ class AscendSFADCPMetadataBuilder(
             self.dcp_size,
             self.cp_kv_cache_interleave_size,
         )[:, self.dcp_rank]
-
-    def _get_dcp_local_block_table(self, block_table: torch.Tensor, num_reqs: int) -> torch.Tensor:
-        local_cols = min(block_table.shape[1], self.max_local_block_table_cols)
-        return block_table[:num_reqs, :local_cols]
-
-    def _ensure_replicated_view_buffers(
-        self,
-        num_reqs: int,
-        num_input_tokens: int,
-        local_block_table_cols: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        block_table_cols = local_block_table_cols * self.dcp_size
-        if (
-            self.block_table_replicated_view_buf.shape[0] < num_reqs
-            or self.block_table_replicated_view_buf.shape[1] < block_table_cols
-        ):
-            raise RuntimeError(
-                f"Replicated view buffer is too small: "
-                f"block_table_replicated_view_buf.shape={self.block_table_replicated_view_buf.shape}, "
-                f"num_reqs={num_reqs}, block_table_cols={block_table_cols}"
-            )
-        if self.slot_mapping_replicated_view_buf.shape[0] < num_input_tokens:
-            raise RuntimeError(
-                f"Replicated view buffer is too small: "
-                f"slot_mapping_replicated_view_buf.shape={self.slot_mapping_replicated_view_buf.shape}, "
-                f"num_input_tokens={num_input_tokens}"
-            )
-        return (
-            self.block_table_replicated_view_buf[:num_reqs, :block_table_cols],
-            self.arange_buffer[:block_table_cols],
-            self.slot_mapping_replicated_view_buf[:num_input_tokens],
-        )
-
-    def _build_block_table_replicated_view(
-        self,
-        dcp_block_table: torch.Tensor,
-        seq_lens: torch.Tensor,
-    ) -> torch.Tensor:
-        num_reqs = dcp_block_table.shape[0]
-        local_block_table_cols = dcp_block_table.shape[1]
-        block_table_replicated_view, replicated_col_idx, _ = self._ensure_replicated_view_buffers(
-            num_reqs,
-            0,
-            local_block_table_cols,
-        )
-
-        total_cp_size = self.dcp_size
-        blocks_per_phys_block = self.blocks_per_phys_block
-        local_col_idx = (
-            replicated_col_idx // (total_cp_size * blocks_per_phys_block) * blocks_per_phys_block
-            + replicated_col_idx % blocks_per_phys_block
-        )
-        rank_in_replicated_view = (replicated_col_idx // blocks_per_phys_block) % total_cp_size
-
-        local_logical_blocks = torch.index_select(dcp_block_table, 1, local_col_idx)
-        if blocks_per_phys_block == 1:
-            replicated_blocks = local_logical_blocks * total_cp_size + rank_in_replicated_view
-        else:
-            local_sub_blocks = local_logical_blocks % blocks_per_phys_block
-            local_phys_blocks = local_logical_blocks // blocks_per_phys_block
-            replicated_blocks = (
-                local_phys_blocks * total_cp_size + rank_in_replicated_view
-            ) * blocks_per_phys_block + local_sub_blocks
-
-        valid_req_mask = (seq_lens[:num_reqs].to(device=self.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
-        replicated_blocks = replicated_blocks * valid_req_mask
-        block_table_replicated_view.copy_(replicated_blocks)
-        return block_table_replicated_view
-
-    def _build_slot_mapping_replicated_view(
-        self,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        block_table_replicated_view: torch.Tensor,
-    ) -> torch.Tensor:
-        num_reqs = common_attn_metadata.num_reqs
-        num_input_tokens = common_attn_metadata.num_input_tokens
-        num_actual_tokens = min(common_attn_metadata.num_actual_tokens, num_input_tokens)
-        local_block_table_cols = block_table_replicated_view.shape[1] // self.dcp_size
-        _, _, slot_mapping_replicated_view = self._ensure_replicated_view_buffers(
-            num_reqs,
-            num_input_tokens,
-            local_block_table_cols,
-        )
-        slot_mapping_replicated_view.fill_(-1)
-        if num_actual_tokens == 0:
-            return slot_mapping_replicated_view
-
-        query_lens = (
-            common_attn_metadata.query_start_loc[1 : num_reqs + 1] - common_attn_metadata.query_start_loc[:num_reqs]
-        )
-        req_indices = torch.repeat_interleave(
-            torch.arange(num_reqs, dtype=torch.int32, device=self.device),
-            query_lens.to(device=self.device),
-            output_size=num_input_tokens,
-        )[:num_actual_tokens]
-        if req_indices.numel() == 0:
-            return slot_mapping_replicated_view
-
-        num_actual_tokens = min(num_actual_tokens, req_indices.shape[0])
-        req_indices = req_indices[:num_actual_tokens]
-        positions = common_attn_metadata.positions[:num_actual_tokens].to(
-            device=self.device,
-            dtype=torch.int32,
-        )
-        logical_block_idx = positions // self.replicated_view_block_size
-        block_offsets = positions % self.replicated_view_block_size
-        block_table_indices = req_indices * block_table_replicated_view.shape[1] + logical_block_idx
-        block_numbers = block_table_replicated_view.flatten()[block_table_indices]
-        slot_mapping_replicated_view[:num_actual_tokens] = (
-            block_numbers * self.replicated_view_block_size + block_offsets
-        )
-        return slot_mapping_replicated_view
 
     def _build_compact_kv_gather_metadata(
         self,

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -18,6 +18,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.utils import select_common_block_size
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.attention.context_parallel.common_cp import ReplicatedKVMetadataMixin
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.utils import all_gather_async
@@ -449,12 +450,15 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         )
 
 
-class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerMetadata]):
+class AscendSFAIndexerMetadataBuilder(
+    ReplicatedKVMetadataMixin,
+    AttentionMetadataBuilder[AscendSFAIndexerMetadata],
+):
     """Builds the metadata consumed by SFA indexer forwards.
 
-    The indexer cache layer shares block ids with the main SFA cache group,
-    so the slot mapping and block table mirror the ``*.attn`` layer's; the
-    rope tables are rebuilt from the same positions via the shared helper.
+    The indexer cache layer shares allocation block ids with the SFA cache.
+    Replicated DCP indexer caches derive full addresses from their own spec;
+    the rope tables are rebuilt from the same positions via the shared helper.
     The slot mapping is emitted write-ready for the active parallel mode
     (full gather mapping under PCP). Variants with their own cache geometry
     override this construction to supply their layout's equivalents.
@@ -473,6 +477,16 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFAIndexerBackend])
         self._pcp_active = vllm_config.parallel_config.prefill_context_parallel_size > 1
+        self._replicated_dcp = getattr(kv_cache_spec, "sfa_dcp_replicated_indexer_size", 1)
+        if self._replicated_dcp > 1 and not self._pcp_active:
+            self._init_replicated_view(
+                kv_cache_spec,
+                self.kernel_block_size,
+                self._replicated_dcp,
+                vllm_config.scheduler_config.max_num_seqs + 1,
+                vllm_config,
+                device,
+            )
 
     @classmethod
     def get_cudagraph_support(
@@ -500,6 +514,12 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
         block_size = self.kernel_block_size
+        block_table = common_attn_metadata.block_table_tensor[:num_reqs]
+        if self._replicated_dcp > 1 and not self._pcp_active:
+            block_table = self._build_block_table_replicated_view(
+                self._get_dcp_local_block_table(block_table, num_reqs), common_attn_metadata.seq_lens
+            )
+            slot_mapping = self._build_slot_mapping_replicated_view(common_attn_metadata, block_table)
 
         cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
 
@@ -517,7 +537,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             slot_mapping=slot_mapping,
             seq_lens=common_attn_metadata.seq_lens[:num_reqs],
             cum_query_lens=common_attn_metadata.query_start_loc[1 : num_reqs + 1],
-            block_table=common_attn_metadata.block_table_tensor[:num_reqs],
+            block_table=block_table,
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             block_size=block_size,


### PR DESCRIPTION
### What this PR does / why we need it?

With Model Runner V2 and a replicated DCP indexer cache, the indexer metadata builder currently forwards the common DCP-local slot mapping and block table. Non-local tokens have invalid write slots, and the local addressing does not match the indexer's full-cache layout. This can produce incorrect responses on long or chunked inputs.

Reuse the existing replicated block-table and slot-mapping builders from SFA by moving them into `ReplicatedKVMetadataMixin` in the existing `context_parallel/common_cp.py`. The indexer invokes these helpers using its own cache spec and persistent buffers. It does not consume SFA metadata or modify the common metadata. The SFA builder retains the same conversion helpers through the mixin.

The indexer path is enabled only for PCP=1 and a replicated-indexer cache spec. Most of the diff is relocation of existing helpers; KV allocation and upstream BlockTables interfaces are unchanged.

### Does this PR introduce _any_ user-facing change?

Corrects indexer cache addressing for the above DCP configuration. No new configuration options.

### How was this patch tested?

- Indexer and SFA CP unit tests passed, including the new regression for full read/write addresses, padding, unchanged common metadata, and persistent buffer addresses.
- On Ascend host 159, GLM-5.2-w4a8 with Model Runner V2, TP8/DCP8/PCP1, EP and async scheduling enabled: all 28 non-disaggregated requests returned HTTP 200 with the expected complete response. Cases include the original 4136-token input, chunk boundaries, retrieval up to 24577 tokens, eight concurrent requests, and a post-concurrency request.
- Chunked prefill enabled, max batched tokens 4096, max model length 32768, block/interleave size 128, FULL_DECODE_ONLY graph sizes [1, 2, 4, 8]. Prefix caching, DSA-CP and sparse C8 were disabled. PCP>1, those optional configurations, and performance are not claimed as hardware-validated by this run.
- Ruff lint/format and `git diff --check` passed.

Hardware validation used the modified attention files on vllm-ascend base `12be3d34a1510be8e19542f577e732a12c47a1d1`.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
