### PR TITLE
remove tensormove operator

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2097,7 +2097,15 @@ class AscendDSAImpl(DSAAttentionImpl):
         if has_decode:
             assert attn_metadata[0].decode is not None
             output_decode = self._forward_decode(layer_name, decode_hidden_states, kv_cache, attn_metadata)
-            o_proj_input[:decode_tokens] = output_decode
+            if (
+                not has_prefill
+                and o_proj_input.shape == output_decode.shape
+                and o_proj_input.dtype == output_decode.dtype
+                and o_proj_input.device == output_decode.device
+            ):
+                o_proj_input = output_decode
+            else:
+                o_proj_input[:decode_tokens] = output_decode
             cos = attn_metadata[0].decode.cos[layer_name]
             sin = attn_metadata[0].decode.sin[layer_name]
 


### PR DESCRIPTION
(cherry picked from commit 1b04a90b9039af9560e2fe6665d7fe81f462c0a9)

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
