### PR TITLE
[Performance][DCP] Optimize v0.26 DCP decode layouts and fix remap boundaries

### DIFF
--- a/DCP_PORT.md
+++ b/DCP_PORT.md
@@ -1,0 +1,85 @@
+# DCP decode port to v0.26
+
+## 2026-09-11 local refresh
+
+Base: releases/v0.26.0rc at5f12bbf34a530cd6c87463c56404535246af6e94.
+Branch: perf/dcp-decode-v026; historical port commit f2648bb0f07e35992398c2a25f3a9692285673f6.
+Original donor: local82bcf6902a5d08cb736d941ea1a874d026d30238.
+Current status: local source refresh and CPU checks complete; no new NPU run.
+
+| Area | Current selection |
+|---|---|
+| Remap | Upstream two-kernel path plus DCP8/interleave128 integer and empty-input repairs |
+| O/LSE | Existing ported raw-bit pack, one AllToAll, FP32 merge and Cast |
+| Query | Existing head-major prepare and contiguous unpack |
+| Indexer store | Existing native quantization plus fused scale conversion/key-scale stores |
+
+Removed the old five-operation remap priority from the attention caller.
+The old standalone sfa_dcp_remap helper remains as historical code, but no
+production caller imports it. The ordinary upstream remap routing/fallbacks
+now apply. The decode_only argument is retained for existing caller compatibility.
+O/LSE/Q/store code and their existing guards are unchanged.
+
+## Local verification
+
+Final focused CPU suite: 50 tests passed (before documentation-only changes).
+Run from this worktree:
+
+```bash
+python3 -m pytest --noconftest -q \
+  tests/ut/attention/test_sfa_dcp_remap.py \
+  tests/ut/attention/test_sparse_index_remap_port.py \
+  tests/ut/attention/test_sfa_dcp_exchange_port.py \
+  tests/ut/attention/test_sfa_dcp_query_port.py \
+  tests/ut/attention/test_sfa_indexer_store.py
+```
+
+NPU regression entry: tests/ut/attention/a2/test_sfa_dcp_remap.py.
+Existing distributed O/LSE entry:
+tests/ut/attention/a2/test_sfa_dcp_exchange_port.py.
+The strict exchange oracle is preserved, including known historical failures.
+
+## Reused experiment evidence (not new validation of these worktrees)
+
+- [Pinned upstream component comparison](../../experiments/upstream_dcp_20260910/REPORT.md)
+  tested release5f12bbf/f2648bb0f helpers on the pinned A3 environment. The
+  pack/combine leaf implementations match local main base ac6405d9; main's
+  additional PCP composition and full main serving were not measured.
+- Original optimized raw-bit O/LSE versus upstream, complete path including
+  communication, merge and BF16 Cast: T1 reduction30.5/30.7%, T6 23.6/28.4%,
+  T12 35.1/33.6% in AB/BA runs. Both paths already use one AllToAll.
+  This is not the later experimental VMM peer exchange and not a serving gain.
+- Query+SFA T6 reduction12.3-13.6%, T12 16.5-19.2%; T1 is unchanged fallback.
+  Native quant+store reduction73.9-75.9% for T1/6/12. Query/store NPU byte,
+  consumer and changed-graph checks passed in the pinned helper experiments.
+- [Remap follow-up](../../experiments/peer_olse_20260911/REMAP_RESULT.md):
+  two-kernel path reduces whole-remap latency35.08-42.63% relative to our
+  old five-operation path. The repaired module is copied byte-for-byte from
+  the tested local working source, not its older82bcf commit.
+- Integer regression: input16777343 belongs to owner0/local2097279; the
+  observed vector division gave owner1/local2097151. DCP8/interleave128 now
+  uses shifts/masks, including boundaries above2**24 and INT32_MAX.
+  Other configurations retain upstream arithmetic, without a new exactness
+  claim. Empty last dimension returns before division by TopK.
+- Historical v0.26 remap test result38PASS/3FAIL preceded this repair.
+  The former DCP_PORT claim of exact large-coordinate arithmetic was disproved
+  on hardware. Those failures are not erased or relabeled as passes.
+- Strict CPU-BF161e-3 tests fail for both original optimized and upstream
+  exchange. Independent FP64 diagnostics bound pre-cast FP32 error below8e-7
+  in the upstream comparison. These are not established donor-only regressions;
+  no tolerance is relaxed and no complete numerical acceptance is claimed.
+  The local9% TPOT result uses a different baseline and must not be claimed
+  for this port or added to the component percentages.
+
+## Scope boundary
+
+No fetch, rebase, remote update, push, PR, runtime installation, pod operation,
+NPU experiment, allocator/host-DRAM placement or experimental VMM peer code is
+part of this refresh. Q/store kernels are unchanged and identical across the
+two port worktrees and local donor. Local main always means ac6405d9, not
+today's remote main. Changes remain uncommitted on the historical port commit.
+
+The new NPU regression tests exercise the actual two-kernel remap against a
+CPU int64 oracle, large coordinates and changed graph inputs. Their presence
+does not mean they ran locally. A new full-worktree NPU/serving validation is
+still required before making a full-port runtime acceptance claim.

