### PR TITLE
[BugFix][MoE] Restore shared-expert gather ordering

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1690,6 +1690,7 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     shared_out = torch.randn(2, 4)
     ascend_shared_experts = SimpleNamespace(
         multistream_overlap=False,
+        start_input_all_gather=MagicMock(return_value=(hidden_states, None)),
         forward=MagicMock(return_value=shared_out),
     )
     routed_events = FusedMoEEvents(
@@ -1724,6 +1725,7 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
         )
         assert result[0] is shared_out
         assert result[1] is routed_out
+        ascend_shared_experts.start_input_all_gather.assert_called_once_with(hidden_states)
         ascend_shared_experts.forward.assert_called_once()
     else:
         runner.routed_experts.forward_impl.assert_called_once_with(
@@ -1796,5 +1798,61 @@ def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
         "input_is_gathered": True,
         "defer_output_wait": True,
     }
+    assert result[0] is shared_out
+    assert result[1] is routed_out
+
+
+def test_forward_impl_waits_for_non_transform_sp_gather_before_routed_dispatch(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4)
+    gathered_states = torch.randn(4, 4)
+    router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 4)
+    gather_done = object()
+    operation_order = []
+    routed_events = FusedMoEEvents(
+        before_routed_experts=None,
+        after_routed_experts=None,
+        before_dispatch=None,
+        before_gmm2=None,
+        before_combine=None,
+    )
+
+    def start_input_all_gather(states):
+        operation_order.append("start_gather")
+        assert states is hidden_states
+        return gathered_states, gather_done
+
+    def routed_forward(**kwargs):
+        operation_order.append("routed_dispatch")
+        return routed_out, routed_events
+
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(side_effect=routed_forward))
+    runner.ascend_shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(side_effect=start_input_all_gather),
+        forward=MagicMock(return_value=shared_out),
+    )
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    current_stream = MagicMock()
+    current_stream.wait_event.side_effect = lambda event: operation_order.append("wait_gather")
+
+    monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: False))
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
+
+    result = runner._forward_impl(hidden_states, router_logits, shared_experts_input=None)
+
+    assert operation_order == ["start_gather", "wait_gather", "routed_dispatch"]
+    runner.ascend_shared_experts.forward.assert_called_once_with(
+        gathered_states,
+        routed_events,
+        input_is_gathered=True,
+        defer_output_wait=False,
+    )
     assert result[0] is shared_out
     assert result[1] is routed_out

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -317,13 +317,19 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     router_logits=router_logits,
                     input_ids=input_ids,
                 )
-            # The runner input transform provides a padded gathered tensor in
-            # SP multistream mode. Trim the shared-MLP view before use.
+            # The routed-transform overlap path provides a padded gathered
+            # tensor before entering this custom op. Other SP-only models must
+            # retain the original gather -> wait -> routed-dispatch ordering.
             shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
             defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
-            shared_expert_input = (
-                shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
-            )
+            shared_input_all_gather_done = None
+            if shared_input_is_gathered:
+                shared_expert_input = shared_hidden_states[: _EXTRA_CTX.num_tokens]
+            else:
+                shared_expert_input, shared_input_all_gather_done = (
+                    self.ascend_shared_experts.start_input_all_gather(shared_hidden_states)
+                )
+                shared_input_is_gathered = shared_input_all_gather_done is not None
             if self.is_internal_router:
                 gate = self.gate
                 assert gate is not None
@@ -344,6 +350,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 before_routed_experts = torch.npu.current_stream().record_event()
                 after_routed_experts = None
 
+            if shared_input_all_gather_done is not None:
+                torch.npu.current_stream().wait_event(shared_input_all_gather_done)
             routed_out, fused_moe_events = self.routed_experts.forward_impl(
                 hidden_states=hidden_states,
                 router_logits=router_logits,


### PR DESCRIPTION
### What this PR does / why we need it?

PR #15252 moved the sequence-parallel shared-expert input all-gather into the routed-transform overlap path. For models without routed transforms, including GLM, the fallback all-gather is enqueued from `AscendSharedExperts.forward()` only after the routed path has already enqueued MC2 dispatch/combine work. This removes the previous event dependency that completed the shared-expert TP all-gather before routed dispatch.

This change restores the pre-#15252 ordering for the non-routed-transform path:

```
shared-expert TP all-gather -> wait_event -> routed experts / MC2 dispatch
```

The routed-transform overlap path remains unchanged. A regression test verifies that the fallback gather starts and is awaited before `routed_experts.forward_impl()`.

This is intended to address the GLM-5.1 W8A8C8 sparse-C8 PD startup failure where all prefill ranks time out in `MoeDistributeDispatchV2_*_1024` during `profile_run` with error 507034. A3 nightly validation is still required to confirm the device-level fix.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ops/fused_moe/fused_moe.py tests/ut/ops/test_fused_moe.py`
- `git diff --check`
- Added `test_forward_impl_waits_for_non_transform_sp_gather_before_routed_dispatch`
- Targeted pytest was not runnable on the Windows host because the local environment does not contain vLLM/torch-NPU; CPU CI and the GLM A3 nightly are required.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
