### PR TITLE
[Ops][Feature] Support inline cos/sin calculation for MRoPE in Qwen3 Family

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
@@ -447,4 +447,3 @@ def test_split_qkv_rmsnorm_mrope_inline_cos_sin(
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
-

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
@@ -128,8 +128,8 @@ def naive_split_qkv_rmsnorm_mrope(
         q_reshaped[token_idx, :, :rotary_dim] = torch.cat([new_q1, new_q2], dim=1)
         k_reshaped[token_idx, :, :rotary_dim] = torch.cat([new_k1, new_k2], dim=1)
 
-    q_result = q_reshaped.view(num_tokens, -1)
-    k_result = k_reshaped.view(num_tokens, -1)
+    q_result = q_reshaped.reshape(num_tokens, n_q_head * head_size)
+    k_result = k_reshaped.reshape(num_tokens, n_kv_head * head_size)
 
     q = q_result.to(qkv.dtype)
     k = k_result.to(qkv.dtype)
@@ -199,8 +199,8 @@ def naive_split_qkv_rmsnorm_mrope_interleaved(
         q_reshaped[token_idx, :, :rotary_dim] = torch.cat([new_q1, new_q2], dim=1)
         k_reshaped[token_idx, :, :rotary_dim] = torch.cat([new_k1, new_k2], dim=1)
 
-    q_result = q_reshaped.view(num_tokens, -1)
-    k_result = k_reshaped.view(num_tokens, -1)
+    q_result = q_reshaped.reshape(num_tokens, n_q_head * head_size)
+    k_result = k_reshaped.reshape(num_tokens, n_kv_head * head_size)
 
     q = q_result.to(qkv.dtype)
     k = k_result.to(qkv.dtype)
@@ -315,6 +315,136 @@ def test_split_qkv_rmsnorm_mrope(
 
     torch.testing.assert_close(real_k.cpu(), golden_k.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
 
+    torch.testing.assert_close(real_v.cpu(), golden_v.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    if has_gate:
+        torch.testing.assert_close(real_gate.cpu(), golden_gate.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
+INLINE_MODEL_CASES = [
+    pytest.param(
+        {
+            "num_q_heads": 8,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "mrope_section": [24, 20, 20],
+            "has_gate": False,
+            "rms_weight_offset": 0.0,
+            "positions_capacity": 4099,
+        },
+        id="qwen3_vl_235b_tp8",
+    ),
+    pytest.param(
+        {
+            "num_q_heads": 8,
+            "num_kv_heads": 1,
+            "head_size": 256,
+            "mrope_section": [11, 11, 10],
+            "has_gate": True,
+            "rms_weight_offset": 1.0,
+            "positions_capacity": 8241,
+        },
+        id="qwen3_5_35b_tp2",
+    ),
+]
+
+
+@pytest.mark.parametrize("num_tokens", [0, 1, 2, 8, 32, 39, 40, 41, 80, 2060, 2062, 4096])
+@pytest.mark.parametrize("model_case", INLINE_MODEL_CASES)
+@pytest.mark.parametrize("is_interleaved", IS_INTERLEAVED)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_split_qkv_rmsnorm_mrope_inline_cos_sin(
+    num_tokens: int,
+    model_case: dict,
+    is_interleaved: bool,
+    dtype: torch.dtype,
+):
+    """Cover both profiled models, strided positions, and the core boundary."""
+    device = "npu:0"
+    eps = 1e-6
+    torch.set_default_device(device)
+
+    num_q_heads = model_case["num_q_heads"]
+    num_kv_heads = model_case["num_kv_heads"]
+    head_size = model_case["head_size"]
+    mrope_section = model_case["mrope_section"]
+    has_gate = model_case["has_gate"]
+    rms_weight_offset = model_case["rms_weight_offset"]
+    positions_capacity = model_case["positions_capacity"]
+    rope_dim = 2 * sum(mrope_section)
+    q_size = num_q_heads * head_size
+    kv_size = num_kv_heads * head_size
+
+    qkv_width = q_size + 2 * kv_size + (q_size if has_gate else 0)
+    qkv = torch.randn(num_tokens, qkv_width, dtype=dtype, device=device)
+    q_weight = torch.randn(head_size, dtype=dtype, device=device) * 0.02
+    k_weight = torch.randn(head_size, dtype=dtype, device=device) * 0.02
+
+    positions_storage = torch.randint(0, 4096, (3, positions_capacity), dtype=torch.int64, device=device)
+    positions = positions_storage[:, 3 : 3 + num_tokens]
+    if num_tokens > 0:
+        assert not positions.is_contiguous()
+    inv_freq = 1.0 / (
+        10000
+        ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)
+    )
+    freqs = positions.to(torch.float32).unsqueeze(-1) * inv_freq
+    cos = freqs.cos()
+    sin = freqs.sin()
+
+    if has_gate:
+        q_gate_data = qkv[:, : q_size * 2].view(-1, num_q_heads, head_size * 2)
+        q_data, golden_gate = torch.chunk(q_gate_data, 2, dim=-1)
+        q_data = q_data.reshape(-1, q_size)
+        golden_gate = golden_gate.reshape(-1, q_size)
+        k_data = qkv[:, 2 * q_size : 2 * q_size + kv_size]
+        v_data = qkv[:, 2 * q_size + kv_size :]
+        qkv_for_ref = torch.cat([q_data, k_data, v_data], dim=-1)
+    else:
+        qkv_for_ref = qkv
+
+    reference = (
+        naive_split_qkv_rmsnorm_mrope_interleaved if is_interleaved else naive_split_qkv_rmsnorm_mrope
+    )
+    golden_q, golden_k, golden_v = reference(
+        qkv_for_ref.cpu(),
+        q_weight.cpu().to(torch.float32) + rms_weight_offset,
+        None,
+        k_weight.cpu().to(torch.float32) + rms_weight_offset,
+        None,
+        cos.cpu(),
+        sin.cpu(),
+        num_q_heads,
+        num_kv_heads,
+        head_size,
+        eps,
+        mrope_section,
+        rope_dim,
+    )
+
+    real_q, real_k, real_v, real_gate = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
+        qkv=qkv,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        eps=eps,
+        mrope_section=mrope_section,
+        is_interleaved=is_interleaved,
+        rope_dim=rope_dim,
+        has_gate=has_gate,
+        positions=positions,
+        inv_freq=inv_freq,
+        rms_weight_offset=rms_weight_offset,
+    )
+
+    torch.testing.assert_close(real_q.cpu(), golden_q.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
+    torch.testing.assert_close(real_k.cpu(), golden_k.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     torch.testing.assert_close(real_v.cpu(), golden_v.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)
     if has_gate:
         torch.testing.assert_close(real_gate.cpu(), golden_gate.cpu(), atol=DEFAULT_ATOL, rtol=DEFAULT_RTOL)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py
@@ -388,10 +388,7 @@ def test_split_qkv_rmsnorm_mrope_inline_cos_sin(
     positions = positions_storage[:, 3 : 3 + num_tokens]
     if num_tokens > 0:
         assert not positions.is_contiguous()
-    inv_freq = 1.0 / (
-        10000
-        ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)
-    )
+    inv_freq = 1.0 / (10000 ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim))
     freqs = positions.to(torch.float32).unsqueeze(-1) * inv_freq
     cos = freqs.cos()
     sin = freqs.sin()
@@ -407,9 +404,7 @@ def test_split_qkv_rmsnorm_mrope_inline_cos_sin(
     else:
         qkv_for_ref = qkv
 
-    reference = (
-        naive_split_qkv_rmsnorm_mrope_interleaved if is_interleaved else naive_split_qkv_rmsnorm_mrope
-    )
+    reference = naive_split_qkv_rmsnorm_mrope_interleaved if is_interleaved else naive_split_qkv_rmsnorm_mrope
     golden_q, golden_k, golden_v = reference(
         qkv_for_ref.cpu(),
         q_weight.cpu().to(torch.float32) + rms_weight_offset,
@@ -452,3 +447,4 @@ def test_split_qkv_rmsnorm_mrope_inline_cos_sin(
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -474,6 +474,17 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
     # Empirical safety threshold for large Triton grids on Ascend NPU
     _ASCEND_TRITON_GRID_LIMIT = 65535
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Materialize this together with the module before ACL graph capture.
+        # The inline fused path must not copy an input from CPU on its first
+        # captured invocation.
+        self.register_buffer(
+            "inv_freq",
+            self._compute_inv_freq(self.base).to(dtype=torch.float32),
+            persistent=False,
+        )
+
     def forward_triton(
         self,
         positions: torch.Tensor,

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -608,4 +608,3 @@ class AscendApplyRotaryEmb(ApplyRotaryEmb):
         output = self._post_process(output, origin_shape, origin_dtype)
 
         return output
-

--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -608,3 +608,4 @@ class AscendApplyRotaryEmb(ApplyRotaryEmb):
         output = self._post_process(output, origin_shape, origin_dtype)
 
         return output
+

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -33,11 +33,15 @@ def split_qkv_rmsnorm_mrope_kernel(
     k_weight_ptr: torch.Tensor,
     k_bias_ptr: torch.Tensor,
     cos_sin_ptr: torch.Tensor,
+    positions_ptr: torch.Tensor,
+    inv_freq_ptr: torch.Tensor,
     out_q_ptr: torch.Tensor,
     out_k_ptr: torch.Tensor,
     out_v_ptr: torch.Tensor,
     out_gate_ptr: torch.Tensor,
     num_tokens,
+    positions_stride_0,
+    positions_stride_1,
     front_core_num,
     num_tokens_each_front_core,
     num_tokens_each_tail_core,
@@ -47,14 +51,16 @@ def split_qkv_rmsnorm_mrope_kernel(
     q_size: tl.constexpr,
     kv_size: tl.constexpr,
     eps: tl.constexpr,
-    mrope_section_t,
-    mrope_section_h,
-    mrope_section_w,
+    mrope_section_t: tl.constexpr,
+    mrope_section_h: tl.constexpr,
+    mrope_section_w: tl.constexpr,
     has_bias: tl.constexpr,
     is_interleaved: tl.constexpr,
     rope_dim: tl.constexpr,
     half_rope_dim: tl.constexpr,
     IS_PARTIAL_ROPE: tl.constexpr,
+    INLINE_COS_SIN: tl.constexpr,
+    RMS_WEIGHT_OFFSET: tl.constexpr,
     gate_size: tl.constexpr,
 ):
     block_idx = tl.program_id(0)
@@ -69,8 +75,8 @@ def split_qkv_rmsnorm_mrope_kernel(
             num_tokens_each_front_core * front_core_num + (block_idx - front_core_num) * num_tokens_each_tail_core
         )
 
-    q_rmsnorm_weight = tl.load(q_weight_ptr + tl.arange(0, head_size))
-    k_rmsnorm_weight = tl.load(k_weight_ptr + tl.arange(0, head_size))
+    q_rmsnorm_weight = tl.load(q_weight_ptr + tl.arange(0, head_size)).to(tl.float32) + RMS_WEIGHT_OFFSET
+    k_rmsnorm_weight = tl.load(k_weight_ptr + tl.arange(0, head_size)).to(tl.float32) + RMS_WEIGHT_OFFSET
 
     if has_bias:
         q_bias = tl.load(q_bias_ptr + tl.arange(0, head_size))
@@ -110,36 +116,50 @@ def split_qkv_rmsnorm_mrope_kernel(
 
         # cos, sin
         cos_offsets = tl.arange(0, half_rope_dim)
+        cos_offsets_fp32 = cos_offsets.to(tl.float32)
         if is_interleaved:
-            h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section_h)
-            w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section_w)
+            axis = cos_offsets - (cos_offsets // 3) * 3
+            h_mask = (axis == 1) & (cos_offsets_fp32 < 3.0 * mrope_section_h)
+            w_mask = (axis == 2) & (cos_offsets_fp32 < 3.0 * mrope_section_w)
             t_mask = ~(h_mask | w_mask)
         else:
-            t_mask = cos_offsets < mrope_section_t
-            h_mask = (mrope_section_t - 1 < cos_offsets) & (cos_offsets < mrope_section_t + mrope_section_h)
-            w_mask = (mrope_section_t + mrope_section_h - 1 < cos_offsets) & (
-                cos_offsets < mrope_section_t + mrope_section_h + mrope_section_w
+            t_mask = cos_offsets_fp32 < mrope_section_t
+            h_mask = (mrope_section_t <= cos_offsets_fp32) & (
+                cos_offsets_fp32 < mrope_section_t + mrope_section_h
+            )
+            w_mask = (mrope_section_t + mrope_section_h <= cos_offsets_fp32) & (
+                cos_offsets_fp32 < mrope_section_t + mrope_section_h + mrope_section_w
             )
 
-        t_cos_offset = cos_sin_ptr + (block_offset + index) * rope_dim
-        h_cos_offset = t_cos_offset + num_tokens * rope_dim
-        w_cos_offset = h_cos_offset + num_tokens * rope_dim
+        if INLINE_COS_SIN:
+            inv_freq_row = tl.load(inv_freq_ptr + cos_offsets).to(tl.float32)
+            token_offset = (block_offset + index) * positions_stride_1
+            t_pos = tl.load(positions_ptr + token_offset).to(tl.float32)
+            h_pos = tl.load(positions_ptr + positions_stride_0 + token_offset).to(tl.float32)
+            w_pos = tl.load(positions_ptr + 2 * positions_stride_0 + token_offset).to(tl.float32)
+            selected_pos = tl.where(h_mask, h_pos, tl.where(w_mask, w_pos, t_pos))
+            freqs = selected_pos * inv_freq_row
+            cos_tensor = tl.cos(freqs).reshape(1, half_rope_dim)
+            sin_tensor = tl.sin(freqs).reshape(1, half_rope_dim)
+        else:
+            t_cos_offset = cos_sin_ptr + (block_offset + index) * rope_dim
+            h_cos_offset = t_cos_offset + num_tokens * rope_dim
+            w_cos_offset = h_cos_offset + num_tokens * rope_dim
 
-        t_sin_offset = cos_sin_ptr + (block_offset + index) * rope_dim + half_rope_dim
-        h_sin_offset = t_sin_offset + num_tokens * rope_dim
-        w_sin_offset = h_sin_offset + num_tokens * rope_dim
+            t_sin_offset = cos_sin_ptr + (block_offset + index) * rope_dim + half_rope_dim
+            h_sin_offset = t_sin_offset + num_tokens * rope_dim
+            w_sin_offset = h_sin_offset + num_tokens * rope_dim
 
-        t_cos_tensor = tl.load(t_cos_offset + cos_offsets, mask=t_mask, other=0)
-        h_cos_tensor = tl.load(h_cos_offset + cos_offsets, mask=h_mask, other=0)
-        w_cos_tensor = tl.load(w_cos_offset + cos_offsets, mask=w_mask, other=0)
-        t_sin_tensor = tl.load(t_sin_offset + cos_offsets, mask=t_mask, other=0)
-        h_sin_tensor = tl.load(h_sin_offset + cos_offsets, mask=h_mask, other=0)
-        w_sin_tensor = tl.load(w_sin_offset + cos_offsets, mask=w_mask, other=0)
+            t_cos_tensor = tl.load(t_cos_offset + cos_offsets, mask=t_mask, other=0)
+            h_cos_tensor = tl.load(h_cos_offset + cos_offsets, mask=h_mask, other=0)
+            w_cos_tensor = tl.load(w_cos_offset + cos_offsets, mask=w_mask, other=0)
+            t_sin_tensor = tl.load(t_sin_offset + cos_offsets, mask=t_mask, other=0)
+            h_sin_tensor = tl.load(h_sin_offset + cos_offsets, mask=h_mask, other=0)
+            w_sin_tensor = tl.load(w_sin_offset + cos_offsets, mask=w_mask, other=0)
 
-        cos_tensor = (t_cos_tensor + h_cos_tensor + w_cos_tensor).to(tl.float32).reshape(1, half_rope_dim)
+            cos_tensor = (t_cos_tensor + h_cos_tensor + w_cos_tensor).to(tl.float32).reshape(1, half_rope_dim)
+            sin_tensor = (t_sin_tensor + h_sin_tensor + w_sin_tensor).to(tl.float32).reshape(1, half_rope_dim)
         cos_tensor = tl.broadcast_to(cos_tensor, (2, half_rope_dim)).reshape(1, rope_dim)
-
-        sin_tensor = (t_sin_tensor + h_sin_tensor + w_sin_tensor).to(tl.float32).reshape(1, half_rope_dim)
         sin_tensor = tl.broadcast_to(sin_tensor, (2, half_rope_dim)).reshape(1, rope_dim)
 
         ## compute ##
@@ -283,17 +303,20 @@ def triton_split_qkv_rmsnorm_mrope(
     qkv: torch.Tensor,
     q_weight: torch.Tensor,
     k_weight: torch.Tensor,
-    cos_sin: torch.Tensor,
-    num_q_heads: int,
-    num_kv_heads: int,
-    head_size: int,
-    eps: float,
-    mrope_section: list[int],
-    is_interleaved: bool,
+    cos_sin: torch.Tensor | None = None,
+    num_q_heads: int = 0,
+    num_kv_heads: int = 0,
+    head_size: int = 0,
+    eps: float = 1e-6,
+    mrope_section: list[int] | None = None,
+    is_interleaved: bool = False,
     rope_dim: int | None = None,
     q_bias: torch.Tensor | None = None,
     k_bias: torch.Tensor | None = None,
     has_gate: bool = False,
+    positions: torch.Tensor | None = None,
+    inv_freq: torch.Tensor | None = None,
+    rms_weight_offset: float = 0.0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     core_num = get_vectorcore_num()
 
@@ -302,10 +325,36 @@ def triton_split_qkv_rmsnorm_mrope(
     num_tokens = qkv.shape[0]
 
     gate_size = q_size if has_gate else 0
+    expected_qkv_width = q_size + gate_size + 2 * kv_size
+    if qkv.ndim != 2 or qkv.shape[1] != expected_qkv_width:
+        raise ValueError(f"qkv must have shape [num_tokens, {expected_qkv_width}]")
+    if q_weight.numel() != head_size or k_weight.numel() != head_size:
+        raise ValueError("q_weight and k_weight must each contain head_size elements")
+    if (q_bias is None) != (k_bias is None):
+        raise ValueError("q_bias and k_bias must be both present or both absent")
+    if q_bias is not None and (q_bias.numel() != head_size or k_bias.numel() != head_size):
+        raise ValueError("q_bias and k_bias must each contain head_size elements")
 
     if rope_dim is None:
         rope_dim = head_size
+    if mrope_section is None or len(mrope_section) != 3:
+        raise ValueError("mrope_section must contain the T, H, and W sections")
+    if 2 * sum(mrope_section) != rope_dim:
+        raise ValueError("2 * sum(mrope_section) must equal rope_dim")
+    if rope_dim > head_size or rope_dim % 2 != 0:
+        raise ValueError("rope_dim must be even and no larger than head_size")
     IS_PARTIAL_ROPE = rope_dim != head_size
+
+    has_inline_arg = positions is not None or inv_freq is not None
+    if cos_sin is not None and has_inline_arg:
+        raise ValueError("cos_sin and (positions, inv_freq) are mutually exclusive")
+    if cos_sin is None and (positions is None or inv_freq is None):
+        raise ValueError("provide either cos_sin or both positions and inv_freq")
+    INLINE_COS_SIN = cos_sin is None
+    if cos_sin is not None:
+        if cos_sin.ndim != 3 or cos_sin.shape != (3, num_tokens, rope_dim):
+            raise ValueError("cos_sin must have shape [3, num_tokens, rope_dim]")
+        cos_sin = cos_sin.contiguous()
 
     front_core_num = core_num
     if num_tokens % core_num != 0:
@@ -323,11 +372,43 @@ def triton_split_qkv_rmsnorm_mrope(
     k_output = torch.empty(num_tokens, kv_size, device=qkv.device, dtype=qkv.dtype)
     v_output = torch.empty(num_tokens, kv_size, device=qkv.device, dtype=qkv.dtype)
     gate_output = torch.empty(num_tokens, gate_size, device=qkv.device, dtype=qkv.dtype)
+    if num_tokens == 0:
+        return q_output, k_output, v_output, gate_output
 
-    total_core = front_core_num + tail_core_num
-    block_dim = core_num
-    if total_core < core_num:
-        block_dim = total_core
+    positions_stride_0 = 0
+    positions_stride_1 = 0
+    if INLINE_COS_SIN:
+        if positions.ndim != 2 or positions.shape[0] != 3:
+            raise ValueError("positions must have shape [3, num_tokens] for inline MRoPE")
+        if positions.shape[1] != num_tokens:
+            raise ValueError("positions.shape[1] must match qkv.shape[0]")
+        if positions.stride(0) <= 0 or positions.stride(1) <= 0:
+            raise ValueError("positions strides must be positive")
+        if positions.dtype not in (torch.int32, torch.int64):
+            raise ValueError("positions must use int32 or int64 indices")
+        if inv_freq.numel() != rope_dim // 2:
+            raise ValueError("inv_freq length must equal rope_dim // 2")
+        if inv_freq.dtype != torch.float32 or not inv_freq.is_contiguous():
+            raise ValueError("inv_freq must be a contiguous float32 tensor")
+        positions_stride_0 = positions.stride(0)
+        positions_stride_1 = positions.stride(1)
+
+    num_tokens_each_tail_core = num_tokens // core_num
+    extra_tokens = num_tokens - num_tokens_each_tail_core * core_num
+    if num_tokens < core_num:
+        front_core_num = num_tokens
+        num_tokens_each_front_core = 1
+        tail_core_num = 0
+        num_tokens_each_tail_core = 0
+    elif extra_tokens == 0:
+        front_core_num = core_num
+        num_tokens_each_front_core = num_tokens_each_tail_core
+        tail_core_num = 0
+    else:
+        front_core_num = extra_tokens
+        num_tokens_each_front_core = num_tokens_each_tail_core + 1
+        tail_core_num = core_num - front_core_num
+    block_dim = front_core_num + tail_core_num
 
     has_bias = q_bias is not None
 
@@ -338,11 +419,15 @@ def triton_split_qkv_rmsnorm_mrope(
         k_weight,
         k_bias,
         cos_sin,
+        positions,
+        inv_freq,
         q_output,
         k_output,
         v_output,
         gate_output,
         num_tokens,
+        positions_stride_0,
+        positions_stride_1,
         front_core_num,
         num_tokens_each_front_core,
         num_tokens_each_tail_core,
@@ -360,6 +445,8 @@ def triton_split_qkv_rmsnorm_mrope(
         rope_dim,
         rope_dim // 2,
         IS_PARTIAL_ROPE,
+        INLINE_COS_SIN,
+        rms_weight_offset,
         gate_size,
     )
 
@@ -370,17 +457,20 @@ def triton_split_qkv_rmsnorm_mrope_fake(
     qkv: torch.Tensor,
     q_weight: torch.Tensor,
     k_weight: torch.Tensor,
-    cos_sin: torch.Tensor,
-    num_q_heads: int,
-    num_kv_heads: int,
-    head_size: int,
-    eps: float,
-    mrope_section: list[int],
-    is_interleaved: bool,
+    cos_sin: torch.Tensor | None = None,
+    num_q_heads: int = 0,
+    num_kv_heads: int = 0,
+    head_size: int = 0,
+    eps: float = 1e-6,
+    mrope_section: list[int] | None = None,
+    is_interleaved: bool = False,
     rope_dim: int | None = None,
     q_bias: torch.Tensor | None = None,
     k_bias: torch.Tensor | None = None,
     has_gate: bool = False,
+    positions: torch.Tensor | None = None,
+    inv_freq: torch.Tensor | None = None,
+    rms_weight_offset: float = 0.0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     num_tokens = qkv.shape[0]
     q_size = num_q_heads * head_size

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -332,9 +332,7 @@ def triton_split_qkv_rmsnorm_mrope(
         raise ValueError("q_bias and k_bias must be both present or both absent")
     if q_bias is not None and k_bias is None:
         raise ValueError("q_bias and k_bias must be both present or both absent")
-    if q_bias is not None and k_bias is not None and (
-        q_bias.numel() != head_size or k_bias.numel() != head_size
-    ):
+    if q_bias is not None and k_bias is not None and (q_bias.numel() != head_size or k_bias.numel() != head_size):
         raise ValueError("q_bias and k_bias must each contain head_size elements")
 
     if rope_dim is None:

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -124,9 +124,7 @@ def split_qkv_rmsnorm_mrope_kernel(
             t_mask = ~(h_mask | w_mask)
         else:
             t_mask = cos_offsets_fp32 < mrope_section_t
-            h_mask = (mrope_section_t <= cos_offsets_fp32) & (
-                cos_offsets_fp32 < mrope_section_t + mrope_section_h
-            )
+            h_mask = (mrope_section_t <= cos_offsets_fp32) & (cos_offsets_fp32 < mrope_section_t + mrope_section_h)
             w_mask = (mrope_section_t + mrope_section_h <= cos_offsets_fp32) & (
                 cos_offsets_fp32 < mrope_section_t + mrope_section_h + mrope_section_w
             )
@@ -515,3 +513,4 @@ direct_register_custom_op(
     mutates_args=[],
     dispatch_key="PrivateUse1",
 )
+

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -320,12 +320,13 @@ def triton_split_qkv_rmsnorm_mrope(
 
     q_size = num_q_heads * head_size
     kv_size = num_kv_heads * head_size
-    num_tokens = qkv.shape[0]
 
+    qkv = qkv.contiguous()
     gate_size = q_size if has_gate else 0
     expected_qkv_width = q_size + gate_size + 2 * kv_size
     if qkv.ndim != 2 or qkv.shape[1] != expected_qkv_width:
         raise ValueError(f"qkv must have shape [num_tokens, {expected_qkv_width}]")
+    num_tokens = qkv.shape[0]
     if q_weight.numel() != head_size or k_weight.numel() != head_size:
         raise ValueError("q_weight and k_weight must each contain head_size elements")
     if q_bias is None and k_bias is not None:
@@ -354,6 +355,8 @@ def triton_split_qkv_rmsnorm_mrope(
     if cos_sin is not None:
         if cos_sin.ndim != 3 or cos_sin.shape != (3, num_tokens, rope_dim):
             raise ValueError("cos_sin must have shape [3, num_tokens, rope_dim]")
+        if cos_sin.device != qkv.device:
+            raise ValueError("cos_sin must be on the same device as qkv")
         cos_sin = cos_sin.contiguous()
 
     front_core_num = core_num
@@ -387,10 +390,14 @@ def triton_split_qkv_rmsnorm_mrope(
             raise ValueError("positions strides must be positive")
         if positions.dtype not in (torch.int32, torch.int64):
             raise ValueError("positions must use int32 or int64 indices")
+        if positions.device != qkv.device:
+            raise ValueError("positions must be on the same device as qkv")
         if inv_freq.numel() != rope_dim // 2:
             raise ValueError("inv_freq length must equal rope_dim // 2")
         if inv_freq.dtype != torch.float32 or not inv_freq.is_contiguous():
             raise ValueError("inv_freq must be a contiguous float32 tensor")
+        if inv_freq.device != qkv.device:
+            raise ValueError("inv_freq must be on the same device as qkv")
         positions_stride_0 = positions.stride(0)
         positions_stride_1 = positions.stride(1)
 

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -328,9 +328,13 @@ def triton_split_qkv_rmsnorm_mrope(
         raise ValueError(f"qkv must have shape [num_tokens, {expected_qkv_width}]")
     if q_weight.numel() != head_size or k_weight.numel() != head_size:
         raise ValueError("q_weight and k_weight must each contain head_size elements")
-    if (q_bias is None) != (k_bias is None):
+    if q_bias is None and k_bias is not None:
         raise ValueError("q_bias and k_bias must be both present or both absent")
-    if q_bias is not None and (q_bias.numel() != head_size or k_bias.numel() != head_size):
+    if q_bias is not None and k_bias is None:
+        raise ValueError("q_bias and k_bias must be both present or both absent")
+    if q_bias is not None and k_bias is not None and (
+        q_bias.numel() != head_size or k_bias.numel() != head_size
+    ):
         raise ValueError("q_bias and k_bias must each contain head_size elements")
 
     if rope_dim is None:
@@ -376,6 +380,7 @@ def triton_split_qkv_rmsnorm_mrope(
     positions_stride_0 = 0
     positions_stride_1 = 0
     if INLINE_COS_SIN:
+        assert positions is not None and inv_freq is not None
         if positions.ndim != 2 or positions.shape[0] != 3:
             raise ValueError("positions must have shape [3, num_tokens] for inline MRoPE")
         if positions.shape[1] != num_tokens:

--- a/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -513,4 +513,3 @@ direct_register_custom_op(
     mutates_args=[],
     dispatch_key="PrivateUse1",
 )
-

--- a/vllm_ascend/patch/worker/mrope_utils.py
+++ b/vllm_ascend/patch/worker/mrope_utils.py
@@ -1,0 +1,12 @@
+import torch
+
+from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
+
+
+def get_rotary_inv_freq(rotary_emb: AscendMRotaryEmbedding, device: torch.device) -> torch.Tensor:
+    """Return the contiguous FP32 inverse-frequency vector on ``device``."""
+    inv_freq = getattr(rotary_emb, "inv_freq", None)
+    if inv_freq is None or inv_freq.device != device:
+        inv_freq = rotary_emb._compute_inv_freq(rotary_emb.base).to(device=device, dtype=torch.float32)
+        rotary_emb.register_buffer("inv_freq", inv_freq, persistent=False)
+    return inv_freq.contiguous()

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -32,6 +32,7 @@ from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.patch.worker.mrope_utils import get_rotary_inv_freq
 from vllm_ascend.utils import is_310p, vllm_version_is
 
 _IS_VLLM_RELEASE = vllm_version_is("0.25.1")
@@ -67,16 +68,22 @@ class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor, output: torch.Tensor = None):
         qkv, _ = self.qkv_proj(hidden_states)
         if "qwen3_5" in self.config.model_type:
-            cos_sin = self.rotary_emb.cos_sin_cache[positions]
-            if cos_sin.device != qkv.device:
-                cos_sin = cos_sin.to(qkv.device)
-            if cos_sin.dtype != qkv.dtype:
-                cos_sin = cos_sin.to(qkv.dtype)
+            inline_cos_sin = positions.ndim == 2
+            cos_sin = None
+            inv_freq = None
+            if inline_cos_sin:
+                inv_freq = get_rotary_inv_freq(self.rotary_emb, qkv.device)
+            else:
+                cos_sin = self.rotary_emb.cos_sin_cache[positions]
+                if cos_sin.device != qkv.device:
+                    cos_sin = cos_sin.to(qkv.device)
+                if cos_sin.dtype != qkv.dtype:
+                    cos_sin = cos_sin.to(qkv.dtype)
 
             q, k, v, gate = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
                 qkv=qkv,
-                q_weight=1.0 + self.q_norm.weight,
-                k_weight=1.0 + self.k_norm.weight,
+                q_weight=self.q_norm.weight,
+                k_weight=self.k_norm.weight,
                 cos_sin=cos_sin,
                 num_q_heads=self.num_heads,
                 num_kv_heads=self.num_kv_heads,
@@ -86,6 +93,9 @@ class AscendQwen3NextAttention(Qwen3NextAttention):
                 is_interleaved=self.rotary_emb.mrope_interleaved,
                 rope_dim=self.rotary_emb.rotary_dim,
                 has_gate=self.attn_output_gate,
+                positions=positions if inline_cos_sin else None,
+                inv_freq=inv_freq,
+                rms_weight_offset=1.0,
             )
         else:
             if self.attn_output_gate:

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -239,3 +239,4 @@ else:
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels
+

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -239,4 +239,3 @@ else:
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels
-

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -119,3 +119,4 @@ def patch_qwen3_vl_moe_pp_layer_range():
 
 
 patch_qwen3_vl_moe_pp_layer_range()
+

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -10,6 +10,7 @@ from vllm.model_executor.models.qwen3_vl import (
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
+from vllm_ascend.patch.worker.mrope_utils import get_rotary_inv_freq
 
 
 def tensor_parallel_wrap(func):
@@ -35,11 +36,19 @@ def tensor_parallel_wrap(func):
 def forward_with_split_qkv_rmsnorm_mrope(self, positions: torch.Tensor, hidden_states: torch.Tensor):
     qkv, _ = self.qkv_proj(hidden_states)
     if isinstance(self.rotary_emb, AscendMRotaryEmbedding):
-        cos_sin = self.rotary_emb.cos_sin_cache[positions]
-        if cos_sin.device != qkv.device:
-            cos_sin = cos_sin.to(qkv.device)
-        if cos_sin.dtype != qkv.dtype:
-            cos_sin = cos_sin.to(qkv.dtype)
+        mrope_section = self.rotary_emb.mrope_section
+        rope_dim = self.rotary_emb.rotary_dim
+        inline_cos_sin = positions.ndim == 2 and mrope_section is not None
+        cos_sin = None
+        inv_freq = None
+        if inline_cos_sin:
+            inv_freq = get_rotary_inv_freq(self.rotary_emb, qkv.device)
+        else:
+            cos_sin = self.rotary_emb.cos_sin_cache[positions]
+            if cos_sin.device != qkv.device:
+                cos_sin = cos_sin.to(qkv.device)
+            if cos_sin.dtype != qkv.dtype:
+                cos_sin = cos_sin.to(qkv.dtype)
         q, k, v, _ = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
             qkv=qkv,
             q_weight=self.q_norm.weight,
@@ -49,9 +58,11 @@ def forward_with_split_qkv_rmsnorm_mrope(self, positions: torch.Tensor, hidden_s
             num_kv_heads=self.num_kv_heads,
             head_size=self.head_dim,
             eps=self.q_norm.variance_epsilon,
-            mrope_section=self.rotary_emb.mrope_section,
+            mrope_section=mrope_section,
             is_interleaved=self.rotary_emb.mrope_interleaved,
-            rope_dim=self.rotary_emb.rotary_dim,
+            rope_dim=rope_dim,
+            positions=positions if inline_cos_sin else None,
+            inv_freq=inv_freq,
         )
     else:
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -119,4 +119,3 @@ def patch_qwen3_vl_moe_pp_layer_range():
 
 
 patch_qwen3_vl_moe_pp_layer_range()
-


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fuses online MRoPE cos/sin generation into the existing Triton split-QKV, RMSNorm and MRoPE operator for Qwen3-family models. It removes the indexed `cos_sin_cache` gather and avoids materializing a per-token `cos_sin` tensor before launching the fused operator.

- Registers the FP32 inverse-frequency vector on `AscendMRotaryEmbedding` before graph capture;
- Passes multi-axis positions and the inverse-frequency vector directly to the fused operator;
- Supports Qwen3-VL and Qwen3.5, including interleaved MRoPE, partial RoPE, gate output, strided positions and Qwen3.5's RMS weight offset;
- Uses the inline path by default for supported multi-axis MRoPE calls; non-multi-axis callers retain the cached cos/sin path;
- Returns empty outputs without launching a kernel when the token count is zero.

### Does this PR introduce any user-facing change?

Yes. Supported Qwen3-VL and Qwen3.5 multi-axis MRoPE calls automatically use the inline cos/sin path. No new environment variable, CLI option or API is introduced, and tensor shapes remain unchanged.

### How was this patch tested?

- Tested on Ascend 910B3 with vLLM commit `752a3a504485790a2e8491cacbb35c137339ad34` and vllm-ascend baseline `3cb3f83db5eceeb1c8a8736b2337e167a225c60e`.
- NPU regression coverage: `128 passed` for the cached path and `102 passed` for the inline path, `230 passed` in total. Coverage includes BF16/FP16, Qwen3-VL/Qwen3.5 shapes, interleaved and non-interleaved layouts, strided positions, gate output, zero tokens, core boundaries and token counts up to 4096.
- `python -m py_compile` passed for all six changed Python files; `git diff --check` is clean.

The two NPU groups can be reproduced with:

```bash
pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py -k inline_cos_sin --maxfail=1
pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_split_qkv_rmsnorm_mrope.py -k "not inline_cos_sin" --maxfail=1
```

### RealWorldQA 精度与性能总结（Baseline vs MRoPE 融合）

测试数据：RealWorldQA（版本 `e3713f`），765 条请求，Max Concurrency=64，输入完全一致，双方均 765/765 成功（0 失败）。测试日期：2026-09-15。

| 指标 | baseline_batch_765 | mrope_new | 变化 |
| --- | ---: | ---: | ---: |
| Accuracy | 73.73% | **74.90%** | **+1.17 个百分点** |
| Benchmark Duration | 1190.8 s | **638.7 s** | **-46.4%，1.86x 提速** |
| Request Throughput | 0.6424 req/s | **1.1978 req/s** | **+86.5%** |
| Input Token Throughput | 930.53 token/s | **1734.89 token/s** | **+86.4%** |
| Output Token Throughput | 105.79 token/s | **196.51 token/s** | **+85.8%** |
| Total Token Throughput | 1036.32 token/s | **1931.41 token/s** | **+86.4%** |
| Average E2E | 89.36 s | **51.97 s** | **-41.8%** |
| Median E2E | 84.73 s | **41.13 s** | **-51.5%** |
| P90 / P99 E2E | 141.20 / 209.44 s | **94.21 / 165.79 s** | **-33.3% / -20.8%** |

- Total input tokens are identical (1,108,069); generated tokens are 125,970 vs 125,512 (-0.36%), so the throughput gain is not explained by shorter outputs.
- The measured accuracy is maintained and is 1.17 percentage points higher in this run. It should not be interpreted as a causal accuracy improvement; fixed sampling parameters and repeated A/B runs are still recommended for deterministic attribution.
- Operator-only NPU microbenchmarks in the delivery validation show the new inline path reducing qwen35 T=4096 from 253 us to 164 us and qwen35 T=32768 from 1985 us to 1454 us; these are kernel execution measurements, not end-to-end latency.

### vLLM versions

- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