--- a/tests/ut/attention/a2/test_sfa_dcp_exchange_port.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_exchange_port.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DCP8 exchange comparison; run via torchrun on an isolated eight-NPU group."""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_cp import (  # noqa: E402
+    fused_sfa_dcp_lse_combine,
+    pack_sfa_dcp_output_lse,
+    sfa_dcp_a2a_fused_combine,
+)
+
+pytestmark = pytest.mark.skipif(int(os.environ.get("WORLD_SIZE", "1")) != 8, reason="requires isolated DCP8")
+
+
+def test_exchange_matches_upstream_and_reference_with_changed_input_graphs():
+    rank = int(os.environ["RANK"])
+    torch.npu.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("hccl")
+    retained = []
+
+    def inputs(tokens, step):
+        generator = torch.Generator().manual_seed(2026 + step)
+        outputs = torch.randn(8, tokens, 64, 512, generator=generator).to(torch.bfloat16)
+        lses = torch.randn(8, tokens, 64, 1, generator=generator)
+        # All-invalid and mixed-invalid heads cover NaN*0 contamination.
+        lses[:, :, 0] = -torch.inf
+        outputs[:, :, 0] = torch.nan
+        for sender, value in enumerate((torch.nan, torch.inf, -torch.inf)):
+            lses[sender, :, 1] = value
+            outputs[sender, :, 1] = torch.nan
+        return outputs, lses
+
+    for tokens in (1, 6, 12):
+        outputs, lses = inputs(tokens, 0)
+        # Head-major storage exercises a strided token-major view.
+        owner = outputs[rank].transpose(0, 1).contiguous().npu()
+        output = owner.transpose(0, 1)
+        lse = lses[rank].npu()
+
+        def invoke(output=output, lse=lse):
+            return sfa_dcp_a2a_fused_combine(output, lse, 8, 1, dist.group.WORLD)
+
+        for _ in range(5):
+            invoke()
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            result = invoke()
+        for step in range(8):
+            outputs, lses = inputs(tokens, step)
+            owner.copy_(outputs[rank].transpose(0, 1).contiguous())
+            lse.copy_(lses[rank])
+            # These unchanged upstream helpers bypass the new dispatch guard.
+            send = pack_sfa_dcp_output_lse(output, lse, 8, 1)
+            recv = torch.empty_like(send)
+            dist.all_to_all_single(recv, send)
+            upstream = fused_sfa_dcp_lse_combine(recv, 512, 1)
+            graph.replay()
+            torch.npu.synchronize()
+            finite = torch.isfinite(lses)
+            weights = torch.nan_to_num(torch.softmax(lses.masked_fill(~finite, -torch.inf), dim=0), nan=0.0)
+            expected = (outputs.float().masked_fill(~finite, 0.0) * weights).sum(0)
+            expected = expected[:, rank * 8 : (rank + 1) * 8].to(torch.bfloat16)
+            assert torch.isfinite(result).all()
+            torch.testing.assert_close(result.cpu(), expected, rtol=1e-3, atol=1e-3)
+            torch.testing.assert_close(result, upstream, rtol=1e-3, atol=1e-3)
+        retained.append((graph, result, owner, lse))
+    dist.barrier()
+    dist.destroy_process_group()

--- a/tests/ut/attention/a2/test_sfa_dcp_query.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_query.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run with torchrun --standalone --nproc-per-node=8 -m pytest --noconftest."""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_dcp_query import (  # noqa: E402
+    can_prepare_query,
+    prepare_query_head_major,
+    unpack_query,
+)
+
+pytestmark = pytest.mark.skipif(int(os.environ.get("WORLD_SIZE", "1")) != 8, reason="requires an isolated DCP8 group")
+
+
+def test_query_gather_raw_bits_and_changed_input_graphs():
+    rank = int(os.environ["RANK"])
+    torch.npu.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("hccl")
+    retained = []
+    patterns = torch.tensor([0, -32768, 1, 127, 32640, -128, 32705, -63], dtype=torch.int16)
+
+    def bits(sender, tokens, width, step):
+        return patterns.roll(sender + step).repeat(tokens * 8 * width // patterns.numel()).view(tokens, 8, width)
+
+    for tokens in (2, 6, 12):
+        n_owner = bits(rank, tokens, 512, 0).transpose(0, 1).contiguous().view(torch.bfloat16).npu()
+        r_owner = bits(rank, tokens, 64, 0).view(torch.bfloat16).npu()
+        qn, qr = n_owner.transpose(0, 1), r_owner
+        assert can_prepare_query(qn, qr)
+
+        def invoke(qn=qn, qr=qr, tokens=tokens):
+            send = prepare_query_head_major(qn, qr)
+            received = torch.empty((64, tokens, 576), dtype=qn.dtype, device=qn.device)
+            dist.all_gather_into_tensor(received, send, async_op=True).wait()
+            return unpack_query(received)
+
+        for _ in range(5):
+            invoke()
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            result = invoke()
+        for step in range(16):
+            n_owner.copy_(bits(rank, tokens, 512, step).transpose(0, 1).contiguous().view(torch.bfloat16))
+            r_owner.copy_(bits(rank, tokens, 64, step).view(torch.bfloat16))
+            graph.replay()
+            torch.npu.synchronize()
+            for actual, width in zip(result, (512, 64)):
+                expected = torch.cat([bits(sender, tokens, width, step) for sender in range(8)], dim=1)
+                assert actual.is_contiguous()
+                assert torch.equal(actual.view(torch.int16).cpu(), expected)
+        retained.append((graph, result, n_owner, r_owner))
+    dist.barrier()
+    dist.destroy_process_group()

--- a/tests/ut/attention/a2/test_sfa_dcp_remap.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_remap.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Two-kernel remap: independent integer oracle and changed graph inputs."""
+
+import pytest
+import torch
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sparse_index_remap import remap_sparse_indices_triton  # noqa: E402
+
+
+def oracle(indices, rank):
+    expected = torch.full_like(indices, -1)
+    # CPU int64 arithmetic is independent of NPU vector integer division.
+    for source, target in zip(indices.long().reshape(-1, 2048), expected.reshape(-1, 2048)):
+        owned = source[(source >= 0) & ((source // 128) % 8 == rank)]
+        target[: owned.numel()] = (owned // 1024 * 128 + owned % 128).to(target.dtype)
+    return expected
+
+
+@pytest.mark.parametrize("rows", [1, 6, 12])
+@pytest.mark.parametrize("rank", range(8))
+def test_exact_integer_boundaries_and_changed_graph_inputs(rows, rank):
+    torch.npu.set_device(0)
+    rng = torch.Generator().manual_seed(20260911 + rows + rank)
+    base = torch.randint(0, 2**31 - 1, (rows, 2048), generator=rng, dtype=torch.int32)
+    boundaries = torch.tensor(
+        [-1, 0, 127, 128, 1023, 1024, 2**24 - 1, 2**24, 2**24 + 127, 2**31 - 1],
+        dtype=torch.int32,
+    )
+    device_input = base.npu()
+    for _ in range(5):
+        remap_sparse_indices_triton(device_input, 8, rank, 128)
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        output = remap_sparse_indices_triton(device_input, 8, rank, 128)
+    for step in range(8):
+        current = torch.roll(base, step, dims=-1)
+        current[:, : boundaries.numel()] = boundaries
+        if step == 0:
+            current.fill_(-1)
+        device_input.copy_(current)
+        graph.replay()
+        assert torch.equal(output.cpu(), oracle(current, rank))
+    torch.npu.synchronize()
+
+
+@pytest.mark.parametrize("shape", [(0, 2048), (1, 0), (2, 3, 0)])
+def test_empty_input(shape):
+    value = torch.empty(shape, dtype=torch.int32, device="npu")
+    assert remap_sparse_indices_triton(value, 8, 0, 128) is value

--- a/tests/ut/attention/a2/test_sfa_indexer_store.py
+++ b/tests/ut/attention/a2/test_sfa_indexer_store.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native quantization byte oracle for final packed indexer K/scale writes."""
+
+import pytest
+import torch
+
+torch_npu = pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_indexer_store import can_fuse_store, store_indexer_key_scale  # noqa: E402
+
+
+def test_native_quantized_cache_bytes_and_changing_graph_slots():
+    torch.npu.set_device(0)
+    retained = []
+    capacity, width = 256, 128
+    for rows in (1, 6, 12):
+        x = torch.randn(rows, width, dtype=torch.bfloat16, device="npu")
+        keys, scales = torch_npu.npu_dynamic_quant(x, dst_type=torch.int8)
+        slots = torch.arange(rows, dtype=torch.int64, device="npu") + 7
+        backing = torch.full((capacity * (width + 2) + 64,), 19, dtype=torch.int8, device="npu")
+        cache = backing[: capacity * width].view(2, 128, 1, width)
+        scale_cache = backing[capacity * width : -64].view(torch.float16).view(2, 128, 1, 1)
+        assert can_fuse_store(cache, scale_cache, slots, rows)
+        for _ in range(5):
+            store_indexer_key_scale(keys, scales, slots, cache, scale_cache)
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            store_indexer_key_scale(keys, scales, slots, cache, scale_cache)
+        for step in range(16):
+            fresh_keys, fresh_scales = torch_npu.npu_dynamic_quant(torch.randn_like(x), dst_type=torch.int8)
+            keys.copy_(fresh_keys)
+            scales.copy_(fresh_scales)
+            selected = torch.arange(rows, dtype=torch.int64) + 3 + step
+            if step % 2:
+                selected[-1] = -1
+            slots.copy_(selected)
+            backing.fill_(19)
+            scale_cache.fill_(3.25)
+            graph.replay()
+            torch.npu.synchronize()
+            expected_keys = torch.full((capacity, width), 19, dtype=torch.int8)
+            expected_scales = torch.full((capacity, 1), 3.25, dtype=torch.float16)
+            valid = selected >= 0
+            expected_keys[selected[valid]] = fresh_keys.cpu()[valid]
+            expected_scales[selected[valid], 0] = fresh_scales.to(torch.float16).cpu()[valid]
+            assert torch.equal(cache.view(capacity, width).cpu(), expected_keys)
+            assert torch.equal(scale_cache.view(capacity, 1).view(torch.int16).cpu(), expected_scales.view(torch.int16))
+            assert bool((backing[-64:] == 19).all())
+        retained.append((graph, backing, keys, scales, slots))
+    torch.npu.synchronize()

--- a/tests/ut/attention/test_sfa_dcp_exchange_port.py
+++ b/tests/ut/attention/test_sfa_dcp_exchange_port.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise exchange routing and invalid-rank semantics without an NPU."""
+
+import ast
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_function(path, name, namespace):
+    source = ROOT / path
+    tree = ast.parse(source.read_text())
+    method = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    future = ast.parse("from __future__ import annotations").body
+    exec(compile(ast.Module(body=future + [method], type_ignores=[]), str(source), "exec"), namespace)
+    return namespace[name]
+
+
+@pytest.mark.parametrize(
+    "tokens,ranks,scatter,supported",
+    [
+        (1, 8, 1, True),
+        (6, 8, 1, True),
+        (12, 8, 1, True),
+        (13, 8, 1, False),
+        (6, 2, 1, True),
+        (8, 8, 0, True),
+    ],
+)
+def test_registered_op_keeps_upstream_fallback_and_output_dtype(tokens, ranks, scatter, supported):
+    calls = []
+    group = object()
+    output = torch.zeros(tokens, 64, 512, dtype=torch.bfloat16)
+    lse = torch.zeros(tokens, 64, 1)
+    shape = (tokens, 64 // ranks, 512) if scatter else (tokens // ranks, 64, 512)
+
+    def exchange(out, stats, selected_group):
+        assert selected_group is group and out is output and stats is lse
+        calls.append("exchange")
+        return torch.ones(shape, dtype=torch.float32)
+
+    def transfer(recv, send, *, group):
+        calls.append("upstream_collective")
+
+    namespace = {
+        "torch": torch,
+        "dist": SimpleNamespace(all_to_all_single=transfer),
+        "can_exchange": lambda *_: supported,
+        "exchange": exchange,
+        "pack_sfa_dcp_output_lse": lambda *_: torch.empty(8, 16),
+        "fused_sfa_dcp_lse_combine": lambda *_: torch.ones(shape, dtype=output.dtype),
+    }
+    run = load_function("vllm_ascend/ops/triton/sfa_cp.py", "sfa_dcp_a2a_fused_combine", namespace)
+    result = run(output, lse, ranks, scatter, group)
+    assert result.dtype == output.dtype and result.shape == shape
+    assert calls == (["exchange"] if ranks == 8 and scatter == 1 and supported else ["upstream_collective"])
+
+
+@pytest.mark.parametrize("tokens,expected", [(0, False), (1, True), (6, True), (12, True), (13, False)])
+def test_exchange_gate(tokens, expected):
+    namespace = {"torch": torch, "triton": object(), "_MAX_DECODE_TOKENS": 12, "_HEADS": 64, "_HEAD_DIM": 512}
+    run = load_function("vllm_ascend/ops/triton/sfa_dcp_exchange.py", "can_exchange", namespace)
+    device = SimpleNamespace(type="npu")
+    output = SimpleNamespace(device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 64, 512))
+    lse = SimpleNamespace(device=device, dtype=torch.float32, shape=(tokens, 64, 1))
+    assert run(output, lse) is expected
+
+
+@pytest.mark.parametrize("token_dim", [1, 2])
+def test_merge_masks_invalid_rank_outputs_before_weighting(token_dim):
+    spec = importlib.util.spec_from_file_location("merge_under_test", ROOT / "vllm_ascend/ops/triton/sfa_dcp_merge.py")
+    merge = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(merge)
+    parts = torch.full((8, 2, 3, 4), float("nan"))
+    lse = torch.full((8, 2, 3), float("-inf"))
+    lse[0] = float("nan")
+    lse[1] = float("inf")
+    parts[2] = 2.0
+    lse[2] = 0.0
+    parts[3] = 4.0
+    lse[3] = 0.0
+    # One position has no valid ranks; even NaN payloads must yield zero.
+    lse[:, 0, 0] = float("-inf")
+    expected = torch.full((2, 3, 4), 3.0)
+    expected[0, 0] = 0.0
+    expected = expected.movedim(token_dim - 1, 0).contiguous()
+    assert torch.equal(merge.fused_merge(parts, lse, token_dim), expected)
+
+
+def test_custom_op_fake_retains_shape_dtype_and_does_not_collect():
+    run = load_function("vllm_ascend/ops/triton/sfa_cp.py", "sfa_dcp_a2a_fused_fake", {"torch": torch})
+    output = torch.empty(6, 64, 512, dtype=torch.bfloat16)
+    result = run(output, torch.empty(6, 64, 1), 8, 1, "unused")
+    assert result.shape == (6, 8, 512) and result.dtype == output.dtype

--- a/tests/ut/attention/test_sfa_dcp_query_port.py
+++ b/tests/ut/attention/test_sfa_dcp_query_port.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Actual query gather/finish routing and async dependency contracts."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import NamedTuple
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "tokens,decode,dsa,prepared",
+    [
+        (1, True, False, False),
+        (6, True, False, True),
+        (12, True, False, True),
+        (13, True, False, False),
+        (6, False, False, False),
+        (6, True, True, False),
+    ],
+)
+def test_query_gather_waits_before_final_unpack_and_preserves_fallback(tokens, decode, dsa, prepared):
+    source = ROOT / "vllm_ascend/attention/context_parallel/sfa_cp.py"
+    tree = ast.parse(source.read_text())
+    context_class = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "DCPGatherContext")
+    impl = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "AscendSFADCPImpl")
+    methods = [
+        n
+        for n in impl.body
+        if isinstance(n, ast.FunctionDef)
+        and n.name in ("_start_dcp_query_gather", "_finish_dcp_gather", "_record_query_gather_context")
+    ]
+    for method in methods:
+        method.decorator_list = []
+    events = []
+    group = object()
+    handle = SimpleNamespace(wait=lambda: events.append("wait"))
+
+    def gather(value, selected_group):
+        assert selected_group is group
+        events.append("gather")
+        return torch.cat([value] * 8, dim=0), handle
+
+    def prep(qn, qr):
+        events.append("prepare")
+        return torch.cat((qn, qr), dim=-1).permute(1, 0, 2).contiguous()
+
+    def unpack(value):
+        assert events[-1] == "wait"
+        events.append("unpack")
+        return tuple(part.contiguous() for part in value.permute(1, 0, 2).split((512, 64), dim=-1))
+
+    namespace = {
+        "torch": torch,
+        "M": object,
+        "AscendSFADCPMetadata": SimpleNamespace,
+        "NamedTuple": NamedTuple,
+        "all_gather_async": gather,
+        "can_prepare_query": lambda qn, qr: 1 < qn.shape[0] <= 12,
+        "prepare_query_head_major": prep,
+        "unpack_query": unpack,
+    }
+    exec(compile(ast.Module(body=[context_class, *methods], type_ignores=[]), str(source), "exec"), namespace)
+    context_type = namespace["DCPGatherContext"]
+
+    def legacy(value, dim, split_sizes):
+        send = value if dim == 0 else value.permute(1, 0, 2).contiguous()
+        gathered, work = gather(send, group)
+        # Four-argument construction must keep older KV/query callers working.
+        return context_type(gathered, work, None if dim == 0 else (1, 0, 2), split_sizes)
+
+    state = SimpleNamespace(
+        enable_dsa_cp=dsa,
+        dcp_size=8,
+        dcp_group=group,
+        _start_dcp_gather=legacy,
+        _parallel_query_gather_dim=lambda: 0 if dsa else 1,
+        _has_prefill=lambda metadata: metadata.num_prefills > 0,
+    )
+    state._start_dcp_query_gather = lambda *args, **kwargs: namespace["_start_dcp_query_gather"](state, *args, **kwargs)
+    qn = torch.arange(tokens * 8 * 512).to(torch.bfloat16).view(8, tokens, 512).transpose(0, 1)
+    qr = torch.ones(tokens, 8, 64, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(num_prefills=0 if decode else 1, dcp_context=SimpleNamespace(gather_context=None))
+    namespace["_record_query_gather_context"](state, qn, qr, metadata)
+    context = metadata.dcp_context.gather_context
+    if not decode:
+        assert context is None and not events
+        return
+    assert context.query_prepared is prepared
+    assert "wait" not in events
+    result = namespace["_finish_dcp_gather"](context)
+    dim = 0 if dsa else 1
+    assert torch.equal(result[0], torch.cat([qn] * 8, dim=dim))
+    assert torch.equal(result[1], torch.cat([qr] * 8, dim=dim))
+    assert events.count("gather") == events.count("wait") == 1
+    assert ("unpack" in events) is prepared
+    if prepared:
+        assert all(part.is_contiguous() for part in result)
+
+
+@pytest.mark.parametrize("tokens,expected", [(0, False), (1, False), (2, True), (6, True), (12, True), (13, False)])
+def test_query_shape_gate_keeps_single_token_and_large_batch_paths(tokens, expected):
+    source = ROOT / "vllm_ascend/ops/triton/sfa_dcp_query.py"
+    tree = ast.parse(source.read_text())
+    method = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "can_prepare_query")
+    namespace = {
+        "torch": torch,
+        "triton": object(),
+        "_LOCAL_HEADS": 8,
+        "_NOPE_DIM": 512,
+        "_ROPE_DIM": 64,
+        "_MAX_DECODE_TOKENS": 12,
+    }
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), "exec"), namespace)
+    device = SimpleNamespace(type="npu")
+    qn = SimpleNamespace(
+        device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 8, 512), stride=lambda: (512, tokens * 512, 1)
+    )
+    qr = SimpleNamespace(
+        device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 8, 64), stride=lambda: (512, 64, 1)
+    )
+    assert namespace["can_prepare_query"](qn, qr) is expected

--- a/tests/ut/attention/test_sfa_dcp_remap.py
+++ b/tests/ut/attention/test_sfa_dcp_remap.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fallback/routing checks without constructing a serving model."""
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+spec = importlib.util.spec_from_file_location("dcp_remap_under_test", ROOT / "vllm_ascend/ops/triton/sfa_dcp_remap.py")
+remap = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = remap
+spec.loader.exec_module(remap)
+
+
+def method():
+    source = ROOT / "vllm_ascend/attention/context_parallel/sfa_cp.py"
+    tree = ast.parse(source.read_text())
+    function = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_remap_sparse_indices"
+    )
+    namespace = {
+        "torch": torch,
+        "HAS_TRITON": False,
+        "can_fuse_remap": remap.can_fuse_remap,
+        "fused_remap": remap.fused_remap,
+    }
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"), namespace)
+    return namespace["_remap_sparse_indices"], namespace
+
+
+def instance(count=8):
+    return SimpleNamespace(
+        dcp_size=8,
+        dcp_rank=0,
+        enable_dsa_cp=False,
+        _dcp_interleave_size=128,
+        _dcp_index_topk=count,
+        _remap_order=torch.arange(count, dtype=torch.float32),
+        _remap_invalid_index=torch.tensor(-1.0),
+    )
+
+
+@pytest.mark.parametrize("decode_only", [False, True])
+def test_cpu_fallback_preserves_order_duplicates_and_invalid_suffix(decode_only):
+    run, _ = method()
+    indices = torch.tensor([[0, 128, 1024, 1, 1025, -1, 2, 0]], dtype=torch.int32)
+    expected = torch.tensor([[0, 128, 1, 129, 2, 0, -1, -1]], dtype=torch.int32)
+    assert torch.equal(run(instance(), indices, decode_only=decode_only), expected)
+
+
+def test_prefill_never_enters_fusion_even_if_layout_qualifies():
+    run, namespace = method()
+    namespace["can_fuse_remap"] = lambda _: True
+
+    def forbidden(*_):
+        raise AssertionError("prefill entered decode fusion")
+
+    namespace["fused_remap"] = forbidden
+    indices = torch.tensor([[0, 128, 1024, 1, 1025, -1, 2, 0]], dtype=torch.int32)
+    assert run(instance(), indices, decode_only=False).shape == indices.shape
+
+
+@pytest.mark.parametrize("attribute,value", [("enable_dsa_cp", True), ("dcp_size", 2), ("_dcp_interleave_size", 1)])
+def test_other_ownership_contracts_never_enter_fusion(attribute, value):
+    run, namespace = method()
+    namespace["can_fuse_remap"] = lambda _: True
+
+    def forbidden(*_):
+        raise AssertionError("unsupported ownership entered decode fusion")
+
+    namespace["fused_remap"] = forbidden
+    state = instance()
+    setattr(state, attribute, value)
+    indices = torch.tensor([[0, 128, 1024, 1, 1025, -1, 2, 0]], dtype=torch.int32)
+    assert run(state, indices, decode_only=True).shape == indices.shape
+
+
+def test_empty_fallback_and_configured_topk_limit():
+    run, _ = method()
+    empty = torch.empty((0, 1, 2048), dtype=torch.int32)
+    assert not remap.can_fuse_remap(empty)
+    assert run(instance(2048), empty, decode_only=True).shape == empty.shape
+    with pytest.raises(RuntimeError, match="exceeds configured index_topk"):
+        run(instance(8), torch.zeros((1, 9), dtype=torch.int32), decode_only=True)
+
+
+def test_single_rank_keeps_original_tensor():
+    run, _ = method()
+    state = instance()
+    state.dcp_size = 1
+    indices = torch.tensor([[1, -1, 2]], dtype=torch.int32)
+    assert run(state, indices, decode_only=True) is indices
+
+
+def test_decode_and_prefill_both_select_two_kernel_remap(monkeypatch):
+    run, namespace = method()
+    calls = []
+    indices = SimpleNamespace(shape=(1, 2048), numel=lambda: 2048, is_npu=True)
+    namespace["HAS_TRITON"] = True
+    namespace["can_fuse_remap"] = lambda _: True
+    namespace["fused_remap"] = lambda *args: calls.append(("donor", args))
+    upstream = SimpleNamespace(remap_sparse_indices_triton=lambda *args: calls.append(("upstream", args)))
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.triton.sparse_index_remap", upstream)
+    state = instance(2048)
+    run(state, indices, decode_only=True)
+    assert calls == [("upstream", (indices, 8, 0, 128))]
+    calls.clear()
+    run(state, indices, decode_only=False)
+    assert calls == [("upstream", (indices, 8, 0, 128))]

