### PR TITLE
[Feature][Model] Add image-level encoder DP for DeepSeek V4 Vision

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -214,6 +214,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/test_minimax_m3.py: 300
   tests/e2e/pull_request/four_card/test_kimi_k3.py: 360
   tests/e2e/pull_request/one_card/test_attention_v1_precision.py: 540
+  tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py: 180
   tests/e2e/pull_request/one_card/test_mla_precision.py: 190
   tests/e2e/pull_request/one_card/test_sfa_v1_precision.py: 120
   tests/e2e/pull_request/one_card/test_eplb_map_to_physical_npu.py: 30

--- a/tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py
+++ b/tests/e2e/pull_request/one_card/test_deepseek_v4_vision_precision.py
@@ -1,0 +1,218 @@
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+import torch_npu  # noqa: F401
+from safetensors.torch import load_file
+from vllm.config import VllmConfig, set_current_vllm_config
+
+from vllm_ascend.models.deepseek_v4.vision import (
+    DeepseekV4VisionAttention,
+    DeepseekV4VisionBlock,
+    DeepseekV4ViT,
+    get_vision_cos_sin,
+)
+from vllm_ascend.utils import register_ascend_customop
+
+VISION_DIM = 1024
+VISION_HEADS = 16
+VISION_INTER_DIM = 2816
+RMS_NORM_EPS = 1e-6
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_ascend_vision_ops():
+    register_ascend_customop()
+    with set_current_vllm_config(VllmConfig()):
+        yield
+
+
+@pytest.fixture
+def vision_config():
+    return SimpleNamespace(
+        vision_dim=VISION_DIM,
+        vision_n_heads=VISION_HEADS,
+        vision_inter_dim=VISION_INTER_DIM,
+    )
+
+
+def _new_bf16_module(module_cls, config):
+    original_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.bfloat16)
+        module = module_cls(config)
+    finally:
+        torch.set_default_dtype(original_dtype)
+    return module.eval().npu()
+
+
+def _reference_rms_norm(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x_fp32 = x.float()
+    normalized = x_fp32 * torch.rsqrt(x_fp32.square().mean(-1, keepdim=True) + RMS_NORM_EPS)
+    return (weight * normalized).to(dtype)
+
+
+def _reference_apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1).to(dtype)
+
+
+def _reference_attention(
+    attention: DeepseekV4VisionAttention,
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens = x.size(0)
+    q, k, v = (
+        tensor.view(num_tokens, attention.n_heads, attention.head_dim) for tensor in attention.wqkv(x).chunk(3, dim=-1)
+    )
+    q = _reference_apply_rotary(q, cos, sin)
+    k = _reference_apply_rotary(k, cos, sin)
+    output = F.scaled_dot_product_attention(
+        q.transpose(0, 1),
+        k.transpose(0, 1),
+        v.transpose(0, 1),
+    )
+    return attention.wo(output.transpose(0, 1).reshape(num_tokens, -1))
+
+
+def _reference_mlp(block: DeepseekV4VisionBlock, x: torch.Tensor) -> torch.Tensor:
+    gate, up = block.mlp.w1(x).chunk(2, dim=-1)
+    return block.mlp.w2(F.silu(gate) * up)
+
+
+def _reference_block(
+    block: DeepseekV4VisionBlock,
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    attention_input = _reference_rms_norm(x, block.norm1.weight)
+    residual = x + _reference_attention(block.attn, attention_input, cos, sin)
+    mlp_input = _reference_rms_norm(residual, block.norm2.weight)
+    return residual + _reference_mlp(block, mlp_input)
+
+
+def _assert_vision_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    max_abs_error: float,
+    mean_abs_error: float,
+    min_cosine_similarity: float,
+) -> None:
+    actual_fp32 = actual.float().reshape(-1)
+    expected_fp32 = expected.float().reshape(-1)
+    error = (actual_fp32 - expected_fp32).abs()
+    cosine_similarity = F.cosine_similarity(actual_fp32, expected_fp32, dim=0)
+
+    max_error = error.max().item()
+    mean_error = error.mean().item()
+    cosine = cosine_similarity.item()
+    metrics = f"max_abs_error={max_error}, mean_abs_error={mean_error}, cosine_similarity={cosine}"
+    print(metrics)
+
+    assert max_error <= max_abs_error, metrics
+    assert mean_error <= mean_abs_error, metrics
+    assert cosine >= min_cosine_similarity, metrics
+
+
+@pytest.mark.parametrize("grid", [(4, 4), (16, 24), (48, 72)])
+def test_fused_attention_matches_original_formula(vision_config, grid):
+    torch.manual_seed(7)
+    attention = _new_bf16_module(DeepseekV4VisionAttention, vision_config)
+    num_tokens = grid[0] * grid[1]
+    x = torch.randn(num_tokens, VISION_DIM, dtype=torch.bfloat16, device="npu")
+    cos, sin = get_vision_cos_sin(grid[0], grid[1], attention.head_dim // 2, 10000.0)
+    cos = cos.npu()
+    sin = sin.npu()
+
+    with torch.inference_mode():
+        expected = _reference_attention(attention, x, cos, sin)
+        actual = attention(x, cos, sin)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.03125,
+        mean_abs_error=0.002,
+        min_cosine_similarity=0.9999,
+    )
+
+
+@pytest.mark.parametrize("grid", [(4, 4), (16, 24), (48, 72)])
+def test_fused_vision_block_matches_original_formula(vision_config, grid):
+    torch.manual_seed(17)
+    block = _new_bf16_module(DeepseekV4VisionBlock, vision_config)
+    num_tokens = grid[0] * grid[1]
+    x = torch.randn(num_tokens, VISION_DIM, dtype=torch.bfloat16, device="npu")
+    cos, sin = get_vision_cos_sin(grid[0], grid[1], VISION_DIM // VISION_HEADS // 2, 10000.0)
+    cos = cos.npu()
+    sin = sin.npu()
+
+    with torch.inference_mode():
+        expected = _reference_block(block, x, cos, sin)
+        actual = block(x.clone(), cos, sin)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.0625,
+        mean_abs_error=0.004,
+        min_cosine_similarity=0.9999,
+    )
+
+
+def test_real_weights_full_vit_matches_original_formula():
+    model_path = os.getenv("DEEPSEEK_V4_VISION_MODEL_PATH")
+    if not model_path:
+        pytest.skip("DEEPSEEK_V4_VISION_MODEL_PATH is not set")
+    assert model_path is not None
+
+    model_root = Path(model_path)
+    config = SimpleNamespace(**json.loads((model_root / "config.json").read_text()))
+    checkpoint = load_file(model_root / "quant_model_weights-00078-of-00078.safetensors")
+    vision_weights = {
+        name.removeprefix("vision."): tensor for name, tensor in checkpoint.items() if name.startswith("vision.")
+    }
+    model = _new_bf16_module(DeepseekV4ViT, config)
+    model.load_state_dict(vision_weights, strict=True)
+
+    torch.manual_seed(29)
+    grid = (16, 24)
+    patches = torch.randn(
+        grid[0] * grid[1],
+        3,
+        config.vision_patch_size,
+        config.vision_patch_size,
+        dtype=torch.bfloat16,
+        device="npu",
+    )
+
+    with torch.inference_mode():
+        expected = model.patch_embed(patches)
+        cos, sin = get_vision_cos_sin(grid[0], grid[1], model.rope_dim, model.rope_theta)
+        cos = cos.npu()
+        sin = sin.npu()
+        for block in model.blocks:
+            expected = _reference_block(block, expected, cos, sin)
+        expected = _reference_rms_norm(expected, model.norm.weight)
+        actual = model(patches, *grid)
+    torch.npu.synchronize()
+
+    _assert_vision_close(
+        actual,
+        expected,
+        max_abs_error=0.125,
+        mean_abs_error=0.005,
+        min_cosine_similarity=0.9999,
+    )

--- a/tests/ut/models/test_deepseek_v4_vision.py
+++ b/tests/ut/models/test_deepseek_v4_vision.py
@@ -1,8 +1,16 @@
-from unittest.mock import MagicMock
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
 from torch import nn
 from vllm.model_executor.models.interfaces import supports_eagle3
 
+from vllm_ascend.models.deepseek_v4 import vision_dp
+from vllm_ascend.models.deepseek_v4.vision import DeepseekV4Aligner, DeepseekV4ViT
 from vllm_ascend.models.deepseek_v4.vl_model import (
     AscendDeepseekV4ForConditionalGeneration,
 )
@@ -18,3 +26,172 @@ def test_vision_wrapper_exposes_dspark_aux_hidden_state_interface():
 
     model.set_aux_hidden_state_layers((41, 42, 43))
     language_model.set_aux_hidden_state_layers.assert_called_once_with((41, 42, 43))
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_image_encoder_dp_is_opt_in(enabled):
+    model = AscendDeepseekV4ForConditionalGeneration.__new__(AscendDeepseekV4ForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.use_data_parallel = enabled
+    model.vision = MagicMock()
+    model.aligner = MagicMock()
+    model.aligner.w1.weight = torch.ones(1)
+    features = torch.tensor([[10.0, 20.0], [30.0, 40.0]])
+    model.aligner.return_value = features
+    patches = torch.ones(2, 3, 2, 2)
+    grid = torch.tensor([[1, 2]])
+    perm = torch.tensor([1, 0])
+    with patch(
+        "vllm_ascend.models.deepseek_v4.vl_model.run_dp_sharded_deepseek_v4_vision",
+        return_value=(features,),
+    ) as dp:
+        result = model._process_image_input(patches, grid, grid, perm)
+    assert model.supports_encoder_tp_data
+    if enabled:
+        dp.assert_called_once_with(model.vision, model.aligner, patches, grid, grid, perm)
+        model.vision.assert_not_called()
+        assert result[0] is features
+    else:
+        dp.assert_not_called()
+        model.vision.assert_called_once()
+        torch.testing.assert_close(result[0], features[perm])
+
+
+def make_models(dtype=torch.float32):
+    torch.manual_seed(17)
+    config = SimpleNamespace(
+        vision_patch_size=2,
+        vision_dim=8,
+        vision_n_heads=2,
+        vision_inter_dim=12,
+        vision_n_layers=2,
+        vision_rope_theta=10000.0,
+        vision_downsample_ratio=3,
+        hidden_size=12,
+    )
+    return DeepseekV4ViT(config).to(dtype).eval(), DeepseekV4Aligner(config).to(dtype).eval()
+
+
+def make_inputs(grids, dtype=torch.float32):
+    generator = torch.Generator().manual_seed(23)
+    vit_grid = torch.tensor(grids, dtype=torch.int64).reshape(-1, 2)
+    llm_grid = (vit_grid + 2) // 3
+    patches = torch.randn(sum(h * w for h, w in grids), 3, 2, 2, generator=generator).to(dtype)
+    lengths = llm_grid.prod(dim=1).tolist()
+    perm = torch.cat([torch.randperm(n, generator=generator) for n in lengths]) if lengths else torch.empty(0).long()
+    return patches, vit_grid, llm_grid, perm
+
+
+def reference_embeddings(vision, aligner, inputs):
+    patches, vit_grid, llm_grid, perm = inputs
+    outputs = []
+    patch_offset = output_offset = 0
+    for (h, w), (lh, lw) in zip(vit_grid.tolist(), llm_grid.tolist(), strict=True):
+        image = patches[patch_offset : patch_offset + h * w].to(aligner.w1.weight.dtype)
+        features = aligner(vision(image, h, w), h, w)
+        outputs.append(features[perm[output_offset : output_offset + lh * lw].to(features.device)])
+        patch_offset += h * w
+        output_offset += lh * lw
+    return tuple(outputs)
+
+
+def assignments(inputs, tp_size):
+    order, counts, _ = vision_dp.get_load_balance_assignment(inputs[1].prod(dim=1).tolist(), tp_size)
+    result = []
+    offset = 0
+    for count in counts:
+        result.append(order[offset : offset + count])
+        offset += count
+    return result
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+@pytest.mark.parametrize("grids", [[(1, 1)], [(4, 4), (3, 5)], [(3, 3), (8, 7), (1, 1), (4, 5), (6, 6)]])
+@torch.inference_mode()
+def test_encoder_dp_matches_replicated_path(monkeypatch, dtype, tp_size, grids):
+    vision, aligner = make_models(dtype)
+    # The processor's dtype need not match the model's dtype.
+    inputs = make_inputs(grids, torch.float32)
+    reference = reference_embeddings(vision, aligner, inputs)
+    rank_images = assignments(inputs, tp_size)
+    max_rows = max(sum(reference[i].shape[0] for i in indices) for indices in rank_images)
+    rank_buffers = []
+    for indices in rank_images:
+        buffer = aligner.w2.weight.new_zeros((max_rows, aligner.w2.out_features))
+        offset = 0
+        for i in indices:
+            rows = reference[i].shape[0]
+            buffer[offset : offset + rows].copy_(reference[i])
+            offset += rows
+        rank_buffers.append(buffer)
+    expected_gather = torch.cat(rank_buffers)
+    monkeypatch.setattr(vision_dp, "get_tensor_model_parallel_world_size", lambda: tp_size)
+    call_count = 0
+    for rank in range(tp_size):
+        monkeypatch.setattr(vision_dp, "get_tensor_model_parallel_rank", lambda rank=rank: rank)
+        spy = MagicMock(wraps=vision.forward)
+        with monkeypatch.context() as context:
+            context.setattr(vision, "forward", spy)
+
+            def gather(local, dim, rank=rank):
+                assert dim == 0
+                torch.testing.assert_close(local, rank_buffers[rank], rtol=0, atol=0)
+                return expected_gather
+
+            gather_mock = MagicMock(side_effect=gather)
+            context.setattr(vision_dp, "tensor_model_parallel_all_gather", gather_mock)
+            output = vision_dp.run_dp_sharded_deepseek_v4_vision(vision, aligner, *inputs)
+        assert len(output) == len(reference)
+        for actual, expected in zip(output, reference, strict=True):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+            assert actual.dtype == dtype
+            if tp_size > 1:
+                assert actual.untyped_storage().data_ptr() != expected_gather.untyped_storage().data_ptr()
+                assert actual.untyped_storage().nbytes() == actual.numel() * actual.element_size()
+        assert spy.call_count == len(rank_images[rank])
+        assert gather_mock.call_count == int(tp_size > 1)
+        call_count += spy.call_count
+    # Every image is computed exactly once across the whole TP group.
+    assert call_count == len(grids)
+
+
+@torch.inference_mode()
+def test_empty_batch_has_no_encoder_or_collective_calls(monkeypatch):
+    vision, aligner = make_models()
+    monkeypatch.setattr(vision, "forward", MagicMock(side_effect=AssertionError("Unexpected encoder call")))
+    gather = MagicMock(side_effect=AssertionError("Unexpected collective"))
+    monkeypatch.setattr(vision_dp, "tensor_model_parallel_all_gather", gather)
+    assert vision_dp.run_dp_sharded_deepseek_v4_vision(vision, aligner, *make_inputs([])) == ()
+
+
+@pytest.mark.parametrize(
+    "case", ["grid_shape", "grid_dtype", "nonpositive", "merge", "patch_count", "perm_count", "perm_dtype"]
+)
+def test_invalid_metadata_rejected_before_collective(monkeypatch, case):
+    vision, aligner = make_models()
+    inputs = list(make_inputs([(4, 5)]))
+    if case == "grid_shape":
+        inputs[1] = inputs[1].flatten()
+    elif case == "grid_dtype":
+        inputs[1] = inputs[1].float()
+    elif case == "nonpositive":
+        inputs[1][0, 0] = 0
+    elif case == "merge":
+        inputs[2][0, 0] += 1
+    elif case == "patch_count":
+        inputs[0] = inputs[0][:-1]
+    elif case == "perm_count":
+        inputs[3] = inputs[3][:-1]
+    elif case == "perm_dtype":
+        inputs[3] = inputs[3].float()
+    gather = MagicMock()
+    monkeypatch.setattr(vision_dp, "tensor_model_parallel_all_gather", gather)
+    with pytest.raises(ValueError):
+        vision_dp.run_dp_sharded_deepseek_v4_vision(vision, aligner, *inputs)
+    gather.assert_not_called()
+
+
+def test_assignment_uses_patch_load_not_image_count():
+    inputs = make_inputs([(10, 10), (3, 3), (2, 2), (1, 1)])
+    assert assignments(inputs, 2) == [[0], [1, 2, 3]]

--- a/tests/ut/models/test_deepseek_v4_vision.py
+++ b/tests/ut/models/test_deepseek_v4_vision.py
@@ -7,13 +7,30 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from torch import nn
+from vllm import ir
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.models.interfaces import supports_eagle3
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.models.deepseek_v4 import vision_dp
 from vllm_ascend.models.deepseek_v4.vision import DeepseekV4Aligner, DeepseekV4ViT
 from vllm_ascend.models.deepseek_v4.vl_model import (
     AscendDeepseekV4ForConditionalGeneration,
 )
+
+
+@pytest.fixture
+def cpu_vision_config(monkeypatch):
+    # Keep numeric DP tests on native PyTorch even when other UTs register
+    # Ascend custom ops. All patches and configuration are scoped to one test.
+    monkeypatch.setattr(CustomOp, "dispatch_forward", lambda self, compile_native=False: self.forward_native)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.mm_encoder_attention.get_vit_attn_backend",
+        lambda **kwargs: AttentionBackendEnum.TORCH_SDPA,
+    )
+    with set_current_vllm_config(VllmConfig()), ir.ops.rms_norm.set_priority(["native"]):
+        yield
 
 
 def test_vision_wrapper_exposes_dspark_aux_hidden_state_interface():
@@ -109,7 +126,7 @@ def assignments(inputs, tp_size):
 @pytest.mark.parametrize("tp_size", [1, 2, 4])
 @pytest.mark.parametrize("grids", [[(1, 1)], [(4, 4), (3, 5)], [(3, 3), (8, 7), (1, 1), (4, 5), (6, 6)]])
 @torch.inference_mode()
-def test_encoder_dp_matches_replicated_path(monkeypatch, dtype, tp_size, grids):
+def test_encoder_dp_matches_replicated_path(monkeypatch, cpu_vision_config, dtype, tp_size, grids):
     vision, aligner = make_models(dtype)
     # The processor's dtype need not match the model's dtype.
     inputs = make_inputs(grids, torch.float32)
@@ -157,7 +174,7 @@ def test_encoder_dp_matches_replicated_path(monkeypatch, dtype, tp_size, grids):
 
 
 @torch.inference_mode()
-def test_empty_batch_has_no_encoder_or_collective_calls(monkeypatch):
+def test_empty_batch_has_no_encoder_or_collective_calls(monkeypatch, cpu_vision_config):
     vision, aligner = make_models()
     monkeypatch.setattr(vision, "forward", MagicMock(side_effect=AssertionError("Unexpected encoder call")))
     gather = MagicMock(side_effect=AssertionError("Unexpected collective"))
@@ -168,7 +185,7 @@ def test_empty_batch_has_no_encoder_or_collective_calls(monkeypatch):
 @pytest.mark.parametrize(
     "case", ["grid_shape", "grid_dtype", "nonpositive", "merge", "patch_count", "perm_count", "perm_dtype"]
 )
-def test_invalid_metadata_rejected_before_collective(monkeypatch, case):
+def test_invalid_metadata_rejected_before_collective(monkeypatch, cpu_vision_config, case):
     vision, aligner = make_models()
     inputs = list(make_inputs([(4, 5)]))
     if case == "grid_shape":

--- a/tests/ut/models/test_deepseek_v4_vision_preprocess.py
+++ b/tests/ut/models/test_deepseek_v4_vision_preprocess.py
@@ -158,3 +158,13 @@ def test_hf_tokenizer_call_is_thread_safe():
         competing_call.result()
 
     assert all(torch.equal(output, torch.tensor([[1]])) for output in outputs)
+
+
+def test_hf_processor_accepts_base_class_call_signature():
+    info = _ConcurrentStubInfo()
+    info.tokenizer = _NonThreadSafeTokenizer()
+    processor = DeepseekV4VLMultiModalProcessor(info, None)
+
+    output = processor._call_hf_processor("prompt", {"images": []}, {})
+
+    assert torch.equal(output["input_ids"], torch.tensor([[1]]))

--- a/vllm_ascend/models/deepseek_v4/mm_preprocess.py
+++ b/vllm_ascend/models/deepseek_v4/mm_preprocess.py
@@ -390,9 +390,11 @@ class DeepseekV4VLMultiModalProcessor(BaseMultiModalProcessor[DeepseekV4VLProces
         prompt: str,
         mm_data: Mapping[str, object],
         mm_kwargs: Mapping[str, object],
-        tok_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object] | None = None,
     ) -> BatchFeature:
-        """Combine the local image transform with v0.27 tokenization."""
+        """Combine the local image transform with vLLM tokenization."""
+        if tok_kwargs is None:
+            tok_kwargs = {}
         processor = self.info.get_hf_processor(**mm_kwargs)
         processed = processor(
             text=prompt,

--- a/vllm_ascend/models/deepseek_v4/vision.py
+++ b/vllm_ascend/models/deepseek_v4/vision.py
@@ -12,6 +12,10 @@ from functools import lru_cache
 import torch
 import torch.nn.functional as F
 from torch import nn
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.attention import MMEncoderAttention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 
 
 @lru_cache(8)
@@ -22,25 +26,6 @@ def get_vision_cos_sin(n_h: int, n_w: int, dim: int, theta: float) -> tuple[torc
     freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float()
     freqs = (freqs * inv_freq).flatten(1)
     return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
-
-
-def apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-    dtype = x.dtype
-    x1, x2 = x.float().chunk(2, dim=-1)
-    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
-
-
-class DeepseekV4RMSNorm(nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        dtype = x.dtype
-        x = x.float()
-        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
-        return (self.weight * x).to(dtype)
 
 
 class DeepseekV4PatchEmbed(nn.Module):
@@ -59,14 +44,24 @@ class DeepseekV4VisionAttention(nn.Module):
         self.head_dim = config.vision_dim // config.vision_n_heads
         self.wqkv = nn.Linear(config.vision_dim, 3 * config.vision_dim)
         self.wo = nn.Linear(config.vision_dim, config.vision_dim)
+        self.apply_rotary_emb = ApplyRotaryEmb(
+            enforce_enable=True,
+            is_neox_style=True,
+            enable_fp32_compute=True,
+        )
+        self.attn = MMEncoderAttention(
+            num_heads=self.n_heads,
+            head_size=self.head_dim,
+            scale=self.head_dim**-0.5,
+        )
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
         n = x.size(0)
         q, k, v = (t.view(n, self.n_heads, self.head_dim) for t in self.wqkv(x).chunk(3, dim=-1))
-        q = apply_rotary(q, cos, sin)
-        k = apply_rotary(k, cos, sin)
-        o = F.scaled_dot_product_attention(q.transpose(0, 1), k.transpose(0, 1), v.transpose(0, 1))
-        return self.wo(o.transpose(0, 1).reshape(n, -1))
+        qk = self.apply_rotary_emb(torch.stack((q, k)), cos.squeeze(1), sin.squeeze(1))
+        q, k = qk.unbind()
+        o = self.attn(q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0))
+        return self.wo(o.squeeze(0).reshape(n, -1))
 
 
 class DeepseekV4VisionMLP(nn.Module):
@@ -74,23 +69,23 @@ class DeepseekV4VisionMLP(nn.Module):
         super().__init__()
         self.w1 = nn.Linear(config.vision_dim, 2 * config.vision_inter_dim, bias=False)
         self.w2 = nn.Linear(config.vision_inter_dim, config.vision_dim, bias=False)
+        self.act_fn = SiluAndMul()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate, up = self.w1(x).chunk(2, dim=-1)
-        return self.w2(F.silu(gate) * up)
+        return self.w2(self.act_fn(self.w1(x)))
 
 
 class DeepseekV4VisionBlock(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.norm1 = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm1 = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
         self.attn = DeepseekV4VisionAttention(config)
-        self.norm2 = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm2 = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
         self.mlp = DeepseekV4VisionMLP(config)
 
     def forward(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x), cos, sin)
-        return x + self.mlp(self.norm2(x))
+        residual = x + self.attn(self.norm1(x), cos, sin)
+        return residual + self.mlp(self.norm2(residual))
 
 
 class DeepseekV4ViT(nn.Module):
@@ -102,7 +97,7 @@ class DeepseekV4ViT(nn.Module):
         self.rope_theta = config.vision_rope_theta
         self.patch_embed = DeepseekV4PatchEmbed(config)
         self.blocks = nn.ModuleList([DeepseekV4VisionBlock(config) for _ in range(config.vision_n_layers)])
-        self.norm = DeepseekV4RMSNorm(config.vision_dim)
+        self.norm = RMSNorm(config.vision_dim, eps=1e-6, dtype=torch.float32)
 
     def forward(self, patches: torch.Tensor, n_vit_h: int, n_vit_w: int) -> torch.Tensor:
         x = self.patch_embed(patches)

--- a/vllm_ascend/models/deepseek_v4/vision_dp.py
+++ b/vllm_ascend/models/deepseek_v4/vision_dp.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Image-level encoder DP within the language model's TP group.
+
+Weights stay replicated. Each image's ViT, aligner and permutation execute on
+one rank; an all-gather restores the complete embedding tuple on every rank.
+All TP ranks must enter with the same ordered, uncached image inputs, as in
+vLLM's other batch-level encoder DP implementations.
+"""
+
+from itertools import accumulate
+
+import torch
+from torch import nn
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
+from vllm.model_executor.models.vision import get_load_balance_assignment
+
+
+def run_dp_sharded_deepseek_v4_vision(
+    vision: nn.Module,
+    aligner: nn.Module,
+    patches: torch.Tensor,
+    vit_grid: torch.Tensor,
+    llm_grid: torch.Tensor,
+    perm: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    """Balance whole images by patch count; gather final, reordered embeddings.
+
+    Unlike the generic MRoPE helper, output lengths come from ``llm_grid``:
+    DeepSeek V4's aligner pads odd grids before spatial merging, so integer
+    division of the input patch count would truncate valid output rows.
+    """
+    if vit_grid.ndim != 2 or vit_grid.shape[1] != 2 or llm_grid.shape != vit_grid.shape:
+        raise ValueError("vit_grid and llm_grid must have matching [num_images, 2] shapes.")
+    if vit_grid.dtype not in (torch.int32, torch.int64) or llm_grid.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Image grids must contain integer dimensions.")
+    if patches.ndim != 4 or perm.ndim != 1 or perm.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Expected patches [num_patches, 3, p, p] and a one-dimensional integer perm.")
+
+    vit_shapes = vit_grid.tolist()
+    llm_shapes = llm_grid.tolist()
+    merge = aligner.downsample_ratio
+    patch_counts: list[int] = []
+    output_counts: list[int] = []
+    for (n_vit_h, n_vit_w), (n_llm_h, n_llm_w) in zip(vit_shapes, llm_shapes, strict=True):
+        if min(n_vit_h, n_vit_w, n_llm_h, n_llm_w) <= 0:
+            raise ValueError("Image grid dimensions must be positive.")
+        expected = ((n_vit_h + merge - 1) // merge, (n_vit_w + merge - 1) // merge)
+        if (n_llm_h, n_llm_w) != expected:
+            raise ValueError(f"llm_grid {(n_llm_h, n_llm_w)} does not match merged ViT grid {expected}.")
+        patch_counts.append(n_vit_h * n_vit_w)
+        output_counts.append(n_llm_h * n_llm_w)
+    if patches.shape[0] != sum(patch_counts) or perm.numel() != sum(output_counts):
+        raise ValueError("Patch/permutation lengths do not match the image grids.")
+    if not patch_counts:
+        return ()
+
+    patch_offsets = [0, *accumulate(patch_counts)]
+    output_offsets = [0, *accumulate(output_counts)]
+
+    def encode_image(index: int) -> torch.Tensor:
+        image_n_vit_h, image_n_vit_w = vit_shapes[index]
+        image_patches = patches[patch_offsets[index] : patch_offsets[index + 1]].to(aligner.w1.weight.dtype)
+        image_embeds = aligner(vision(image_patches, image_n_vit_h, image_n_vit_w), image_n_vit_h, image_n_vit_w)
+        item_perm = perm[output_offsets[index] : output_offsets[index + 1]].to(image_embeds.device)
+        return image_embeds[item_perm]
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size == 1:
+        return tuple(encode_image(index) for index in range(len(patch_counts)))
+    tp_rank = get_tensor_model_parallel_rank()
+    image_order, samples_per_rank, _ = get_load_balance_assignment(patch_counts, tp_size)
+    sample_offsets = [0, *accumulate(samples_per_rank)]
+    rank_images = [image_order[sample_offsets[rank] : sample_offsets[rank + 1]] for rank in range(tp_size)]
+
+    rows_per_rank = [sum(output_counts[index] for index in indices) for indices in rank_images]
+    max_rows = max(rows_per_rank)
+
+    # Empty ranks participate with the same shape/dtype/device, without running
+    # dummy images through the encoder. Zero padding is discarded after gather.
+    local_embeds = aligner.w2.weight.new_zeros((max_rows, aligner.w2.out_features))
+    cursor = 0
+    for index in rank_images[tp_rank]:
+        rows = output_counts[index]
+        local_embeds[cursor : cursor + rows].copy_(encode_image(index))
+        cursor += rows
+    gathered = tensor_model_parallel_all_gather(local_embeds, dim=0)
+
+    ordered_embeds: dict[int, torch.Tensor] = {}
+    for rank, indices in enumerate(rank_images):
+        cursor = rank * max_rows
+        for index in indices:
+            rows = output_counts[index]
+            # Encoder caches retain individual images. Do not let one cached
+            # image keep the entire padded, all-rank gather allocation alive.
+            ordered_embeds[index] = gathered[cursor : cursor + rows].clone()
+            cursor += rows
+    return tuple(ordered_embeds[index] for index in range(len(patch_counts)))

--- a/vllm_ascend/models/deepseek_v4/vl_model.py
+++ b/vllm_ascend/models/deepseek_v4/vl_model.py
@@ -34,6 +34,7 @@ from vllm_ascend.models.deepseek_v4.vision import (
     DeepseekV4Aligner,
     DeepseekV4ViT,
 )
+from vllm_ascend.models.deepseek_v4.vision_dp import run_dp_sharded_deepseek_v4_vision
 
 
 def _vision_parameter_name(name: str) -> str | None:
@@ -59,6 +60,7 @@ class AscendDeepseekV4ForConditionalGeneration(
     """DeepSeek-V4 vision entry point using the Ascend text backbone."""
 
     requires_raw_input_tokens = True
+    supports_encoder_tp_data = True
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -77,6 +79,7 @@ class AscendDeepseekV4ForConditionalGeneration(
         self.config = config
         self.multimodal_config = model_config.multimodal_config
         assert self.multimodal_config is not None
+        self.use_data_parallel = self.multimodal_config.mm_encoder_tp_mode == "data"
 
         image_enabled = config.vision_n_layers > 0 and self.multimodal_config.get_limit_per_prompt("image") > 0
         with self._mark_tower_model(vllm_config, {"image"}):
@@ -134,6 +137,8 @@ class AscendDeepseekV4ForConditionalGeneration(
         perm: torch.Tensor,
     ) -> tuple[torch.Tensor, ...]:
         assert self.vision is not None and self.aligner is not None
+        if self.use_data_parallel:
+            return run_dp_sharded_deepseek_v4_vision(self.vision, self.aligner, patches, vit_grid, llm_grid, perm)
         patches = patches.to(self.aligner.w1.weight.dtype)
 
         embeds: list[torch.Tensor] = []


### PR DESCRIPTION
### What this PR does / why we need it?

Depends on #15943. The [incremental DP-only diff](https://github.com/vrooml/vllm-ascend/compare/4d09311095ebf33b01037e31d5992c34f3ed5914...33e711537db0b95d5d005266e53678da6a4ec9d9) contains one commit and three files; rebase after the prerequisite merges.

Add image-level DP within each TP group to avoid encoding the same images on every rank. Encoder weights remain replicated.

- Distribute whole images by patch count using vLLM's load-balancing helper.
- Run ViT and aligner only on the assigned rank.
- Pad and all-gather embeddings, then restore image order with independent per-image storage.
- Handle empty batches/ranks and TP1 without dummy image encoding.

### Does this PR introduce _any_ user-facing change?

Enable with `--mm-encoder-tp-mode data`. The default `weights` path and language-model computation are unchanged. Encoder DP is independent of request-level `data_parallel_size`.

### How was this patch tested?

- Added CPU UT coverage in `tests/ut/models/test_deepseek_v4_vision.py`: weights/data dispatch, TP1/2/4, FP32/BF16, heterogeneous grids, empty batches/ranks, padding, output parity/order, independent storage and invalid metadata. Collectives are mocked.
- Manual four-NPU/HCCL checks passed for empty, one-image, two-image and five-image inputs, including encoder-call counts and output parity.
- Real-weight ViT+aligner checks passed for single, heterogeneous, reversed and repeated images: all 16 rank/case comparisons had maximum absolute error `0` against replicated encoding (`rtol=1e-3`, `atol=1e-3`).
- Targeted `ruff check`, `ruff format --check`, and `git diff --check` passed.

Hardware validation used the offline `c2563694b` checkout with #15943 vision changes and this DP implementation applied; the tested vision source files match this PR.

AISBench A/B used the same code/data, switching only `weights` (A) versus `data` (B):

- 16 NPUs, TP4/DP4 with EP, `FULL_DECODE_ONLY`, non-eager, profiling disabled.
- Concurrency 128; 32 warmup and 128 measured requests per scene/round; maximum output length 32 tokens.
- A1-B1-B2-A2 order; all 2,048 measured requests succeeded.

| Request scene | Mean TTFT change | Mean per-round request throughput change |
|---|---:|---:|
| One small image | -11.09% | +14.93% |
| One large image | -8.91% | +14.29% |
| Eight heterogeneous images | -17.66% | +21.85% |
| One large and seven smaller heterogeneous images | -19.66% | +23.41% |

Results are client-side, per-round means over two repeats of 128-request batches. Single-image throughput varied: small-image B2 was 1.49% below A2; multi-image gains were consistent across repeats.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
