### PR TITLE
[Feature][Kimi K3 DSPark] Enable TP for context_proj

### DIFF
--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -8,7 +8,7 @@ import torch
 from torch import nn
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -154,13 +154,14 @@ class AscendK3DSparkModel(UpstreamK3DSparkModel):
         self.quant_config = get_draft_quant_config(vllm_config)
         self.embed_tokens: nn.Module | None = None
 
-        self.context_proj = ReplicatedLinear(
+        self.context_proj = ColumnParallelLinear(
             self.config.target_hidden_size * self.config.num_target_layers,
             self.config.hidden_size,
             bias=False,
             return_bias=False,
             quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "context_proj"),
+            gather_output=True,
         )
         self.context_norm = RMSNorm(
             self.config.hidden_size,


### PR DESCRIPTION
### What this PR does / why we need it?

Switch `context_proj` from `ReplicatedLinear` to `ColumnParallelLinear` (`gather_output=True`) so the projection weight [7168, 35840] is sharded along the output dim (7168) across TP ranks instead of being replicated.

This is not just a memory saving. During decode the context_proj GEMM is memory-bandwidth bound: profiling shows aic_mte2_ratio ~94% vs aic_mac_ratio ~8% (weight-load bound, batch=8). With the weight replicated, every rank re-reads the full ~490MB weight each step and the cluster bandwidth is not distributed. Sharding the output dim cuts the per-rank HBM weight read by TPx and spreads the traffic across ranks. `gather_output=True` reassembles [8, 7168] for `context_norm`, leaving the `combine_hidden_states` caller unchanged. Numerically equivalent to the replicated path; checkpoint layout unchanged.

Idea from: https://github.com/vllm-project/vllm-ascend/pull/15144

before: 710us(matmul)
<img width="2069" height="913" alt="image-20260828144021394" src="https://github.com/user-attachments/assets/287a60d5-e5bc-475d-bf69-15b5987d6e51" />
after: 104us(matmul+allgather)
<img width="1872" height="1600" alt="image-20260831153334539" src="https://github.com/user-attachments/assets/efc82be4-0d7d-4a89-aadf-b8f1f9453b7f" />


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Validated end-to-end on a 4-node TP16/DP4 Kimi K3 deployment as part of the K3 v0.26.0rc PR stack: spec-decode acceptance rate flat vs baseline.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