--- a/tests/ut/attention/test_sfa_indexer_store.py
+++ b/tests/ut/attention/test_sfa_indexer_store.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise the real SFA forward's cache-write ordering and fallback routing."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def run_forward(rows, state="decode", ranks=8, cache_supported=True, has_indexer=True):
+    """Run real SFA control flow with CPU stand-ins for unrelated NPU math."""
+    source = ROOT / "vllm_ascend/attention/sfa_v1.py"
+    tree = ast.parse(source.read_text())
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "AscendSFAImpl")
+    methods = [
+        n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name in ("forward", "indexer_select_pre_process")
+    ]
+    events = []
+    slots = torch.arange(rows, dtype=torch.int64) + 3
+    keys = torch.arange(rows * 128, dtype=torch.int64).remainder(127).to(torch.int8).view(rows, 128)
+    scales = torch.full((rows,), 1.0006, dtype=torch.float32)
+    cache = (
+        torch.zeros(32, 2),
+        torch.zeros(32, 2),
+        torch.zeros(32, 128, dtype=torch.int8),
+        torch.zeros(32, 1, dtype=torch.float16),
+    )
+    if not has_indexer:
+        cache = cache[:2]
+
+    def scatter(destination, indices, values):
+        assert "wait" in events
+        events.append("scatter")
+        destination.index_copy_(0, indices.flatten(), values)
+
+    def store(quant, stats, indices, key_cache, scale_cache):
+        assert "wait" in events and "publish" not in events
+        assert stats.dtype == torch.float32
+        events.append("fused_store")
+        key_cache.index_copy_(0, indices, quant)
+        scale_cache.index_copy_(0, indices, stats.to(torch.float16))
+
+    namespace = {
+        "torch": torch,
+        "torch_npu": SimpleNamespace(npu_dynamic_quant=lambda *_, **__: (keys, scales), npu_scatter_nd_update_=scatter),
+        "HAS_TRITON": True,
+        "rope_forward_triton_siso": lambda x, *_, **__: x,
+        "AscendSFAImpl": SimpleNamespace(k_hadamard=torch.eye(128, dtype=torch.bfloat16)),
+        "AscendAttentionState": SimpleNamespace(DecodeOnly="decode", SpecDecoding="spec"),
+        "PreprocessType": SimpleNamespace(NATIVE="native", MLAPO="mlapo", PROLOG_V3="prolog"),
+        "MLAPO_MAX_SUPPORTED_TOKENS": 512,
+        "can_fuse_store": lambda *args: cache_supported,
+        "store_indexer_key_scale": store,
+        "wait_for_kv_layer_from_connector": lambda *_: events.append("wait"),
+        "notify_kv_cache_written": lambda *_: events.append("publish"),
+        "record_attention_compute_start": lambda: events.append("read_fence"),
+        "maybe_save_kv_layer_to_connector": lambda *_: None,
+    }
+    future = ast.parse("from __future__ import annotations").body
+    exec(compile(ast.Module(body=future + methods, type_ignores=[]), str(source), "exec"), namespace)
+    backend = SimpleNamespace(
+        enable_dsa_cp=False,
+        enable_dsa_cp_with_o_proj_tp=False,
+        enable_sp=False,
+        enable_sparse_li_c8=True,
+        enable_sparse_sfa_c8=False,
+        has_indexer=has_indexer,
+        dcp_size=ranks,
+        head_dim=128,
+        qk_rope_head_dim=64,
+        q_lora_rank=2,
+        kv_lora_rank=2,
+        kv_cache_indexer_k_idx=2,
+        kv_cache_indexer_scale_idx=3,
+        preprocess_type="native",
+        skip_topk=not has_indexer,
+        use_index_cache=False,
+        is_rope_neox_style=False,
+        c8_k_cache_dtype=torch.int8,
+        c8_k_scale_cache_dtype=torch.float16,
+        _compose_sfa_kv_cache=lambda value: value,
+        _get_sfa_kv_slot_mapping=lambda metadata: metadata.slot_mapping,
+        _use_li_c8_reshape_optim=lambda: False,
+        fused_qkv_a_proj=lambda x: (torch.zeros(rows, 68), None),
+        q_a_layernorm=lambda x: x,
+        wk_weights_proj=lambda x: (torch.zeros(rows, 160, dtype=torch.bfloat16), None),
+        k_norm=lambda x: x,
+        exec_kv=lambda *args: (None, None, None),
+        _maybe_gather_kv_for_dsacp=lambda *a: (a[3], a[4], None, []),
+        _q_proj_and_k_up_proj=lambda x: (x, x),
+        rope_single=lambda x, *args: x,
+        _record_query_gather_context=lambda *args: None,
+        _maybe_store_kvcache_for_c8_n_dsacp=lambda *a: (None, None, a[3], None, None),
+        _get_full_kv=lambda value, *args: value,
+        indexer_select_post_process=lambda **kwargs: torch.zeros(rows, 1, dtype=torch.int32),
+        _get_indexcache_topk_indices=lambda *_: torch.zeros(rows, 1, dtype=torch.int32),
+        _execute_sparse_flash_attention_process=lambda *args: torch.ones(rows, 4),
+        _v_up_proj=lambda x: x,
+        o_proj=lambda x: (x, None),
+        layer_name="test_layer",
+    )
+    backend.indexer_select_pre_process = lambda **kwargs: namespace["indexer_select_pre_process"](backend, **kwargs)
+    metadata = SimpleNamespace(
+        cos=torch.ones(rows, 64),
+        sin=torch.zeros(rows, 64),
+        slot_mapping=slots,
+        cum_query_lens=None,
+        seq_lens=None,
+        num_input_tokens=rows,
+        attn_state=state,
+        dsa_cp_context=None,
+    )
+    namespace["forward"](backend, "test_layer", torch.zeros(rows, 4), cache, metadata, output=torch.empty(rows, 4))
+    assert events.index("wait") < events.index("publish") < events.index("read_fence")
+    if not has_indexer:
+        assert "fused_store" not in events and "scatter" not in events
+        return events
+    assert torch.equal(cache[2][slots], keys)
+    assert torch.equal(cache[3][slots], scales.to(torch.float16).view(rows, 1))
+    assert not cache[2][:3].any() and not cache[3][:3].any()
+    return events
+
+
+@pytest.mark.parametrize("rows,state", [(1, "decode"), (6, "spec"), (12, "spec")])
+def test_direct_store_preserves_native_quant_bytes_and_publication_order(rows, state):
+    events = run_forward(rows, state)
+    assert events.count("fused_store") == 1 and "scatter" not in events
+
+
+def test_layers_reusing_topk_do_not_access_missing_indexer_cache():
+    run_forward(6, has_indexer=False)
+
+
+@pytest.mark.parametrize("kwargs", [{"state": "prefill"}, {"ranks": 2}, {"cache_supported": False}])
+def test_unsupported_routes_keep_two_native_scatters(kwargs):
+    events = run_forward(6, **kwargs)
+    assert events.count("scatter") == 2 and "fused_store" not in events
+
+
+@pytest.mark.parametrize("rows,expected", [(0, False), (1, True), (6, True), (12, True), (13, False)])
+def test_store_shape_gate_retains_large_batch_fallback(rows, expected):
+    source = ROOT / "vllm_ascend/ops/triton/sfa_indexer_store.py"
+    tree = ast.parse(source.read_text())
+    method = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "can_fuse_store")
+    namespace = {"torch": torch, "triton": object(), "_KEY_WIDTH": 128, "_MAX_DECODE_ROWS": 12}
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), "exec"), namespace)
+    device = SimpleNamespace(type="npu")
+
+    def metadata(value):
+        return SimpleNamespace(
+            device=device,
+            dtype=value.dtype,
+            ndim=value.ndim,
+            shape=value.shape,
+            numel=value.numel,
+            is_contiguous=value.is_contiguous,
+        )
+
+    cache = metadata(torch.empty((2, 128, 1, 128), dtype=torch.int8))
+    scales = metadata(torch.empty((2, 128, 1, 1), dtype=torch.float16))
+    slots = metadata(torch.empty(rows, dtype=torch.int64))
+    assert namespace["can_fuse_store"](cache, scales, slots, rows) is expected

