### PR TITLE
fuse compressor meta into sk

### DIFF
--- a/csrc/attention/compressor_metadata/op_kernel/compressor_metadata.h
+++ b/csrc/attention/compressor_metadata/op_kernel/compressor_metadata.h
@@ -81,7 +81,7 @@ class CompressorMetadataKernel {
 public:
     __aicore__ inline CompressorMetadataKernel() {}
 
-    __aicore__ inline void Init(CompressorMetadataTilingData* tilingData, TPipe* pipe)
+    __aicore__ inline void Init(const CompressorMetadataTilingData* tilingData, TPipe* pipe)
     {
         numRows_ = tilingData->numRows;
         actualNumReqs_ = tilingData->actualNumReqs;


### PR DESCRIPTION
(cherry picked from commit feda89cc5f23b67aaca4713ccd1f6d63c21b62c4)

### What this PR does / why we need it?
修复comperssor meta算子静态编译问题，解决部分SK断图问题
-->

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