--- a/tests/ut/attention/test_sparse_index_remap_port.py
+++ b/tests/ut/attention/test_sparse_index_remap_port.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Empty input must return before dividing by TopK or launching kernels."""
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("shape", [(0, 2048), (1, 0), (2, 3, 0)])
+def test_empty_remap_preserves_shape_dtype_and_avoids_launch(shape):
+    source = Path(__file__).resolve().parents[3] / "vllm_ascend/ops/triton/sparse_index_remap.py"
+    tree = ast.parse(source.read_text())
+    function = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "remap_sparse_indices_triton")
+    namespace = {"torch": torch}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"), namespace)
+    value = torch.empty(shape, dtype=torch.int32)
+    assert namespace["remap_sparse_indices_triton"](value, 8, 0, 128) is value

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -24,6 +24,7 @@ from vllm_ascend.attention.sfa_v1 import (
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
+from vllm_ascend.ops.triton.sfa_dcp_query import can_prepare_query, prepare_query_head_major, unpack_query
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -35,6 +36,7 @@ class DCPGatherContext(NamedTuple):
     handle: torch.distributed.Work | None
     restore_perm: tuple[int, ...] | None
     split_sizes: tuple[int, ...]
+    query_prepared: bool = False
 
 
 @dataclass
@@ -485,6 +487,8 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
     ) -> tuple[torch.Tensor, ...]:
         if context.handle is not None:
             context.handle.wait()
+        if context.query_prepared:
+            return unpack_query(context.gathered)
         gathered = context.gathered
         if context.restore_perm is not None:
             gathered = gathered.permute(context.restore_perm).contiguous()
@@ -505,7 +509,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         gathered, handle = all_gather_async(x.permute(perm).contiguous(), self.dcp_group)
         return gathered, handle, restore_perm
 
-    def _remap_sparse_indices(self, topk_indices: torch.Tensor) -> torch.Tensor:
+    def _remap_sparse_indices(self, topk_indices: torch.Tensor, *, decode_only: bool = False) -> torch.Tensor:
         if self.dcp_size <= 1:
             return topk_indices
 
@@ -607,6 +611,18 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 "Cannot fuse DCP query gather for ql_nope/q_pe with "
                 f"shapes {tuple(ql_nope.shape)} / {tuple(q_pe.shape)} "
                 f"and dtypes {ql_nope.dtype} / {q_pe.dtype}."
+            )
+
+        # Both callers reach this path only after excluding prefill/mixed batches.
+        if query_gather_dim == 1 and self.dcp_size == 8 and can_prepare_query(ql_nope, q_pe):
+            prepared = prepare_query_head_major(ql_nope, q_pe)
+            gathered, handle = all_gather_async(prepared, self.dcp_group)
+            return DCPGatherContext(
+                gathered=gathered,
+                handle=handle,
+                restore_perm=(1, 0, 2),
+                split_sizes=(ql_nope.shape[-1], q_pe.shape[-1]),
+                query_prepared=True,
             )
 
         # Avoid back-to-back DCP all_gather calls for the two SFA query
@@ -739,7 +755,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
             # the DSA token shards first, then remap for this receiver rank's
             # DCP-local KV shard.
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
-        topk_indices = self._remap_sparse_indices(topk_indices)
+        topk_indices = self._remap_sparse_indices(topk_indices, decode_only=True)
         ql_nope, q_pe = self._finish_dcp_gather(gather_context)
         sfa_output, softmax_max, softmax_sum = DeviceOperator.execute_sparse_flash_attention_process(
             self,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -50,6 +50,7 @@ from vllm_ascend.memcache_comm_fence import (
 )
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
+from vllm_ascend.ops.triton.sfa_indexer_store import can_fuse_store, store_indexer_key_scale
 from vllm_ascend.quantization.methods import (
     AscendW8A8DynamicLinearMethod,
     AscendW8A8LinearMethod,
@@ -1396,6 +1397,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         x: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
+        defer_scale_cast: bool = False,
     ):
         if not self.has_indexer:
             raise RuntimeError(
@@ -1433,7 +1435,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         if self.enable_sparse_li_c8:
             k_li = k_li @ AscendSFAImpl.k_hadamard
             k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
-            k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
+            if not defer_scale_cast:
+                k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
             k_li_scale = k_li_scale.unsqueeze(-1)  # [b*s,1]
         else:
             k_li_scale = None
@@ -1851,6 +1854,22 @@ class AscendSFAImpl(MLAAttentionImpl):
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens
         output_padded = output
+        fuse_indexer_store = (
+            self.has_indexer
+            and self.enable_sparse_li_c8
+            and not self.enable_sparse_sfa_c8
+            and not self.enable_dsa_cp
+            and getattr(self, "dcp_size", 1) == 8
+            and not self._use_li_c8_reshape_optim()
+            and attn_metadata.attn_state in (AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding)
+            and kv_cache is not None
+            and can_fuse_store(
+                kv_cache[self.kv_cache_indexer_k_idx],
+                kv_cache[self.kv_cache_indexer_scale_idx],
+                slot_mapping,
+                num_input_tokens,
+            )
+        )
 
         # Asynchronously all-gather o_proj for DSA-CP prefill. This applies to
         # both a mixed-role instance and a PD-disaggregated P node.
@@ -1882,7 +1901,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                     f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
                 )
             if self.has_indexer:
-                k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+                k_li, k_li_scale = self.indexer_select_pre_process(
+                    x=hidden_states, cos=cos, sin=sin, defer_scale_cast=fuse_indexer_store
+                )
             else:
                 k_li, k_li_scale = None, None
             wait_for_kv_layer_from_connector(layer_name)
@@ -1924,6 +1945,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     x=hidden_states,
                     cos=cos,
                     sin=sin,
+                    defer_scale_cast=fuse_indexer_store,
                 )
             else:
                 k_li, k_li_scale = None, None
@@ -1984,7 +2006,12 @@ class AscendSFAImpl(MLAAttentionImpl):
             dsa_k_cache_idx = self.kv_cache_indexer_k_idx
             dsa_k_scale_cache_idx = self.kv_cache_indexer_scale_idx
 
-            if use_li_c8_reshape_optim:
+            if fuse_indexer_store:
+                assert k_li_scale is not None
+                store_indexer_key_scale(
+                    k_li, k_li_scale, slot_mapping, kv_cache[dsa_k_cache_idx], kv_cache[dsa_k_scale_cache_idx]
+                )
+            elif use_li_c8_reshape_optim:
                 torch.ops._C_ascend.store_kv_block(
                     k_li,
                     kv_cache[dsa_k_cache_idx],
@@ -1999,7 +2026,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     slot_mapping.view(-1, 1),
                     k_li.view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
-            if self.enable_sparse_li_c8:
+            if self.enable_sparse_li_c8 and not fuse_indexer_store:
                 assert len(kv_cache) == (3 if self.enable_sparse_sfa_c8 else 4)
                 if k_li_scale is not None:
                     if use_li_c8_reshape_optim:

--- a/vllm_ascend/ops/triton/sfa_cp.py
+++ b/vllm_ascend/ops/triton/sfa_cp.py
@@ -8,6 +8,7 @@ from vllm.distributed.parallel_state import _groups
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
+from vllm_ascend.ops.triton.sfa_dcp_exchange import can_exchange, exchange
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
 
 
@@ -359,6 +360,10 @@ def sfa_dcp_a2a_fused_combine(
     group: dist.ProcessGroup,
 ) -> torch.Tensor:
     """Run stride-aware pack, one HCCL All2All, and fused LSE combine."""
+    # Native head-sharded decode only; DSA-CP and other geometry keep the
+    # upstream pack/combine. Stay inside the existing custom-op boundary.
+    if dcp_size == 8 and scatter_dim == 1 and can_exchange(sfa_output, softmax_lse):
+        return exchange(sfa_output, softmax_lse, group).to(sfa_output.dtype)
     send = pack_sfa_dcp_output_lse(
         sfa_output,
         softmax_lse,

--- a/vllm_ascend/ops/triton/sfa_dcp_exchange.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_exchange.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bit-preserving native-DCP8 output/LSE exchange for small decode batches."""
+
+import torch
+import torch.distributed as dist
+
+from vllm_ascend.ops.triton.sfa_dcp_merge import fused_merge
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_RANKS = 8
+_HEADS = 64
+_HEAD_DIM = 512
+_OUTPUT_WORDS_PER_PEER = 2048
+_WORDS_PER_PEER = 2056
+_MAX_DECODE_TOKENS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _pack_t1_peer(output_words, lse, send, lse_head_stride: tl.constexpr):
+        peer = tl.program_id(0)
+        word = tl.arange(0, 2048)
+        values = tl.load(output_words + peer * 2048 + word, mask=word < 2048, other=0)
+        tl.store(send + peer * 2056 + word, values, mask=word < 2048)
+        local_head = tl.arange(0, 8)
+        stats = tl.load(
+            lse + (peer * 8 + local_head) * lse_head_stride,
+            mask=local_head < 8,
+            other=0.0,
+        )
+        tl.store(
+            send + peer * 2056 + 2048 + local_head,
+            stats.to(tl.int32, bitcast=True),
+            mask=local_head < 8,
+        )
+
+    @triton.jit
+    def _pack_token_peer(
+        output,
+        lse,
+        send,
+        output_s0: tl.constexpr,
+        output_s1: tl.constexpr,
+        lse_s0: tl.constexpr,
+        lse_s1: tl.constexpr,
+        tokens: tl.constexpr,
+        local_heads: tl.constexpr,
+        head_words: tl.constexpr,
+        stats_tile: tl.constexpr,
+    ):
+        peer = tl.program_id(0)
+        output_words: tl.constexpr = local_heads * head_words
+        peer_words: tl.constexpr = tokens * (output_words + local_heads)
+        word = tl.arange(0, output_words)
+        local_head = word // head_words
+        dim_word = word % head_words
+        peer_base = peer * peer_words
+        for token in range(tokens):
+            values = tl.load(output + token * output_s0 + (peer * local_heads + local_head) * output_s1 + dim_word)
+            tl.store(send + peer_base + token * output_words + word, values)
+        index = tl.arange(0, stats_tile)
+        token, head = index // local_heads, index % local_heads
+        stats = tl.load(
+            lse + token * lse_s0 + (peer * local_heads + head) * lse_s1,
+            mask=index < tokens * local_heads,
+            other=0.0,
+        )
+        tl.store(
+            send + peer_base + tokens * output_words + index,
+            stats.to(tl.int32, bitcast=True),
+            mask=index < tokens * local_heads,
+        )
+
+
+def can_exchange(output: torch.Tensor, lse: torch.Tensor) -> bool:
+    # These properties are uniform within a valid DCP group. Do not choose
+    # different collective counts based on rank-local allocation/stride state.
+    return (
+        triton is not None
+        and output.device.type == "npu"
+        and output.dtype == torch.bfloat16
+        and output.ndim == 3
+        and 0 < output.shape[0] <= _MAX_DECODE_TOKENS
+        and tuple(output.shape[1:]) == (_HEADS, _HEAD_DIM)
+        and lse.device == output.device
+        and lse.dtype == torch.float32
+        and tuple(lse.shape) == (output.shape[0], _HEADS, 1)
+    )
+
+
+def _exchange_tokens(output: torch.Tensor, lse: torch.Tensor, group) -> torch.Tensor:
+    if not can_exchange(output, lse) or dist.get_world_size(group) != _RANKS:
+        raise ValueError("Unsupported native-DCP8 output/LSE exchange")
+    tokens = output.shape[0]
+    local_heads = _HEADS // _RANKS
+    # Stride-dependent normalization stays inside the one-collective path.
+    if output.stride(-1) != 1 or any(stride % 2 for stride in output.stride()[:2]):
+        output = output.contiguous()
+    if output.storage_offset() % 2:
+        output = output.clone()
+    words = output.view(torch.int32)
+    peer_words = tokens * _WORDS_PER_PEER
+    send = torch.empty((_RANKS, peer_words), dtype=torch.int32, device=output.device)
+    _pack_token_peer[(_RANKS,)](
+        words,
+        lse,
+        send,
+        *words.stride()[:2],
+        *lse.stride()[:2],
+        tokens,
+        local_heads,
+        _HEAD_DIM // 2,
+        triton.next_power_of_2(tokens * local_heads),
+    )
+    recv = torch.empty_like(send)
+    dist.all_to_all_single(recv, send, group=group)
+    # Final receiver layout is token-major: no transpose or receive-side copy.
+    parts = recv.view(output.dtype).as_strided(
+        (_RANKS, tokens, local_heads, _HEAD_DIM),
+        (peer_words * 2, local_heads * _HEAD_DIM, _HEAD_DIM, 1),
+    )
+    stats = recv.view(torch.float32).as_strided(
+        (_RANKS, tokens, local_heads),
+        (peer_words, local_heads, 1),
+        storage_offset=tokens * _OUTPUT_WORDS_PER_PEER,
+    )
+    return fused_merge(parts, stats, token_dim=1)
+
+
+def exchange(output: torch.Tensor, lse: torch.Tensor, group) -> torch.Tensor:
+    """Exchange eight head shards, retaining FP32 LSE bits and merge math."""
+    if output.shape[0] != 1:
+        return _exchange_tokens(output, lse, group)
+    output = output.contiguous()
+    if output.storage_offset() % 2:
+        output = output.clone()
+    lse = lse.contiguous()
+    words = output.view(torch.int32)
+    send = torch.empty((_RANKS, _WORDS_PER_PEER), dtype=torch.int32, device=output.device)
+    _pack_t1_peer[(_RANKS,)](words, lse, send, lse.stride(1))
+    recv = torch.empty_like(send)
+    dist.all_to_all_single(recv, send, group=group)
+    parts = recv.view(output.dtype).as_strided(
+        (_RANKS, _HEADS // _RANKS, 1, _HEAD_DIM),
+        (_WORDS_PER_PEER * 2, _HEAD_DIM, _HEAD_DIM, 1),
+    )
+    stats = recv.view(torch.float32).as_strided(
+        (_RANKS, _HEADS // _RANKS, 1),
+        (_WORDS_PER_PEER, 1, 1),
+        storage_offset=_OUTPUT_WORDS_PER_PEER,
+    )
+    return fused_merge(parts, stats, token_dim=2)

--- a/vllm_ascend/ops/triton/sfa_dcp_merge.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_merge.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FP32 local merge for the small-batch DCP exchange."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+    from triton.language.extra.cann import extension
+
+    get_element = extension.get_element
+except ImportError:  # CPU-only test environments retain exact torch semantics.
+    triton = None
+    tl = None
+    get_element = None
+
+
+_SUPPORTED_RANKS = (2, 8)
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+
+
+def torch_merge(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> torch.Tensor:
+    """Reference merge with upstream invalid-rank masking semantics."""
+    if out_recv.ndim != 4 or lse_recv.ndim != 3 or out_recv.shape[:3] != lse_recv.shape:
+        raise RuntimeError(
+            "DCP output merge expects matching rank/token/head dimensions, "
+            f"got {tuple(out_recv.shape)} and {tuple(lse_recv.shape)}."
+        )
+    if token_dim not in (1, 2):
+        raise RuntimeError(f"DCP output merge token_dim must be 1 or 2, got {token_dim}.")
+    finite = torch.isfinite(lse_recv)
+    lse = lse_recv.masked_fill(~finite, float("-inf"))
+    weights = torch.nan_to_num(torch.softmax(lse, dim=0), nan=0.0)
+    values = out_recv.to(lse.dtype).masked_fill(~finite.unsqueeze(-1), 0.0)
+    output = (values * weights.unsqueeze(-1)).sum(dim=0)
+    return output.movedim(token_dim - 1, 0).contiguous()
+
+
+if triton is not None:
+
+    @triton.jit
+    def _fused_merge_kernel(
+        out_ptr,
+        lse_ptr,
+        result_ptr,
+        out_s0: tl.constexpr,
+        out_s1: tl.constexpr,
+        out_s2: tl.constexpr,
+        out_s3: tl.constexpr,
+        lse_s0: tl.constexpr,
+        lse_s1: tl.constexpr,
+        lse_s2: tl.constexpr,
+        result_s0: tl.constexpr,
+        result_s1: tl.constexpr,
+        result_s2: tl.constexpr,
+        rows: tl.constexpr,
+        head_count: tl.constexpr,
+        head_dim: tl.constexpr,
+        total_tiles: tl.constexpr,
+        num_programs: tl.constexpr,
+        ranks: tl.constexpr,
+        native_layout: tl.constexpr,
+        block_d: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        rank_ids = tl.arange(0, ranks)
+        for tile in tl.range(pid, total_tiles, num_programs):
+            row = tile // tl.cdiv(head_dim, block_d)
+            dim = (tile % tl.cdiv(head_dim, block_d)) * block_d + tl.arange(0, block_d)
+            mask = dim < head_dim
+            token = row // head_count
+            head = row % head_count
+            if native_layout:
+                lse_offsets = rank_ids * lse_s0 + head * lse_s1 + token * lse_s2
+            else:
+                lse_offsets = rank_ids * lse_s0 + token * lse_s1 + head * lse_s2
+            raw_lse = tl.load(lse_ptr + lse_offsets).to(tl.float32)
+            finite = (raw_lse == raw_lse) & (raw_lse > float("-inf")) & (raw_lse < float("inf"))
+            safe_lse = tl.where(finite, raw_lse, float("-inf"))
+            max_lse = tl.max(safe_lse, axis=0)
+            shifted = tl.where(finite, safe_lse - max_lse, 0.0)
+            exponent = tl.where(finite, tl.exp(shifted), 0.0)
+            denominator = tl.sum(exponent, axis=0)
+            safe_denominator = tl.where(denominator > 0.0, denominator, 1.0)
+            weights = exponent / safe_denominator
+            result = tl.zeros((block_d,), dtype=tl.float32)
+            for rank in tl.static_range(0, ranks):
+                weight = get_element(weights, (rank,))
+                if native_layout:
+                    out_offsets = rank * out_s0 + head * out_s1 + token * out_s2 + dim * out_s3
+                else:
+                    out_offsets = rank * out_s0 + token * out_s1 + head * out_s2 + dim * out_s3
+                values = tl.load(out_ptr + out_offsets, mask=mask, other=0.0).to(tl.float32)
+                # Match upstream: invalid-rank NaN/Inf outputs must not leak
+                # through a zero LSE weight (NaN * 0 is still NaN).
+                values = tl.where(get_element(finite, (rank,)), values, 0.0)
+                result += values * weight
+            tl.store(result_ptr + token * result_s0 + head * result_s1 + dim * result_s2, result, mask=mask)
+
+
+def _fast_path(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> bool:
+    if triton is None or get_element is None or out_recv.device.type != "npu" or out_recv.device != lse_recv.device:
+        return False
+    if out_recv.ndim != 4 or lse_recv.ndim != 3 or 0 in out_recv.shape or 0 in lse_recv.shape:
+        return False
+    if out_recv.shape[0] not in _SUPPORTED_RANKS or out_recv.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if lse_recv.dtype != torch.float32 or token_dim not in (1, 2):
+        return False
+    return not (
+        out_recv.shape[:3] != lse_recv.shape
+        or any(stride < 0 for stride in out_recv.stride())
+        or any(stride < 0 for stride in lse_recv.stride())
+        or out_recv.stride(-1) != 1
+        or lse_recv.stride(-1) != 1
+    )
+
+
+def fused_merge(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> torch.Tensor:
+    """Fuse only the post-All2All local math; unsupported inputs use torch."""
+    if not _fast_path(out_recv, lse_recv, token_dim):
+        return torch_merge(out_recv, lse_recv, token_dim)
+    ranks = out_recv.shape[0]
+    if token_dim == 2:
+        _, heads, tokens, head_dim = out_recv.shape
+        native_layout = True
+    else:
+        _, tokens, heads, head_dim = out_recv.shape
+        native_layout = False
+    result = torch.empty((tokens, heads, head_dim), dtype=torch.float32, device=out_recv.device)
+    # Rank-wise accumulation avoids the failed R×D materialization. D512 now
+    # holds one FP32 accumulator plus one rank vector; retry verifies compiler UB.
+    block_d = min(triton.next_power_of_2(head_dim), 512)
+    tiles = tokens * heads * math.ceil(head_dim / block_d)
+    properties = triton.runtime.driver.active.utils.get_device_properties(out_recv.device.index)
+    programs = min(tiles, properties["num_vectorcore"])
+    _fused_merge_kernel[(programs,)](
+        out_recv,
+        lse_recv,
+        result,
+        *out_recv.stride(),
+        *lse_recv.stride(),
+        *result.stride(),
+        tokens * heads,
+        heads,
+        head_dim,
+        total_tiles=tiles,
+        num_programs=programs,
+        ranks=ranks,
+        native_layout=native_layout,
+        block_d=block_d,
+    )
+    return result

--- a/vllm_ascend/ops/triton/sfa_dcp_query.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_query.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Direct gather-input packing and final SFA query unpacking for DCP8 decode."""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_LOCAL_HEADS = 8
+_TOTAL_HEADS = 64
+_NOPE_DIM = 512
+_ROPE_DIM = 64
+_PACKED_DIM = _NOPE_DIM + _ROPE_DIM
+_MAX_DECODE_TOKENS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _prepare_query_head_major(
+        qn,
+        qr,
+        out,
+        ns0: tl.constexpr,
+        ns1: tl.constexpr,
+        ns2: tl.constexpr,
+        rs0: tl.constexpr,
+        rs1: tl.constexpr,
+        rs2: tl.constexpr,
+        tokens: tl.constexpr,
+        programs: tl.constexpr,
+        heads: tl.constexpr,
+        nope_dim: tl.constexpr,
+        rope_dim: tl.constexpr,
+    ):
+        n = tl.arange(0, nope_dim)
+        r = tl.arange(0, rope_dim)
+        for row in tl.range(tl.program_id(0), heads * tokens, programs):
+            head, token = row // tokens, row % tokens
+            a = tl.load(qn + token * ns0 + head * ns1 + n * ns2)
+            b = tl.load(qr + token * rs0 + head * rs1 + r * rs2)
+            tl.store(out + row * (nope_dim + rope_dim) + n, a)
+            tl.store(out + row * (nope_dim + rope_dim) + nope_dim + r, b)
+
+    @triton.jit
+    def _unpack_query_fragments(
+        gathered,
+        qn,
+        qr,
+        tokens: tl.constexpr,
+        programs: tl.constexpr,
+        heads: tl.constexpr,
+        nope_dim: tl.constexpr,
+        rope_dim: tl.constexpr,
+    ):
+        n = tl.arange(0, nope_dim)
+        r = tl.arange(0, rope_dim)
+        for row in tl.range(tl.program_id(0), tokens * heads, programs):
+            token, head = row // heads, row % heads
+            base = (head * tokens + token) * (nope_dim + rope_dim)
+            a = tl.load(gathered + base + n)
+            b = tl.load(gathered + base + nope_dim + r)
+            tl.store(qn + row * nope_dim + n, a)
+            tl.store(qr + row * rope_dim + r, b)
+
+
+def can_prepare_query(qn: torch.Tensor, qr: torch.Tensor) -> bool:
+    return (
+        triton is not None
+        and qn.device.type == "npu"
+        and qr.device == qn.device
+        and qn.dtype == qr.dtype == torch.bfloat16
+        and qn.ndim == qr.ndim == 3
+        and tuple(qn.shape[1:]) == (_LOCAL_HEADS, _NOPE_DIM)
+        and tuple(qr.shape) == (qn.shape[0], _LOCAL_HEADS, _ROPE_DIM)
+        and 1 < qn.shape[0] <= _MAX_DECODE_TOKENS
+        and all(stride >= 0 for stride in (*qn.stride(), *qr.stride()))
+    )
+
+
+def prepare_query_head_major(qn: torch.Tensor, qr: torch.Tensor) -> torch.Tensor:
+    if not can_prepare_query(qn, qr):
+        raise ValueError("Unsupported native-DCP8 query preparation")
+    tokens = qn.shape[0]
+    result = torch.empty((_LOCAL_HEADS, tokens, _PACKED_DIM), dtype=qn.dtype, device=qn.device)
+    cores = triton.runtime.driver.active.utils.get_device_properties(qn.device.index)["num_vectorcore"]
+    programs = min(_LOCAL_HEADS * tokens, cores)
+    _prepare_query_head_major[(programs,)](
+        qn,
+        qr,
+        result,
+        *qn.stride(),
+        *qr.stride(),
+        tokens,
+        programs,
+        _LOCAL_HEADS,
+        _NOPE_DIM,
+        _ROPE_DIM,
+    )
+    return result
+
+
+def unpack_query(gathered: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        triton is None
+        or gathered.device.type != "npu"
+        or gathered.dtype != torch.bfloat16
+        or gathered.ndim != 3
+        or gathered.shape[0] != _TOTAL_HEADS
+        or gathered.shape[2] != _PACKED_DIM
+        or not 1 < gathered.shape[1] <= _MAX_DECODE_TOKENS
+        or not gathered.is_contiguous()
+    ):
+        raise ValueError("Unsupported native-DCP8 gathered query")
+    tokens = gathered.shape[1]
+    qn = torch.empty((tokens, _TOTAL_HEADS, _NOPE_DIM), dtype=gathered.dtype, device=gathered.device)
+    qr = torch.empty((tokens, _TOTAL_HEADS, _ROPE_DIM), dtype=gathered.dtype, device=gathered.device)
+    cores = triton.runtime.driver.active.utils.get_device_properties(gathered.device.index)["num_vectorcore"]
+    programs = min(tokens * _TOTAL_HEADS, cores)
+    _unpack_query_fragments[(programs,)](
+        gathered,
+        qn,
+        qr,
+        tokens,
+        programs,
+        _TOTAL_HEADS,
+        _NOPE_DIM,
+        _ROPE_DIM,
+    )
+    return qn, qr

--- a/vllm_ascend/ops/triton/sfa_dcp_remap.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_remap.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuse native-DCP decode remap arithmetic around native sort and gather.
+
+The validated fast path is DCP8, interleave128, Top-K2048, contiguous int32
+indices and at most12 decode rows. Other inputs retain the caller's upstream
+path. Integer coordinates preserve this release's remapping semantics even
+above 2**24; only the unique position keys used for sorting are FP32.
+"""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_DCP_SIZE = 8
+_INTERLEAVE_SIZE = 128
+_TOPK = 2048
+_MAX_DECODE_ROWS = 12
+_SINGLE_ROW_BLOCK = 128
+_MULTI_ROW_BLOCK = 256
+
+
+if triton is not None:
+
+    @triton.jit
+    def _prepare_remap(
+        indices,
+        keys,
+        mapped,
+        elements: tl.constexpr,
+        count: tl.constexpr,
+        ranks: tl.constexpr,
+        rank: tl.constexpr,
+        interleave: tl.constexpr,
+        programs: tl.constexpr,
+        block: tl.constexpr,
+    ):
+        for tile in tl.range(tl.program_id(0), tl.cdiv(elements, block), programs):
+            offset = tile * block + tl.arange(0, block)
+            value = tl.load(indices + offset, mask=offset < elements, other=-1)
+            local_block = value // interleave
+            owner = local_block - (local_block // ranks) * ranks
+            owned = (value >= 0) & (owner == rank)
+            if interleave == 1:
+                local = value // ranks
+            else:
+                local_offsets = value - local_block * interleave
+                local = (value // (ranks * interleave)) * interleave + local_offsets
+            key = (offset % count).to(tl.float32) + tl.where(owned, 0.0, count)
+            tl.store(keys + offset, key, mask=offset < elements)
+            tl.store(mapped + offset, tl.where(owned, local, -1), mask=offset < elements)
+
+
+def can_fuse_remap(indices: torch.Tensor) -> bool:
+    return (
+        triton is not None
+        and indices.device.type == "npu"
+        and indices.dtype == torch.int32
+        and indices.ndim > 0
+        and indices.shape[-1] == _TOPK
+        and 0 < indices.numel() <= _MAX_DECODE_ROWS * _TOPK
+        and indices.is_contiguous()
+    )
+
+
+def fused_remap(indices: torch.Tensor, rank: int) -> torch.Tensor:
+    if not can_fuse_remap(indices) or not 0 <= rank < _DCP_SIZE:
+        raise ValueError("Unsupported native-DCP remap input or rank")
+    elements = indices.numel()
+    keys = torch.empty_like(indices, dtype=torch.float32)
+    mapped = torch.empty_like(indices)
+    block = _SINGLE_ROW_BLOCK if elements == _TOPK else _MULTI_ROW_BLOCK
+    cores = triton.runtime.driver.active.utils.get_device_properties(indices.device.index)["num_vectorcore"]
+    programs = min(triton.cdiv(elements, block), cores)
+    _prepare_remap[(programs,)](
+        indices,
+        keys,
+        mapped,
+        elements,
+        _TOPK,
+        _DCP_SIZE,
+        rank,
+        _INTERLEAVE_SIZE,
+        programs,
+        block,
+    )
+    # Native sort/gather outperform the tested scan/scatter and indirect-load
+    # Triton variants. Unique position keys preserve the original Top-K order.
+    _, order = torch.sort(keys, dim=-1)
+    return torch.gather(mapped, dim=-1, index=order.to(torch.int32))

--- a/vllm_ascend/ops/triton/sfa_indexer_store.py
+++ b/vllm_ascend/ops/triton/sfa_indexer_store.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Store native-quantized indexer keys and FP16 scales in one kernel.
+
+Keep native quantization and its INT8 tie behavior. Only final scale conversion
+and the two scatters are fused. Valid cache slots must be unique, as provided
+by decode slot mapping; padded negative slots are skipped.
+"""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_KEY_WIDTH = 128
+_MAX_DECODE_ROWS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _store_indexer_key_scale(
+        quant,
+        scales,
+        slots,
+        cache,
+        scale_cache,
+        capacity: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        column = tl.arange(0, 128)
+        key = tl.load(quant + row * 128 + column)
+        scale = tl.load(scales + row)
+        slot = tl.load(slots + row).to(tl.int64)
+        valid = (slot >= 0) & (slot < capacity)
+        tl.store(cache + slot * 128 + column, key, valid)
+        tl.store(scale_cache + slot, scale, valid)
+
+
+def can_fuse_store(cache: torch.Tensor, scale_cache: torch.Tensor, slots: torch.Tensor, rows: int) -> bool:
+    return (
+        triton is not None
+        and cache.device.type == "npu"
+        and scale_cache.device == cache.device == slots.device
+        and cache.dtype == torch.int8
+        and scale_cache.dtype == torch.float16
+        and slots.dtype in (torch.int32, torch.int64)
+        and cache.ndim > 0
+        and cache.shape[-1] == _KEY_WIDTH
+        and cache.numel() // _KEY_WIDTH == scale_cache.numel()
+        and cache.numel() > 0
+        and cache.is_contiguous()
+        and scale_cache.is_contiguous()
+        and slots.is_contiguous()
+        and slots.ndim == 1
+        and slots.numel() == rows
+        and 0 < rows <= _MAX_DECODE_ROWS
+    )
+
+
+def store_indexer_key_scale(
+    quant: torch.Tensor,
+    scales: torch.Tensor,
+    slots: torch.Tensor,
+    cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+) -> None:
+    """Publish at the existing cache-write point, after the connector wait."""
+    rows = slots.numel()
+    if (
+        not can_fuse_store(cache, scale_cache, slots, rows)
+        or quant.device != cache.device
+        or scales.device != cache.device
+        or quant.dtype != torch.int8
+        or scales.dtype != torch.float32
+        or quant.numel() != rows * _KEY_WIDTH
+        or scales.numel() != rows
+        or not quant.is_contiguous()
+        or not scales.is_contiguous()
+    ):
+        raise ValueError("Unsupported native-DCP indexer key/scale store")
+    _store_indexer_key_scale[(rows,)](quant, scales, slots, cache, scale_cache, cache.numel() // _KEY_WIDTH)

--- a/vllm_ascend/ops/triton/sparse_index_remap.py
+++ b/vllm_ascend/ops/triton/sparse_index_remap.py
@@ -33,6 +33,7 @@ def remap_sparse_indices_fused_kernel(
     dcp_size,
     interleave_size,
     dcp_rank,
+    EXACT_DCP8: tl.constexpr,
     INTERLEAVE_ONE: tl.constexpr,
     BLOCK: tl.constexpr,
     NUM_CHUNKS: tl.constexpr,
@@ -53,18 +54,20 @@ def remap_sparse_indices_fused_kernel(
     in_bounds = offsets < topk_count
 
     idx = tl.load(indices_ptr + row * topk_count + offsets, mask=in_bounds, other=-1)
-    # Integer remap math: matches the fp32 torch fallback bit-exactly
-    # (indices are far below 2^24), and the int32/fp32 variants measured
-    # identically on NPU.
-    block_idx = idx // interleave_size
-    owner = block_idx - (block_idx // dcp_size) * dcp_size
-    valid = (idx >= 0) & (owner == dcp_rank)
-
-    if INTERLEAVE_ONE:
-        remapped = idx // dcp_size
+    # This backend's vector divsi loses integer boundaries above 2**24.
+    # Keep the native DCP8/interleave128 path entirely in bit operations.
+    if EXACT_DCP8:
+        owner = (idx >> 7) & 7
+        remapped = ((idx >> 10) << 7) + (idx & 127)
     else:
-        local_offsets = idx - block_idx * interleave_size
-        remapped = (idx // (dcp_size * interleave_size)) * interleave_size + local_offsets
+        block_idx = idx // interleave_size
+        owner = block_idx - (block_idx // dcp_size) * dcp_size
+        if INTERLEAVE_ONE:
+            remapped = idx // dcp_size
+        else:
+            local_offsets = idx - block_idx * interleave_size
+            remapped = (idx // (dcp_size * interleave_size)) * interleave_size + local_offsets
+    valid = (idx >= 0) & (owner == dcp_rank)
 
     valid_i32 = valid.to(tl.int32)
     chunk_out = chunk_out_ptr + (row * NUM_CHUNKS + chunk) * BLOCK
@@ -141,9 +144,9 @@ def remap_sparse_indices_triton(
         topk_indices = topk_indices.contiguous()
     indices = topk_indices if topk_indices.dtype == torch.int32 else topk_indices.to(torch.int32)
     topk_count = indices.shape[-1]
-    rows = indices.numel() // topk_count
-    if rows == 0 or topk_count == 0:
+    if indices.numel() == 0:
         return topk_indices
+    rows = indices.numel() // topk_count
     # The torch implementation operates per-row on the last dim, so arbitrary
     # leading dims (e.g. [dcp_size, 1, topk_count] from the DCP all_gather) can
     # be flattened to a 2D view and restored afterwards.
@@ -164,6 +167,7 @@ def remap_sparse_indices_triton(
         dcp_size,
         interleave_size,
         dcp_rank,
+        EXACT_DCP8=dcp_size == 8 and interleave_size == 128,
         INTERLEAVE_ONE=interleave_size == 1,
         BLOCK=block,
         NUM_CHUNKS=num_chunks,


### PR DESCRIPTION
### What this PR does / why we need it?

Optimize native DCP decode layouts on the pinned `releases/v0.26.0rc` base
`5f12bbf34a530cd6c87463c56404535246af6e94`.

- Keep upstream two-kernel sparse-index remap, with DCP8/interleave128 integer
  boundary and empty-input repairs.
- Pack BF16 output and FP32 LSE as raw bits into one AllToAll, then merge in
  FP32 and convert back to BF16.
- Prepare head-major query gathers and retain native INT8 quantization with
  fused final key/scale stores.
- **New:** expand O/LSE eligibility from `T <= 12` to
  `T <= min(max_num_batched_tokens, 192)`. Query/store limits are unchanged.
  **192 is a manually chosen cap, not a demonstrated kernel limit. Larger
  values have not been tested and retain the upstream fallback.**

The added gain comes from allowing larger eligible calls to use the existing
optimized O/LSE layout, not from increasing the scheduled batch size or
reducing collective count. Both paths already use one AllToAll. No allocator,
memory-placement or experimental VMM peer-exchange change is included.

### Does this PR introduce _any_ user-facing change?

No new serving API or configuration knob. The existing scheduler token budget
now also bounds optimized O/LSE routing. Unsupported geometry/dtypes retain
upstream fallback. Invalid-shard merge masking preserves upstream nonfinite
handling; integer remap repair remains limited to DCP8/interleave128.

### How was this patch tested?

- Fresh focused CPU suite: **95 passed**; routing tests cover scheduler budgets,
  current configuration changes, standalone initialization and fallback.
- A3 direct-helper changing-input graph checks: nine sizes from T13 through
  T192, **1,152 rank-level checks**. Registered-op graph routing/capture checks
  separately cover T48/T192, **128 rank-level checks**.
- Full synthetic decode serving: GLM-5.2 W4A8, 32 A3 NPUs in one superpod,
  DP4/local-DP2/TP8/DCP8/EP32, MTP5 with zero synthetic acceptance,
  zero-filled DecodeBenchConnector KV, full decode graphs, concurrency32,
  50 identical 20K-40K prompts and exactly700 output tokens per request.
  Scheduler budget192; actual vLLM revision `b5e8e2561`.

| Same-image runtime composition | Per-run mean TPOT (ms) | Median of run TPOT (ms) | Median throughput (tok/s) |
|---|---|---:|---:|
| PR15970 default keep-view baseline |114.626,114.192|114.409|221.196|
| Previous combined port, cap12 |114.339,114.006|114.172|221.521|
| Updated combined port, cap192 |105.798,99.110,105.807|105.798|238.331|

All seven fixed-output runs completed **50/50 requests, 35,000 output tokens,
zero recorded errors**, with identical input-length arrays. No repetitions
were discarded. Median-of-runs TPOT improves **7.53% versus PR15970** and
**7.33% versus cap12**; throughput improves **7.75% / 7.59%**, respectively.
The cap12/cap192 manifests differ only in the two O/LSE files. Warmups were
excluded; no audit RPC or profiler ran during included measurements. Imported
source paths/hashes were checked on all32workers before measurement.

Scope: these were image-compatible Python overlays, with PR15970 default
behavior adapted to the image's older config API, not full-worktree installs
or an exact reproduction of a colleague's historical manual merge. Candidate
run variation is larger than baseline variation. These small samples do not
establish confidence intervals, model accuracy, actual shape-frequency counts,
or performance on other workloads.

Known numerical limitation remains: strict CPU-BF16 `atol=rtol=1e-3` checks
fail for both optimized and upstream exchange. No tolerance was relaxed and
no complete numerical acceptance is claimed. The PR's existing review state
is unchanged.

Local publication checks: 95 CPU tests pass. Full `bash format.sh ci` passes
the other hooks, including Gitleaks and ShellCheck, but Actionlint fails when
its macOS ShellCheck subprocesses are terminated; a full CI pass is not claimed.
Raw requests and internal runtime artifacts are not published.
Earlier component results and their boundaries remain documented there.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
