### PR TITLE
[Performance][DCP] Refresh native decode layouts and remap fixes for main

### DIFF
--- a/DCP_PORT.md
+++ b/DCP_PORT.md
@@ -1,0 +1,90 @@
+# DCP decode layout port: fixed local main
+
+## 2026-09-11 local refresh
+
+Base: local main ac6405d9eb12e1466d00a0fb4e67ab87c1a33061.
+Branch: perf/dcp-decode-layouts; historical port commit3788d00d5ee808a785cee3a4cac2237bf53c9eea.
+Original donor: local82bcf6902a5d08cb736d941ea1a874d026d30238.
+Current status: local source refresh and CPU checks complete; no new NPU run.
+
+| Area | Current selection |
+|---|---|
+| Remap | Retain upstream two-kernel path; add tested DCP8/interleave128 integer and empty-input repairs |
+| O/LSE | Add v0.26 port's raw-bit pack, one AllToAll, FP32 merge and Cast |
+| Query | Existing head-major prepare and contiguous unpack; unchanged |
+| Indexer store | Existing native quantization plus fused stores in AscendSFAIndexerBackend; unchanged |
+
+O/LSE reuses sfa_dcp_exchange.py and sfa_dcp_merge.py byte-for-byte from the
+measured v0.26 port. This preserves its invalid-rank masking adaptation.
+Routing stays inside the existing registered custom op and retains FakeTensor
+behavior/signatures. It selects the new path only without a PCP group, for
+scatter_size8/scatter_dim1 and eligible BF16 T1-12/H64/D512 + FP32 LSE.
+The current native attention caller reaches this path from decode handling.
+PCP composition, token-scatter DSA-CP, other group sizes, unsupported shapes
+and scatter-size1 keep the original upstream pipeline. A missing scatter
+group still raises before any communication.
+
+## Local verification
+
+Final focused CPU suite: 43 tests passed.
+Tests cover old/new routing, PCP gather preservation (including no scatter),
+DSA token scatter, dtype/shape fallback, FakeTensor output, invalid-shard
+merge semantics, empty remap, query wait ordering and store routing.
+
+```bash
+python3 -m pytest --noconftest -q \
+  tests/ut/attention/test_sparse_index_remap_port.py \
+  tests/ut/attention/test_sfa_dcp_exchange_port.py \
+  tests/ut/attention/test_sfa_dcp_query_port.py \
+  tests/ut/attention/test_sfa_indexer_store_port.py
+```
+
+NPU entries: tests/ut/attention/a2/test_sfa_dcp_remap.py and
+tests/ut/attention/a2/test_sfa_dcp_exchange_port.py. The exchange test retains
+its strict oracle; it is not expected to waive the historical CPU-BF16 failures.
+No main-PCP device result or full main serving speedup is asserted.
+
+## Reused experiment evidence (not new validation of these worktrees)
+
+- [Pinned upstream component comparison](../../experiments/upstream_dcp_20260910/REPORT.md)
+  tested release5f12bbf/f2648bb0f helpers on the pinned A3 environment. The
+  pack/combine leaf implementations match local main base ac6405d9; main's
+  additional PCP composition and full main serving were not measured.
+- Original optimized raw-bit O/LSE versus upstream, complete path including
+  communication, merge and BF16 Cast: T1 reduction30.5/30.7%, T6 23.6/28.4%,
+  T12 35.1/33.6% in AB/BA runs. Both paths already use one AllToAll.
+  This is not the later experimental VMM peer exchange and not a serving gain.
+- Query+SFA T6 reduction12.3-13.6%, T12 16.5-19.2%; T1 is unchanged fallback.
+  Native quant+store reduction73.9-75.9% for T1/6/12. Query/store NPU byte,
+  consumer and changed-graph checks passed in the pinned helper experiments.
+- [Remap follow-up](../../experiments/peer_olse_20260911/REMAP_RESULT.md):
+  two-kernel path reduces whole-remap latency35.08-42.63% relative to our
+  old five-operation path. The repaired module is copied byte-for-byte from
+  the tested local working source, not its older82bcf commit.
+- Integer regression: input16777343 belongs to owner0/local2097279; the
+  observed vector division gave owner1/local2097151. DCP8/interleave128 now
+  uses shifts/masks, including boundaries above2**24 and INT32_MAX.
+  Other configurations retain upstream arithmetic, without a new exactness
+  claim. Empty last dimension returns before division by TopK.
+- Historical v0.26 remap test result38PASS/3FAIL preceded this repair.
+  The former DCP_PORT claim of exact large-coordinate arithmetic was disproved
+  on hardware. Those failures are not erased or relabeled as passes.
+- Strict CPU-BF161e-3 tests fail for both original optimized and upstream
+  exchange. Independent FP64 diagnostics bound pre-cast FP32 error below8e-7
+  in the upstream comparison. These are not established donor-only regressions;
+  no tolerance is relaxed and no complete numerical acceptance is claimed.
+  The local9% TPOT result uses a different baseline and must not be claimed
+  for this port or added to the component percentages.
+
+## Scope boundary
+
+No fetch, rebase, remote update, push, PR, runtime installation, pod operation,
+NPU experiment, allocator/host-DRAM placement or experimental VMM peer code is
+part of this refresh. Q/store kernels are unchanged and identical across the
+two port worktrees and local donor. Local main always means ac6405d9, not
+today's remote main. Changes remain uncommitted on the historical port commit.
+
+The new NPU regression tests exercise the actual two-kernel remap against a
+CPU int64 oracle, large coordinates and changed graph inputs. Their presence
+does not mean they ran locally. A new full-worktree NPU/serving validation is
+still required before making a full-port runtime acceptance claim.

--- a/tests/ut/attention/a2/test_sfa_dcp_exchange_port.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_exchange_port.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DCP8 exchange comparison; run via torchrun on an isolated eight-NPU group."""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_cp import (  # noqa: E402
+    fused_sfa_dcp_lse_combine,
+    pack_sfa_dcp_output_lse,
+    sfa_dcp_a2a_fused_combine,
+)
+
+pytestmark = pytest.mark.skipif(int(os.environ.get("WORLD_SIZE", "1")) != 8, reason="requires isolated DCP8")
+
+
+def test_exchange_matches_upstream_and_reference_with_changed_input_graphs():
+    rank = int(os.environ["RANK"])
+    torch.npu.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("hccl")
+    retained = []
+
+    def inputs(tokens, step):
+        generator = torch.Generator().manual_seed(2026 + step)
+        outputs = torch.randn(8, tokens, 64, 512, generator=generator).to(torch.bfloat16)
+        lses = torch.randn(8, tokens, 64, 1, generator=generator)
+        # All-invalid and mixed-invalid heads cover NaN*0 contamination.
+        lses[:, :, 0] = -torch.inf
+        outputs[:, :, 0] = torch.nan
+        for sender, value in enumerate((torch.nan, torch.inf, -torch.inf)):
+            lses[sender, :, 1] = value
+            outputs[sender, :, 1] = torch.nan
+        return outputs, lses
+
+    for tokens in (1, 6, 12):
+        outputs, lses = inputs(tokens, 0)
+        # Head-major storage exercises a strided token-major view.
+        owner = outputs[rank].transpose(0, 1).contiguous().npu()
+        output = owner.transpose(0, 1)
+        lse = lses[rank].npu()
+
+        def invoke(output=output, lse=lse):
+            return sfa_dcp_a2a_fused_combine(output, lse, 8, 1, dist.group.WORLD)
+
+        for _ in range(5):
+            invoke()
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            result = invoke()
+        for step in range(8):
+            outputs, lses = inputs(tokens, step)
+            owner.copy_(outputs[rank].transpose(0, 1).contiguous())
+            lse.copy_(lses[rank])
+            # These unchanged upstream helpers bypass the new dispatch guard.
+            send = pack_sfa_dcp_output_lse(output, lse, 8, 1)
+            recv = torch.empty_like(send)
+            dist.all_to_all_single(recv, send)
+            upstream = fused_sfa_dcp_lse_combine(recv, 512, 1)
+            graph.replay()
+            torch.npu.synchronize()
+            finite = torch.isfinite(lses)
+            weights = torch.nan_to_num(torch.softmax(lses.masked_fill(~finite, -torch.inf), dim=0), nan=0.0)
+            expected = (outputs.float().masked_fill(~finite, 0.0) * weights).sum(0)
+            expected = expected[:, rank * 8 : (rank + 1) * 8].to(torch.bfloat16)
+            assert torch.isfinite(result).all()
+            torch.testing.assert_close(result.cpu(), expected, rtol=1e-3, atol=1e-3)
+            torch.testing.assert_close(result, upstream, rtol=1e-3, atol=1e-3)
+        retained.append((graph, result, owner, lse))
+    dist.barrier()
+    dist.destroy_process_group()

--- a/tests/ut/attention/a2/test_sfa_dcp_query_port.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_query_port.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run with torchrun --standalone --nproc-per-node=8 -m pytest --noconftest."""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_dcp_query import (  # noqa: E402
+    can_prepare_query,
+    prepare_query_head_major,
+    unpack_query,
+)
+
+pytestmark = pytest.mark.skipif(int(os.environ.get("WORLD_SIZE", "1")) != 8, reason="requires an isolated DCP8 group")
+
+
+def test_query_gather_raw_bits_and_changed_input_graphs():
+    rank = int(os.environ["RANK"])
+    torch.npu.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("hccl")
+    retained = []
+    patterns = torch.tensor([0, -32768, 1, 127, 32640, -128, 32705, -63], dtype=torch.int16)
+
+    def bits(sender, tokens, width, step):
+        return patterns.roll(sender + step).repeat(tokens * 8 * width // patterns.numel()).view(tokens, 8, width)
+
+    for tokens in (2, 6, 12):
+        n_owner = bits(rank, tokens, 512, 0).transpose(0, 1).contiguous().view(torch.bfloat16).npu()
+        r_owner = bits(rank, tokens, 64, 0).view(torch.bfloat16).npu()
+        qn, qr = n_owner.transpose(0, 1), r_owner
+        assert can_prepare_query(qn, qr)
+
+        def invoke(qn=qn, qr=qr, tokens=tokens):
+            send = prepare_query_head_major(qn, qr)
+            received = torch.empty((64, tokens, 576), dtype=qn.dtype, device=qn.device)
+            dist.all_gather_into_tensor(received, send, async_op=True).wait()
+            return unpack_query(received)
+
+        for _ in range(5):
+            invoke()
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            result = invoke()
+        for step in range(16):
+            n_owner.copy_(bits(rank, tokens, 512, step).transpose(0, 1).contiguous().view(torch.bfloat16))
+            r_owner.copy_(bits(rank, tokens, 64, step).view(torch.bfloat16))
+            graph.replay()
+            torch.npu.synchronize()
+            for actual, width in zip(result, (512, 64)):
+                expected = torch.cat([bits(sender, tokens, width, step) for sender in range(8)], dim=1)
+                assert actual.is_contiguous()
+                assert torch.equal(actual.view(torch.int16).cpu(), expected)
+        retained.append((graph, result, n_owner, r_owner))
+    dist.barrier()
+    dist.destroy_process_group()

--- a/tests/ut/attention/a2/test_sfa_dcp_remap.py
+++ b/tests/ut/attention/a2/test_sfa_dcp_remap.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Two-kernel remap: independent integer oracle and changed graph inputs."""
+
+import pytest
+import torch
+
+pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sparse_index_remap import remap_sparse_indices_triton  # noqa: E402
+
+
+def oracle(indices, rank):
+    expected = torch.full_like(indices, -1)
+    # CPU int64 arithmetic is independent of NPU vector integer division.
+    for source, target in zip(indices.long().reshape(-1, 2048), expected.reshape(-1, 2048)):
+        owned = source[(source >= 0) & ((source // 128) % 8 == rank)]
+        target[: owned.numel()] = (owned // 1024 * 128 + owned % 128).to(target.dtype)
+    return expected
+
+
+@pytest.mark.parametrize("rows", [1, 6, 12])
+@pytest.mark.parametrize("rank", range(8))
+def test_exact_integer_boundaries_and_changed_graph_inputs(rows, rank):
+    torch.npu.set_device(0)
+    rng = torch.Generator().manual_seed(20260911 + rows + rank)
+    base = torch.randint(0, 2**31 - 1, (rows, 2048), generator=rng, dtype=torch.int32)
+    boundaries = torch.tensor(
+        [-1, 0, 127, 128, 1023, 1024, 2**24 - 1, 2**24, 2**24 + 127, 2**31 - 1],
+        dtype=torch.int32,
+    )
+    device_input = base.npu()
+    for _ in range(5):
+        remap_sparse_indices_triton(device_input, 8, rank, 128)
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        output = remap_sparse_indices_triton(device_input, 8, rank, 128)
+    for step in range(8):
+        current = torch.roll(base, step, dims=-1)
+        current[:, : boundaries.numel()] = boundaries
+        if step == 0:
+            current.fill_(-1)
+        device_input.copy_(current)
+        graph.replay()
+        assert torch.equal(output.cpu(), oracle(current, rank))
+    torch.npu.synchronize()
+
+
+@pytest.mark.parametrize("shape", [(0, 2048), (1, 0), (2, 3, 0)])
+def test_empty_input(shape):
+    value = torch.empty(shape, dtype=torch.int32, device="npu")
+    assert remap_sparse_indices_triton(value, 8, 0, 128) is value

--- a/tests/ut/attention/a2/test_sfa_indexer_store_port.py
+++ b/tests/ut/attention/a2/test_sfa_indexer_store_port.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native quantization byte oracle for final packed indexer K/scale writes."""
+
+import pytest
+import torch
+
+torch_npu = pytest.importorskip("torch_npu")
+
+from vllm_ascend.ops.triton.sfa_indexer_store import can_fuse_store, store_indexer_key_scale  # noqa: E402
+
+
+def test_native_quantized_cache_bytes_and_changing_graph_slots():
+    torch.npu.set_device(0)
+    retained = []
+    capacity, width = 256, 128
+    for rows in (1, 6, 12):
+        x = torch.randn(rows, width, dtype=torch.bfloat16, device="npu")
+        keys, scales = torch_npu.npu_dynamic_quant(x, dst_type=torch.int8)
+        slots = torch.arange(rows, dtype=torch.int64, device="npu") + 7
+        backing = torch.full((capacity * (width + 2) + 64,), 19, dtype=torch.int8, device="npu")
+        cache = backing[: capacity * width].view(2, 128, 1, width)
+        scale_cache = backing[capacity * width : -64].view(torch.float16).view(2, 128, 1, 1)
+        assert can_fuse_store(cache, scale_cache, slots, rows)
+        for _ in range(5):
+            store_indexer_key_scale(keys, scales, slots, cache, scale_cache)
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            store_indexer_key_scale(keys, scales, slots, cache, scale_cache)
+        for step in range(16):
+            fresh_keys, fresh_scales = torch_npu.npu_dynamic_quant(torch.randn_like(x), dst_type=torch.int8)
+            keys.copy_(fresh_keys)
+            scales.copy_(fresh_scales)
+            selected = torch.arange(rows, dtype=torch.int64) + 3 + step
+            if step % 2:
+                selected[-1] = -1
+            slots.copy_(selected)
+            backing.fill_(19)
+            scale_cache.fill_(3.25)
+            graph.replay()
+            torch.npu.synchronize()
+            expected_keys = torch.full((capacity, width), 19, dtype=torch.int8)
+            expected_scales = torch.full((capacity, 1), 3.25, dtype=torch.float16)
+            valid = selected >= 0
+            expected_keys[selected[valid]] = fresh_keys.cpu()[valid]
+            expected_scales[selected[valid], 0] = fresh_scales.to(torch.float16).cpu()[valid]
+            assert torch.equal(cache.view(capacity, width).cpu(), expected_keys)
+            assert torch.equal(scale_cache.view(capacity, 1).view(torch.int16).cpu(), expected_scales.view(torch.int16))
+            assert bool((backing[-64:] == 19).all())
+        retained.append((graph, backing, keys, scales, slots))
+    torch.npu.synchronize()

--- a/tests/ut/attention/test_sfa_dcp_exchange_port.py
+++ b/tests/ut/attention/test_sfa_dcp_exchange_port.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise exchange routing and invalid-rank semantics without an NPU."""
+
+import ast
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_function(path, name, namespace):
+    source = ROOT / path
+    tree = ast.parse(source.read_text())
+    method = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    future = ast.parse("from __future__ import annotations").body
+    exec(compile(ast.Module(body=future + [method], type_ignores=[]), str(source), "exec"), namespace)
+    return namespace[name]
+
+
+@pytest.mark.parametrize(
+    "tokens,ranks,scatter,supported,pcp",
+    [
+        (1, 8, 1, True, False),
+        (6, 8, 1, True, False),
+        (12, 8, 1, True, False),
+        (13, 8, 1, False, False),
+        (6, 2, 1, True, False),
+        (8, 8, 0, True, False),
+        (6, 8, 1, True, True),
+        (6, 1, 1, True, True),
+        (6, 1, 1, True, False),
+    ],
+)
+def test_registered_op_keeps_upstream_fallback_and_output_dtype(tokens, ranks, scatter, supported, pcp):
+    calls = []
+    group = object()
+    output = torch.zeros(tokens, 64, 512, dtype=torch.bfloat16)
+    lse = torch.zeros(tokens, 64, 1)
+    shape = (tokens, 64 // ranks, 512) if scatter else (tokens // ranks, 64, 512)
+
+    def exchange(out, stats, selected_group):
+        assert selected_group is group and out is output and stats is lse
+        calls.append("exchange")
+        return torch.ones(shape, dtype=torch.float32)
+
+    def transfer(recv, send, *, group):
+        calls.append("upstream_collective")
+
+    namespace = {
+        "torch": torch,
+        "dist": SimpleNamespace(all_to_all_single=transfer),
+        "can_exchange": lambda *_: supported,
+        "exchange": exchange,
+        "pack_sfa_dcp_output_lse": lambda *_, **kwargs: torch.empty(8, 16),
+        "fused_sfa_dcp_lse_combine": lambda *_, **kwargs: torch.ones(shape, dtype=output.dtype),
+    }
+    run = load_function("vllm_ascend/ops/triton/sfa_cp.py", "sfa_dcp_a2a_fused_combine", namespace)
+
+    def pcp_gather(value, dim):
+        assert dim == 0
+        calls.append("pcp_gather")
+        return value
+
+    pcp_group = SimpleNamespace(all_gather=pcp_gather) if pcp else None
+    result = run(output, lse, ranks, scatter, group, pcp_group)
+    assert result.dtype == output.dtype and result.shape == shape
+    if ranks == 8 and scatter == 1 and supported and not pcp:
+        assert calls == ["exchange"]
+    else:
+        assert calls == (["upstream_collective"] if ranks > 1 else []) + (["pcp_gather"] if pcp else [])
+
+
+@pytest.mark.parametrize("tokens,expected", [(0, False), (1, True), (6, True), (12, True), (13, False)])
+def test_exchange_gate(tokens, expected):
+    namespace = {"torch": torch, "triton": object(), "_MAX_DECODE_TOKENS": 12, "_HEADS": 64, "_HEAD_DIM": 512}
+    run = load_function("vllm_ascend/ops/triton/sfa_dcp_exchange.py", "can_exchange", namespace)
+    device = SimpleNamespace(type="npu")
+    output = SimpleNamespace(device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 64, 512))
+    lse = SimpleNamespace(device=device, dtype=torch.float32, shape=(tokens, 64, 1))
+    assert run(output, lse) is expected
+
+
+@pytest.mark.parametrize("token_dim", [1, 2])
+def test_merge_masks_invalid_rank_outputs_before_weighting(token_dim):
+    spec = importlib.util.spec_from_file_location("merge_under_test", ROOT / "vllm_ascend/ops/triton/sfa_dcp_merge.py")
+    merge = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(merge)
+    parts = torch.full((8, 2, 3, 4), float("nan"))
+    lse = torch.full((8, 2, 3), float("-inf"))
+    lse[0] = float("nan")
+    lse[1] = float("inf")
+    parts[2] = 2.0
+    lse[2] = 0.0
+    parts[3] = 4.0
+    lse[3] = 0.0
+    # One position has no valid ranks; even NaN payloads must yield zero.
+    lse[:, 0, 0] = float("-inf")
+    expected = torch.full((2, 3, 4), 3.0)
+    expected[0, 0] = 0.0
+    expected = expected.movedim(token_dim - 1, 0).contiguous()
+    assert torch.equal(merge.fused_merge(parts, lse, token_dim), expected)
+
+
+def test_custom_op_fake_retains_shape_dtype_and_does_not_collect():
+    run = load_function("vllm_ascend/ops/triton/sfa_cp.py", "sfa_dcp_a2a_fused_fake", {"torch": torch})
+    output = torch.empty(6, 64, 512, dtype=torch.bfloat16)
+    result = run(output, torch.empty(6, 64, 1), 8, 1, "unused")
+    assert result.shape == (6, 8, 512) and result.dtype == output.dtype
+
+
+@pytest.mark.parametrize("supported", [False, True])
+def test_missing_scatter_group_raises_without_communication(supported):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("communication attempted without a group")
+
+    namespace = {
+        "torch": torch,
+        "can_exchange": lambda *_: supported,
+        "exchange": forbidden,
+        "dist": SimpleNamespace(all_to_all_single=forbidden),
+        "pack_sfa_dcp_output_lse": lambda *args, **kwargs: torch.empty(8, 16),
+    }
+    run = load_function("vllm_ascend/ops/triton/sfa_cp.py", "sfa_dcp_a2a_fused_combine", namespace)
+    with pytest.raises(ValueError, match="explicit All2All group"):
+        run(torch.empty(6, 64, 512, dtype=torch.bfloat16), torch.empty(6, 64, 1), 8, 1, None)

--- a/tests/ut/attention/test_sfa_dcp_query_port.py
+++ b/tests/ut/attention/test_sfa_dcp_query_port.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Actual query gather/finish routing and async dependency contracts."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import NamedTuple
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "tokens,decode,dsa,prepared",
+    [
+        (1, True, False, False),
+        (6, True, False, True),
+        (12, True, False, True),
+        (13, True, False, False),
+        (6, False, False, False),
+        (6, True, True, False),
+    ],
+)
+def test_query_gather_waits_before_final_unpack_and_preserves_fallback(tokens, decode, dsa, prepared):
+    source = ROOT / "vllm_ascend/attention/context_parallel/sfa_cp.py"
+    tree = ast.parse(source.read_text())
+    context_class = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "DCPGatherContext")
+    impl = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "AscendSFADCPImpl")
+    methods = [
+        n
+        for n in impl.body
+        if isinstance(n, ast.FunctionDef)
+        and n.name in ("_start_dcp_query_gather", "_finish_dcp_gather", "_record_query_gather_context")
+    ]
+    for method in methods:
+        method.decorator_list = []
+    events = []
+    group = object()
+    handle = SimpleNamespace(wait=lambda: events.append("wait"))
+
+    def gather(value, selected_group):
+        assert selected_group is group
+        events.append("gather")
+        return torch.cat([value] * 8, dim=0), handle
+
+    def prep(qn, qr):
+        events.append("prepare")
+        return torch.cat((qn, qr), dim=-1).permute(1, 0, 2).contiguous()
+
+    def unpack(value):
+        assert events[-1] == "wait"
+        events.append("unpack")
+        return tuple(part.contiguous() for part in value.permute(1, 0, 2).split((512, 64), dim=-1))
+
+    namespace = {
+        "torch": torch,
+        "M": object,
+        "AscendSFADCPMetadata": SimpleNamespace,
+        "NamedTuple": NamedTuple,
+        "all_gather_async": gather,
+        "can_prepare_query": lambda qn, qr: 1 < qn.shape[0] <= 12,
+        "prepare_query_head_major": prep,
+        "unpack_query": unpack,
+    }
+    exec(compile(ast.Module(body=[context_class, *methods], type_ignores=[]), str(source), "exec"), namespace)
+    context_type = namespace["DCPGatherContext"]
+
+    def legacy(value, dim, split_sizes):
+        send = value if dim == 0 else value.permute(1, 0, 2).contiguous()
+        gathered, work = gather(send, group)
+        # Four-argument construction must keep older KV/query callers working.
+        return context_type(gathered, work, None if dim == 0 else (1, 0, 2), split_sizes)
+
+    state = SimpleNamespace(
+        enable_dsa_cp=dsa,
+        dcp_size=8,
+        dcp_group=group,
+        _start_dcp_gather=legacy,
+        _parallel_query_gather_dim=lambda: 0 if dsa else 1,
+        _has_prefill=lambda metadata: metadata.num_prefills > 0,
+    )
+    state._start_dcp_query_gather = lambda *args, **kwargs: namespace["_start_dcp_query_gather"](state, *args, **kwargs)
+    qn = torch.arange(tokens * 8 * 512).to(torch.bfloat16).view(8, tokens, 512).transpose(0, 1)
+    qr = torch.ones(tokens, 8, 64, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(num_prefills=0 if decode else 1, dcp_context=SimpleNamespace(gather_context=None))
+    namespace["_record_query_gather_context"](state, qn, qr, metadata)
+    context = metadata.dcp_context.gather_context
+    if not decode:
+        assert context is None and not events
+        return
+    assert context.query_prepared is prepared
+    assert "wait" not in events
+    result = namespace["_finish_dcp_gather"](context)
+    dim = 0 if dsa else 1
+    assert torch.equal(result[0], torch.cat([qn] * 8, dim=dim))
+    assert torch.equal(result[1], torch.cat([qr] * 8, dim=dim))
+    assert events.count("gather") == events.count("wait") == 1
+    assert ("unpack" in events) is prepared
+    if prepared:
+        assert all(part.is_contiguous() for part in result)
+
+
+@pytest.mark.parametrize("tokens,expected", [(0, False), (1, False), (2, True), (6, True), (12, True), (13, False)])
+def test_query_shape_gate_keeps_single_token_and_large_batch_paths(tokens, expected):
+    source = ROOT / "vllm_ascend/ops/triton/sfa_dcp_query.py"
+    tree = ast.parse(source.read_text())
+    method = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "can_prepare_query")
+    namespace = {
+        "torch": torch,
+        "triton": object(),
+        "_LOCAL_HEADS": 8,
+        "_NOPE_DIM": 512,
+        "_ROPE_DIM": 64,
+        "_MAX_DECODE_TOKENS": 12,
+    }
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), "exec"), namespace)
+    device = SimpleNamespace(type="npu")
+    qn = SimpleNamespace(
+        device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 8, 512), stride=lambda: (512, tokens * 512, 1)
+    )
+    qr = SimpleNamespace(
+        device=device, dtype=torch.bfloat16, ndim=3, shape=(tokens, 8, 64), stride=lambda: (512, 64, 1)
+    )
+    assert namespace["can_prepare_query"](qn, qr) is expected

--- a/tests/ut/attention/test_sfa_indexer_store_port.py
+++ b/tests/ut/attention/test_sfa_indexer_store_port.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise the upstream indexer pipeline without an NPU or model load."""
+
+import ast
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "variant", ["native", "prefill", "mixed", "pcp", "dsa", "dcp1", "large", "subclass", "reshape"]
+)
+def test_native_quantization_and_cache_pipeline_routing(variant):
+    """Keep quantization exact and finish parallel-layout transforms before writing."""
+    source = ROOT / "vllm_ascend/attention/indexer.py"
+    cls = next(
+        n
+        for n in ast.parse(source.read_text()).body
+        if isinstance(n, ast.ClassDef) and n.name == "AscendSFAIndexerBackend"
+    )
+    methods = [
+        n
+        for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name in ("forward", "forward_k", "_gather_cache_inputs")
+    ]
+    events = []
+    rows = 13 if variant == "large" else 6
+    quant = torch.arange(rows * 128).remainder(127).to(torch.int8).view(rows, 128)
+    scales = torch.full((rows,), 0.12345, dtype=torch.float32)
+    caches = (torch.zeros(256, 128, dtype=torch.int8), torch.zeros(256, 1, dtype=torch.float16))
+
+    class Backend:
+        k_hadamard = torch.eye(128, dtype=torch.bfloat16)
+
+    class OtherBackend(Backend):
+        pass
+
+    def native_quant(*args, **kwargs):
+        events.append("quant")
+        return quant, scales
+
+    def store(keys, stats, slots, key_cache, scale_cache):
+        assert events[-1] == "gather_done" and stats.dtype == torch.float32
+        events.append("fused")
+        key_cache.index_copy_(0, slots, keys)
+        scale_cache.index_copy_(0, slots, stats.to(torch.float16))
+
+    namespace = {
+        "torch": torch,
+        "HAS_TRITON": True,
+        "AscendSFAIndexerBackend": Backend,
+        "torch_npu": SimpleNamespace(npu_dynamic_quant=native_quant),
+        "rope_forward_triton_siso": lambda x, *args, **kwargs: x,
+        "can_fuse_store": lambda k, s, slots, n: 0 < n <= 12,
+        "store_indexer_key_scale": store,
+        "INDEXER_K_CACHE_SLOT": 0,
+        "INDEXER_SCALE_CACHE_SLOT": 1,
+        "_gather_prefill_cache_inputs": lambda tensors, slots, count: (tensors, slots),
+        "all_gather_async": lambda value, *args, **kwargs: (value, None),
+        "get_tp_group": lambda: None,
+    }
+    future = ast.parse("from __future__ import annotations").body
+    exec(compile(ast.Module(body=future + methods, type_ignores=[]), str(source), "exec"), namespace)
+    state = OtherBackend() if variant == "subclass" else Backend()
+    state._dcp_size = 1 if variant == "dcp1" else 8
+    state._pcp_active, state._dsa_cp_active = variant == "pcp", variant == "dsa"
+    state.enable_sparse_li_c8 = True
+    state._use_c8_reshape_optim = lambda: variant == "reshape"
+    state.k_cache = SimpleNamespace(kv_cache=caches)
+    state.wk_weights_proj = lambda x: (torch.zeros(rows, 160, dtype=torch.bfloat16), None)
+    state.k_norm = lambda x: x
+    state.head_dim, state.qk_rope_head_dim, state.is_rope_neox_style = 128, 64, False
+    state.c8_k_cache_dtype, state.c8_k_scale_cache_dtype = torch.int8, torch.float16
+    state.forward_k = MethodType(namespace["forward_k"], state)
+
+    def gather(*args):
+        result = namespace["_gather_cache_inputs"](state, *args)
+        events.append("gather_done")
+        return result
+
+    def legacy(keys, stats, slots, **kwargs):
+        assert events[-1] == "gather_done" and stats.dtype == torch.float16
+        events.append("legacy")
+        caches[0].index_copy_(0, slots, keys)
+        caches[1].index_copy_(0, slots, stats)
+
+    state._gather_cache_inputs, state.write_cache = gather, legacy
+    decode = 0 if variant == "prefill" else (1 if variant == "mixed" else rows)
+    metadata = SimpleNamespace(
+        num_actual_tokens=rows, num_decode_tokens=decode, slot_mapping=torch.arange(rows, dtype=torch.int64) + 5
+    )
+    x = torch.zeros(rows, 4)
+    result = namespace["forward"](
+        state, x, None, torch.ones(rows, 64), torch.zeros(rows, 64), x, metadata, compute_topk=False
+    )
+    assert result is None and events == ["quant", "gather_done", "fused" if variant == "native" else "legacy"]
+    assert torch.equal(caches[0][metadata.slot_mapping], quant)
+    assert torch.equal(caches[1][metadata.slot_mapping], scales.to(torch.float16).view(rows, 1))

--- a/tests/ut/attention/test_sparse_index_remap_port.py
+++ b/tests/ut/attention/test_sparse_index_remap_port.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Empty input must return before dividing by TopK or launching kernels."""
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("shape", [(0, 2048), (1, 0), (2, 3, 0)])
+def test_empty_remap_preserves_shape_dtype_and_avoids_launch(shape):
+    source = Path(__file__).resolve().parents[3] / "vllm_ascend/ops/triton/sparse_index_remap.py"
+    tree = ast.parse(source.read_text())
+    function = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "remap_sparse_indices_triton")
+    namespace = {"torch": torch}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"), namespace)
+    value = torch.empty(shape, dtype=torch.int32)
+    assert namespace["remap_sparse_indices_triton"](value, 8, 0, 128) is value

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -27,6 +27,7 @@ from vllm_ascend.attention.sfa_v1 import (
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
+from vllm_ascend.ops.triton.sfa_dcp_query import can_prepare_query, prepare_query_head_major, unpack_query
 from vllm_ascend.utils import (
     _round_up,
     enable_dsa_cp,
@@ -204,6 +205,7 @@ class DCPGatherContext(NamedTuple):
     handle: torch.distributed.Work | None
     restore_perm: tuple[int, ...] | None
     split_sizes: tuple[int, ...]
+    query_prepared: bool = False
 
 
 @dataclass
@@ -1145,6 +1147,8 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
     ) -> tuple[torch.Tensor, ...]:
         if context.handle is not None:
             context.handle.wait()
+        if context.query_prepared:
+            return unpack_query(context.gathered)
         gathered = context.gathered
         if context.restore_perm is not None:
             gathered = gathered.permute(context.restore_perm).contiguous()
@@ -1267,6 +1271,19 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 "Cannot fuse DCP query gather for ql_nope/q_pe with "
                 f"shapes {tuple(ql_nope.shape)} / {tuple(q_pe.shape)} "
                 f"and dtypes {ql_nope.dtype} / {q_pe.dtype}."
+            )
+
+        # Decode-only callers reach this method; PCP+DCP keeps
+        # its separate TP-group override and DSA-CP gathers tokens on dim 0.
+        if query_gather_dim == 1 and self.dcp_size == 8 and can_prepare_query(ql_nope, q_pe):
+            prepared = prepare_query_head_major(ql_nope, q_pe)
+            gathered, handle = all_gather_async(prepared, self.dcp_group)
+            return DCPGatherContext(
+                gathered=gathered,
+                handle=handle,
+                restore_perm=(1, 0, 2),
+                split_sizes=(ql_nope.shape[-1], q_pe.shape[-1]),
+                query_prepared=True,
             )
 
         # Avoid back-to-back DCP all_gather calls for the two SFA query

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -23,6 +23,7 @@ from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
+from vllm_ascend.ops.triton.sfa_indexer_store import can_fuse_store, store_indexer_key_scale
 from vllm_ascend.utils import enable_dsa_cp, vllm_version_is
 
 if vllm_version_is("0.28.0"):
@@ -180,6 +181,7 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         # prefill region across the CP group, DSA-CP all-gathers the indexer
         # k across the TP group. Both are no-ops in the base layout.
         parallel_config = get_current_vllm_config().parallel_config
+        self._dcp_size = parallel_config.decode_context_parallel_size
         self._pcp_active = parallel_config.prefill_context_parallel_size > 1
         self._dsa_cp_active = enable_dsa_cp()
 
@@ -261,6 +263,8 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         hidden_states: torch.Tensor,
         cos: torch.Tensor,
         sin: torch.Tensor,
+        *,
+        defer_scale_cast: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """k path: compute ``k_li`` (and ``k_li_scale`` when LI C8 is
         enabled) from the hidden-states stage SFA hands in (raw states on
@@ -298,7 +302,8 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         if self.enable_sparse_li_c8:
             k_li = k_li @ AscendSFAIndexerBackend.k_hadamard
             k_li, k_li_scale = torch_npu.npu_dynamic_quant(k_li.view(-1, self.head_dim), dst_type=self.c8_k_cache_dtype)
-            k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
+            if not defer_scale_cast:
+                k_li_scale = k_li_scale.to(self.c8_k_scale_cache_dtype)  # [b*s,]
             k_li_scale = k_li_scale.unsqueeze(-1)  # [b*s,1]
         else:
             k_li_scale = None
@@ -371,9 +376,40 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         DSA-CP shards them to the local token shard, matching the sharded
         inputs. ``indexer_metadata`` carries the indexer's own cache view
         plus the parallel-layout values injected by SFA."""
-        k_li, k_li_scale = self.forward_k(k_hidden_states, cos, sin)
+        # Only the native backend may bypass its ordinary write_cache method.
+        # PCP/DSA-CP and custom cache subclasses keep their established layout.
+        fuse_store = (
+            type(self) is AscendSFAIndexerBackend
+            and getattr(self, "_dcp_size", 1) == 8
+            and not self._pcp_active
+            and not self._dsa_cp_active
+            and self.enable_sparse_li_c8
+            and not self._use_c8_reshape_optim()
+            and indexer_metadata.num_actual_tokens > 0
+            and indexer_metadata.num_decode_tokens == indexer_metadata.num_actual_tokens
+            and can_fuse_store(
+                self.k_cache.kv_cache[INDEXER_K_CACHE_SLOT],
+                self.k_cache.kv_cache[INDEXER_SCALE_CACHE_SLOT],
+                indexer_metadata.slot_mapping,
+                k_hidden_states.shape[0],
+            )
+        )
+        if fuse_store:
+            k_li, k_li_scale = self.forward_k(k_hidden_states, cos, sin, defer_scale_cast=True)
+        else:
+            k_li, k_li_scale = self.forward_k(k_hidden_states, cos, sin)
         k_li, k_li_scale, slot_mapping = self._gather_cache_inputs(k_li, k_li_scale, indexer_metadata)
-        self.write_cache(k_li, k_li_scale, slot_mapping, indexer_attn_metadata=indexer_metadata)
+        if fuse_store:
+            assert k_li_scale is not None
+            store_indexer_key_scale(
+                k_li,
+                k_li_scale,
+                slot_mapping,
+                self.k_cache.kv_cache[INDEXER_K_CACHE_SLOT],
+                self.k_cache.kv_cache[INDEXER_SCALE_CACHE_SLOT],
+            )
+        else:
+            self.write_cache(k_li, k_li_scale, slot_mapping, indexer_attn_metadata=indexer_metadata)
         if not compute_topk:
             return None
 

--- a/vllm_ascend/ops/triton/sfa_cp.py
+++ b/vllm_ascend/ops/triton/sfa_cp.py
@@ -8,6 +8,7 @@ from vllm.distributed.parallel_state import GroupCoordinator, _groups
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
+from vllm_ascend.ops.triton.sfa_dcp_exchange import can_exchange, exchange
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
 
 
@@ -364,6 +365,13 @@ def sfa_dcp_a2a_fused_combine(
     scatter_size is the All2All group size, not the unified DCP size when
     stacking PCP and DCP. Use 1 when Q heads were not gathered over TP.
     """
+    # Keep PCP composition and token-scatter paths on the upstream implementation.
+    # This is the tested raw-bit All2All path, not the experimental VMM peer path.
+    if pcp_group is None and scatter_size == 8 and scatter_dim == 1 and can_exchange(sfa_output, softmax_lse):
+        if scatter_group is None:
+            raise ValueError("SFA output scatter requires an explicit All2All group.")
+        return exchange(sfa_output, softmax_lse, scatter_group).to(sfa_output.dtype)
+
     send = pack_sfa_dcp_output_lse(
         sfa_output,
         softmax_lse,

--- a/vllm_ascend/ops/triton/sfa_dcp_exchange.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_exchange.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bit-preserving native-DCP8 output/LSE exchange for small decode batches."""
+
+import torch
+import torch.distributed as dist
+
+from vllm_ascend.ops.triton.sfa_dcp_merge import fused_merge
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_RANKS = 8
+_HEADS = 64
+_HEAD_DIM = 512
+_OUTPUT_WORDS_PER_PEER = 2048
+_WORDS_PER_PEER = 2056
+_MAX_DECODE_TOKENS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _pack_t1_peer(output_words, lse, send, lse_head_stride: tl.constexpr):
+        peer = tl.program_id(0)
+        word = tl.arange(0, 2048)
+        values = tl.load(output_words + peer * 2048 + word, mask=word < 2048, other=0)
+        tl.store(send + peer * 2056 + word, values, mask=word < 2048)
+        local_head = tl.arange(0, 8)
+        stats = tl.load(
+            lse + (peer * 8 + local_head) * lse_head_stride,
+            mask=local_head < 8,
+            other=0.0,
+        )
+        tl.store(
+            send + peer * 2056 + 2048 + local_head,
+            stats.to(tl.int32, bitcast=True),
+            mask=local_head < 8,
+        )
+
+    @triton.jit
+    def _pack_token_peer(
+        output,
+        lse,
+        send,
+        output_s0: tl.constexpr,
+        output_s1: tl.constexpr,
+        lse_s0: tl.constexpr,
+        lse_s1: tl.constexpr,
+        tokens: tl.constexpr,
+        local_heads: tl.constexpr,
+        head_words: tl.constexpr,
+        stats_tile: tl.constexpr,
+    ):
+        peer = tl.program_id(0)
+        output_words: tl.constexpr = local_heads * head_words
+        peer_words: tl.constexpr = tokens * (output_words + local_heads)
+        word = tl.arange(0, output_words)
+        local_head = word // head_words
+        dim_word = word % head_words
+        peer_base = peer * peer_words
+        for token in range(tokens):
+            values = tl.load(output + token * output_s0 + (peer * local_heads + local_head) * output_s1 + dim_word)
+            tl.store(send + peer_base + token * output_words + word, values)
+        index = tl.arange(0, stats_tile)
+        token, head = index // local_heads, index % local_heads
+        stats = tl.load(
+            lse + token * lse_s0 + (peer * local_heads + head) * lse_s1,
+            mask=index < tokens * local_heads,
+            other=0.0,
+        )
+        tl.store(
+            send + peer_base + tokens * output_words + index,
+            stats.to(tl.int32, bitcast=True),
+            mask=index < tokens * local_heads,
+        )
+
+
+def can_exchange(output: torch.Tensor, lse: torch.Tensor) -> bool:
+    # These properties are uniform within a valid DCP group. Do not choose
+    # different collective counts based on rank-local allocation/stride state.
+    return (
+        triton is not None
+        and output.device.type == "npu"
+        and output.dtype == torch.bfloat16
+        and output.ndim == 3
+        and 0 < output.shape[0] <= _MAX_DECODE_TOKENS
+        and tuple(output.shape[1:]) == (_HEADS, _HEAD_DIM)
+        and lse.device == output.device
+        and lse.dtype == torch.float32
+        and tuple(lse.shape) == (output.shape[0], _HEADS, 1)
+    )
+
+
+def _exchange_tokens(output: torch.Tensor, lse: torch.Tensor, group) -> torch.Tensor:
+    if not can_exchange(output, lse) or dist.get_world_size(group) != _RANKS:
+        raise ValueError("Unsupported native-DCP8 output/LSE exchange")
+    tokens = output.shape[0]
+    local_heads = _HEADS // _RANKS
+    # Stride-dependent normalization stays inside the one-collective path.
+    if output.stride(-1) != 1 or any(stride % 2 for stride in output.stride()[:2]):
+        output = output.contiguous()
+    if output.storage_offset() % 2:
+        output = output.clone()
+    words = output.view(torch.int32)
+    peer_words = tokens * _WORDS_PER_PEER
+    send = torch.empty((_RANKS, peer_words), dtype=torch.int32, device=output.device)
+    _pack_token_peer[(_RANKS,)](
+        words,
+        lse,
+        send,
+        *words.stride()[:2],
+        *lse.stride()[:2],
+        tokens,
+        local_heads,
+        _HEAD_DIM // 2,
+        triton.next_power_of_2(tokens * local_heads),
+    )
+    recv = torch.empty_like(send)
+    dist.all_to_all_single(recv, send, group=group)
+    # Final receiver layout is token-major: no transpose or receive-side copy.
+    parts = recv.view(output.dtype).as_strided(
+        (_RANKS, tokens, local_heads, _HEAD_DIM),
+        (peer_words * 2, local_heads * _HEAD_DIM, _HEAD_DIM, 1),
+    )
+    stats = recv.view(torch.float32).as_strided(
+        (_RANKS, tokens, local_heads),
+        (peer_words, local_heads, 1),
+        storage_offset=tokens * _OUTPUT_WORDS_PER_PEER,
+    )
+    return fused_merge(parts, stats, token_dim=1)
+
+
+def exchange(output: torch.Tensor, lse: torch.Tensor, group) -> torch.Tensor:
+    """Exchange eight head shards, retaining FP32 LSE bits and merge math."""
+    if output.shape[0] != 1:
+        return _exchange_tokens(output, lse, group)
+    output = output.contiguous()
+    if output.storage_offset() % 2:
+        output = output.clone()
+    lse = lse.contiguous()
+    words = output.view(torch.int32)
+    send = torch.empty((_RANKS, _WORDS_PER_PEER), dtype=torch.int32, device=output.device)
+    _pack_t1_peer[(_RANKS,)](words, lse, send, lse.stride(1))
+    recv = torch.empty_like(send)
+    dist.all_to_all_single(recv, send, group=group)
+    parts = recv.view(output.dtype).as_strided(
+        (_RANKS, _HEADS // _RANKS, 1, _HEAD_DIM),
+        (_WORDS_PER_PEER * 2, _HEAD_DIM, _HEAD_DIM, 1),
+    )
+    stats = recv.view(torch.float32).as_strided(
+        (_RANKS, _HEADS // _RANKS, 1),
+        (_WORDS_PER_PEER, 1, 1),
+        storage_offset=_OUTPUT_WORDS_PER_PEER,
+    )
+    return fused_merge(parts, stats, token_dim=2)

--- a/vllm_ascend/ops/triton/sfa_dcp_merge.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_merge.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FP32 local merge for the small-batch DCP exchange."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+    from triton.language.extra.cann import extension
+
+    get_element = extension.get_element
+except ImportError:  # CPU-only test environments retain exact torch semantics.
+    triton = None
+    tl = None
+    get_element = None
+
+
+_SUPPORTED_RANKS = (2, 8)
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+
+
+def torch_merge(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> torch.Tensor:
+    """Reference merge with upstream invalid-rank masking semantics."""
+    if out_recv.ndim != 4 or lse_recv.ndim != 3 or out_recv.shape[:3] != lse_recv.shape:
+        raise RuntimeError(
+            "DCP output merge expects matching rank/token/head dimensions, "
+            f"got {tuple(out_recv.shape)} and {tuple(lse_recv.shape)}."
+        )
+    if token_dim not in (1, 2):
+        raise RuntimeError(f"DCP output merge token_dim must be 1 or 2, got {token_dim}.")
+    finite = torch.isfinite(lse_recv)
+    lse = lse_recv.masked_fill(~finite, float("-inf"))
+    weights = torch.nan_to_num(torch.softmax(lse, dim=0), nan=0.0)
+    values = out_recv.to(lse.dtype).masked_fill(~finite.unsqueeze(-1), 0.0)
+    output = (values * weights.unsqueeze(-1)).sum(dim=0)
+    return output.movedim(token_dim - 1, 0).contiguous()
+
+
+if triton is not None:
+
+    @triton.jit
+    def _fused_merge_kernel(
+        out_ptr,
+        lse_ptr,
+        result_ptr,
+        out_s0: tl.constexpr,
+        out_s1: tl.constexpr,
+        out_s2: tl.constexpr,
+        out_s3: tl.constexpr,
+        lse_s0: tl.constexpr,
+        lse_s1: tl.constexpr,
+        lse_s2: tl.constexpr,
+        result_s0: tl.constexpr,
+        result_s1: tl.constexpr,
+        result_s2: tl.constexpr,
+        rows: tl.constexpr,
+        head_count: tl.constexpr,
+        head_dim: tl.constexpr,
+        total_tiles: tl.constexpr,
+        num_programs: tl.constexpr,
+        ranks: tl.constexpr,
+        native_layout: tl.constexpr,
+        block_d: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        rank_ids = tl.arange(0, ranks)
+        for tile in tl.range(pid, total_tiles, num_programs):
+            row = tile // tl.cdiv(head_dim, block_d)
+            dim = (tile % tl.cdiv(head_dim, block_d)) * block_d + tl.arange(0, block_d)
+            mask = dim < head_dim
+            token = row // head_count
+            head = row % head_count
+            if native_layout:
+                lse_offsets = rank_ids * lse_s0 + head * lse_s1 + token * lse_s2
+            else:
+                lse_offsets = rank_ids * lse_s0 + token * lse_s1 + head * lse_s2
+            raw_lse = tl.load(lse_ptr + lse_offsets).to(tl.float32)
+            finite = (raw_lse == raw_lse) & (raw_lse > float("-inf")) & (raw_lse < float("inf"))
+            safe_lse = tl.where(finite, raw_lse, float("-inf"))
+            max_lse = tl.max(safe_lse, axis=0)
+            shifted = tl.where(finite, safe_lse - max_lse, 0.0)
+            exponent = tl.where(finite, tl.exp(shifted), 0.0)
+            denominator = tl.sum(exponent, axis=0)
+            safe_denominator = tl.where(denominator > 0.0, denominator, 1.0)
+            weights = exponent / safe_denominator
+            result = tl.zeros((block_d,), dtype=tl.float32)
+            for rank in tl.static_range(0, ranks):
+                weight = get_element(weights, (rank,))
+                if native_layout:
+                    out_offsets = rank * out_s0 + head * out_s1 + token * out_s2 + dim * out_s3
+                else:
+                    out_offsets = rank * out_s0 + token * out_s1 + head * out_s2 + dim * out_s3
+                values = tl.load(out_ptr + out_offsets, mask=mask, other=0.0).to(tl.float32)
+                # Match upstream: invalid-rank NaN/Inf outputs must not leak
+                # through a zero LSE weight (NaN * 0 is still NaN).
+                values = tl.where(get_element(finite, (rank,)), values, 0.0)
+                result += values * weight
+            tl.store(result_ptr + token * result_s0 + head * result_s1 + dim * result_s2, result, mask=mask)
+
+
+def _fast_path(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> bool:
+    if triton is None or get_element is None or out_recv.device.type != "npu" or out_recv.device != lse_recv.device:
+        return False
+    if out_recv.ndim != 4 or lse_recv.ndim != 3 or 0 in out_recv.shape or 0 in lse_recv.shape:
+        return False
+    if out_recv.shape[0] not in _SUPPORTED_RANKS or out_recv.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if lse_recv.dtype != torch.float32 or token_dim not in (1, 2):
+        return False
+    return not (
+        out_recv.shape[:3] != lse_recv.shape
+        or any(stride < 0 for stride in out_recv.stride())
+        or any(stride < 0 for stride in lse_recv.stride())
+        or out_recv.stride(-1) != 1
+        or lse_recv.stride(-1) != 1
+    )
+
+
+def fused_merge(out_recv: torch.Tensor, lse_recv: torch.Tensor, token_dim: int) -> torch.Tensor:
+    """Fuse only the post-All2All local math; unsupported inputs use torch."""
+    if not _fast_path(out_recv, lse_recv, token_dim):
+        return torch_merge(out_recv, lse_recv, token_dim)
+    ranks = out_recv.shape[0]
+    if token_dim == 2:
+        _, heads, tokens, head_dim = out_recv.shape
+        native_layout = True
+    else:
+        _, tokens, heads, head_dim = out_recv.shape
+        native_layout = False
+    result = torch.empty((tokens, heads, head_dim), dtype=torch.float32, device=out_recv.device)
+    # Rank-wise accumulation avoids the failed R×D materialization. D512 now
+    # holds one FP32 accumulator plus one rank vector; retry verifies compiler UB.
+    block_d = min(triton.next_power_of_2(head_dim), 512)
+    tiles = tokens * heads * math.ceil(head_dim / block_d)
+    properties = triton.runtime.driver.active.utils.get_device_properties(out_recv.device.index)
+    programs = min(tiles, properties["num_vectorcore"])
+    _fused_merge_kernel[(programs,)](
+        out_recv,
+        lse_recv,
+        result,
+        *out_recv.stride(),
+        *lse_recv.stride(),
+        *result.stride(),
+        tokens * heads,
+        heads,
+        head_dim,
+        total_tiles=tiles,
+        num_programs=programs,
+        ranks=ranks,
+        native_layout=native_layout,
+        block_d=block_d,
+    )
+    return result

--- a/vllm_ascend/ops/triton/sfa_dcp_query.py
+++ b/vllm_ascend/ops/triton/sfa_dcp_query.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Direct gather-input packing and final SFA query unpacking for DCP8 decode."""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_LOCAL_HEADS = 8
+_TOTAL_HEADS = 64
+_NOPE_DIM = 512
+_ROPE_DIM = 64
+_PACKED_DIM = _NOPE_DIM + _ROPE_DIM
+_MAX_DECODE_TOKENS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _prepare_query_head_major(
+        qn,
+        qr,
+        out,
+        ns0: tl.constexpr,
+        ns1: tl.constexpr,
+        ns2: tl.constexpr,
+        rs0: tl.constexpr,
+        rs1: tl.constexpr,
+        rs2: tl.constexpr,
+        tokens: tl.constexpr,
+        programs: tl.constexpr,
+        heads: tl.constexpr,
+        nope_dim: tl.constexpr,
+        rope_dim: tl.constexpr,
+    ):
+        n = tl.arange(0, nope_dim)
+        r = tl.arange(0, rope_dim)
+        for row in tl.range(tl.program_id(0), heads * tokens, programs):
+            head, token = row // tokens, row % tokens
+            a = tl.load(qn + token * ns0 + head * ns1 + n * ns2)
+            b = tl.load(qr + token * rs0 + head * rs1 + r * rs2)
+            tl.store(out + row * (nope_dim + rope_dim) + n, a)
+            tl.store(out + row * (nope_dim + rope_dim) + nope_dim + r, b)
+
+    @triton.jit
+    def _unpack_query_fragments(
+        gathered,
+        qn,
+        qr,
+        tokens: tl.constexpr,
+        programs: tl.constexpr,
+        heads: tl.constexpr,
+        nope_dim: tl.constexpr,
+        rope_dim: tl.constexpr,
+    ):
+        n = tl.arange(0, nope_dim)
+        r = tl.arange(0, rope_dim)
+        for row in tl.range(tl.program_id(0), tokens * heads, programs):
+            token, head = row // heads, row % heads
+            base = (head * tokens + token) * (nope_dim + rope_dim)
+            a = tl.load(gathered + base + n)
+            b = tl.load(gathered + base + nope_dim + r)
+            tl.store(qn + row * nope_dim + n, a)
+            tl.store(qr + row * rope_dim + r, b)
+
+
+def can_prepare_query(qn: torch.Tensor, qr: torch.Tensor) -> bool:
+    return (
+        triton is not None
+        and qn.device.type == "npu"
+        and qr.device == qn.device
+        and qn.dtype == qr.dtype == torch.bfloat16
+        and qn.ndim == qr.ndim == 3
+        and tuple(qn.shape[1:]) == (_LOCAL_HEADS, _NOPE_DIM)
+        and tuple(qr.shape) == (qn.shape[0], _LOCAL_HEADS, _ROPE_DIM)
+        and 1 < qn.shape[0] <= _MAX_DECODE_TOKENS
+        and all(stride >= 0 for stride in (*qn.stride(), *qr.stride()))
+    )
+
+
+def prepare_query_head_major(qn: torch.Tensor, qr: torch.Tensor) -> torch.Tensor:
+    if not can_prepare_query(qn, qr):
+        raise ValueError("Unsupported native-DCP8 query preparation")
+    tokens = qn.shape[0]
+    result = torch.empty((_LOCAL_HEADS, tokens, _PACKED_DIM), dtype=qn.dtype, device=qn.device)
+    cores = triton.runtime.driver.active.utils.get_device_properties(qn.device.index)["num_vectorcore"]
+    programs = min(_LOCAL_HEADS * tokens, cores)
+    _prepare_query_head_major[(programs,)](
+        qn,
+        qr,
+        result,
+        *qn.stride(),
+        *qr.stride(),
+        tokens,
+        programs,
+        _LOCAL_HEADS,
+        _NOPE_DIM,
+        _ROPE_DIM,
+    )
+    return result
+
+
+def unpack_query(gathered: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        triton is None
+        or gathered.device.type != "npu"
+        or gathered.dtype != torch.bfloat16
+        or gathered.ndim != 3
+        or gathered.shape[0] != _TOTAL_HEADS
+        or gathered.shape[2] != _PACKED_DIM
+        or not 1 < gathered.shape[1] <= _MAX_DECODE_TOKENS
+        or not gathered.is_contiguous()
+    ):
+        raise ValueError("Unsupported native-DCP8 gathered query")
+    tokens = gathered.shape[1]
+    qn = torch.empty((tokens, _TOTAL_HEADS, _NOPE_DIM), dtype=gathered.dtype, device=gathered.device)
+    qr = torch.empty((tokens, _TOTAL_HEADS, _ROPE_DIM), dtype=gathered.dtype, device=gathered.device)
+    cores = triton.runtime.driver.active.utils.get_device_properties(gathered.device.index)["num_vectorcore"]
+    programs = min(tokens * _TOTAL_HEADS, cores)
+    _unpack_query_fragments[(programs,)](
+        gathered,
+        qn,
+        qr,
+        tokens,
+        programs,
+        _TOTAL_HEADS,
+        _NOPE_DIM,
+        _ROPE_DIM,
+    )
+    return qn, qr

--- a/vllm_ascend/ops/triton/sfa_indexer_store.py
+++ b/vllm_ascend/ops/triton/sfa_indexer_store.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Store native-quantized indexer keys and FP16 scales in one kernel.
+
+Keep native quantization and its INT8 tie behavior. Only final scale conversion
+and the two scatters are fused. Valid cache slots must be unique, as provided
+by decode slot mapping; padded negative slots are skipped.
+"""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+
+_KEY_WIDTH = 128
+_MAX_DECODE_ROWS = 12
+
+
+if triton is not None:
+
+    @triton.jit
+    def _store_indexer_key_scale(
+        quant,
+        scales,
+        slots,
+        cache,
+        scale_cache,
+        capacity: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        column = tl.arange(0, 128)
+        key = tl.load(quant + row * 128 + column)
+        scale = tl.load(scales + row)
+        slot = tl.load(slots + row).to(tl.int64)
+        valid = (slot >= 0) & (slot < capacity)
+        tl.store(cache + slot * 128 + column, key, valid)
+        tl.store(scale_cache + slot, scale, valid)
+
+
+def can_fuse_store(cache: torch.Tensor, scale_cache: torch.Tensor, slots: torch.Tensor, rows: int) -> bool:
+    return (
+        triton is not None
+        and cache.device.type == "npu"
+        and scale_cache.device == cache.device == slots.device
+        and cache.dtype == torch.int8
+        and scale_cache.dtype == torch.float16
+        and slots.dtype in (torch.int32, torch.int64)
+        and cache.ndim > 0
+        and cache.shape[-1] == _KEY_WIDTH
+        and cache.numel() // _KEY_WIDTH == scale_cache.numel()
+        and cache.numel() > 0
+        and cache.is_contiguous()
+        and scale_cache.is_contiguous()
+        and slots.is_contiguous()
+        and slots.ndim == 1
+        and slots.numel() == rows
+        and 0 < rows <= _MAX_DECODE_ROWS
+    )
+
+
+def store_indexer_key_scale(
+    quant: torch.Tensor,
+    scales: torch.Tensor,
+    slots: torch.Tensor,
+    cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+) -> None:
+    """Publish at the existing cache-write point, after the connector wait."""
+    rows = slots.numel()
+    if (
+        not can_fuse_store(cache, scale_cache, slots, rows)
+        or quant.device != cache.device
+        or scales.device != cache.device
+        or quant.dtype != torch.int8
+        or scales.dtype != torch.float32
+        or quant.numel() != rows * _KEY_WIDTH
+        or scales.numel() != rows
+        or not quant.is_contiguous()
+        or not scales.is_contiguous()
+    ):
+        raise ValueError("Unsupported native-DCP indexer key/scale store")
+    _store_indexer_key_scale[(rows,)](quant, scales, slots, cache, scale_cache, cache.numel() // _KEY_WIDTH)

--- a/vllm_ascend/ops/triton/sparse_index_remap.py
+++ b/vllm_ascend/ops/triton/sparse_index_remap.py
@@ -33,6 +33,7 @@ def remap_sparse_indices_fused_kernel(
     dcp_size,
     interleave_size,
     dcp_rank,
+    EXACT_DCP8: tl.constexpr,
     INTERLEAVE_ONE: tl.constexpr,
     BLOCK: tl.constexpr,
     NUM_CHUNKS: tl.constexpr,
@@ -53,18 +54,20 @@ def remap_sparse_indices_fused_kernel(
     in_bounds = offsets < topk_count
 
     idx = tl.load(indices_ptr + row * topk_count + offsets, mask=in_bounds, other=-1)
-    # Integer remap math: matches the fp32 torch fallback bit-exactly
-    # (indices are far below 2^24), and the int32/fp32 variants measured
-    # identically on NPU.
-    block_idx = idx // interleave_size
-    owner = block_idx - (block_idx // dcp_size) * dcp_size
-    valid = (idx >= 0) & (owner == dcp_rank)
-
-    if INTERLEAVE_ONE:
-        remapped = idx // dcp_size
+    # This backend's vector divsi loses integer boundaries above 2**24.
+    # Keep the native DCP8/interleave128 path entirely in bit operations.
+    if EXACT_DCP8:
+        owner = (idx >> 7) & 7
+        remapped = ((idx >> 10) << 7) + (idx & 127)
     else:
-        local_offsets = idx - block_idx * interleave_size
-        remapped = (idx // (dcp_size * interleave_size)) * interleave_size + local_offsets
+        block_idx = idx // interleave_size
+        owner = block_idx - (block_idx // dcp_size) * dcp_size
+        if INTERLEAVE_ONE:
+            remapped = idx // dcp_size
+        else:
+            local_offsets = idx - block_idx * interleave_size
+            remapped = (idx // (dcp_size * interleave_size)) * interleave_size + local_offsets
+    valid = (idx >= 0) & (owner == dcp_rank)
 
     valid_i32 = valid.to(tl.int32)
     chunk_out = chunk_out_ptr + (row * NUM_CHUNKS + chunk) * BLOCK
@@ -141,9 +144,9 @@ def remap_sparse_indices_triton(
         topk_indices = topk_indices.contiguous()
     indices = topk_indices if topk_indices.dtype == torch.int32 else topk_indices.to(torch.int32)
     topk_count = indices.shape[-1]
-    rows = indices.numel() // topk_count
-    if rows == 0 or topk_count == 0:
+    if indices.numel() == 0:
         return topk_indices
+    rows = indices.numel() // topk_count
     # The torch implementation operates per-row on the last dim, so arbitrary
     # leading dims (e.g. [dcp_size, 1, topk_count] from the DCP all_gather) can
     # be flattened to a 2D view and restored afterwards.
@@ -164,6 +167,7 @@ def remap_sparse_indices_triton(
         dcp_size,
         interleave_size,
         dcp_rank,
+        EXACT_DCP8=dcp_size == 8 and interleave_size == 128,
         INTERLEAVE_ONE=interleave_size == 1,
         BLOCK=block,
         NUM_CHUNKS=num_chunks,


### PR DESCRIPTION
### What this PR does / why we need it?

Continue #16349 on main, refreshed onto
`d052552072254a21560e8c5ebc04b80524c89622` without rewriting the published
branch history. This replaces the old fixed-main-base port and resolves its conflicts.

- Preserve upstream two-kernel sparse-index remap, with DCP8/interleave128
  integer-boundary repairs and an empty-input early return.
- Raw-bit BF16 output/FP32 LSE packing, one AllToAll, FP32 merge and BF16
  conversion for eligible native head-scatter DCP8 calls.
- Bring #16349's O/LSE eligibility expansion to
  `T <= min(max_num_batched_tokens, 192)`. **192 is a manually selected cap,
  not a demonstrated kernel limit. Larger values are untested and fall back.**
- Retain head-major query preparation and native INT8 quantization with fused
  final indexer key/scale writes; their smaller eligibility limits are unchanged.

Current-main integration preserves indexer-owned RoPE metadata and projection
weights reuse. PCP, token-scatter, returned-LSE and deferred-combine modes keep
their upstream implementations. No allocator, memory-placement, SuperMem
serving configuration or experimental VMM peer path is included.

Both exchange implementations already use one AllToAll. This change does not
increase the scheduler's token budget or claim a reduction in collective count.

### Does this PR introduce _any_ user-facing change?

No new serving API or configuration knob. Main no longer retains `vllm_config`
on `AscendConfig`, so the attention caller explicitly passes its current
scheduler budget through a trailing optional `decode_token_budget` argument
on the registered operator and its FakeTensor implementation. Existing callers
may omit it; standalone helpers retain the manual cap.

Unsupported layouts/dtypes preserve upstream fallback, group validation and
invalid-shard behavior. Query/store limits and numerical thresholds are unchanged.

### How was this patch tested?

#### Test placement and checks

Single-card Triton precision tests now live in the requested directory:
`tests/e2e/nightly/single_node/ops/singlecard_ops/triton/`:

- `test_sfa_indexer_store_triton.py`: native INT8 key/scale byte precision and changing ACLGraph slots.
- `test_sfa_dcp_remap.py`: integer-boundary oracle, changing graph inputs and empty-input cases.

Both are byte-identical moves, with unchanged numerical assertions/tolerances.
Query gather and O/LSE exchange tests still require a real eight-NPU DCP group;
they remain under `tests/ut/attention/a2/`, not in the single-card suite.

After relocation: **101 focused CPU tests passed; all-file pre-commit and manual
stages passed**. Runtime code is unchanged. No new NPU rerun is claimed for the
path-only move; the device evidence below names the actual tested revision.

#### Fresh NPU and real-weight integration evidence

- At `222262c17`: DCP8 query gather/unpack changing-input graphs; single-card
  indexer store (48 replays) and remap (27 cases, 192 replays plus 3 empty cases).
- At runtime source **`c1e82ee97510f7805a6eef7663c53e7e3afacfe3`**: registered
  DCP8 O/LSE T48/T192 capture/replay on all eight ranks, including changing inputs
  and 128 rank/shape/replay checks against an exact uniform-LSE oracle.
- Reduced-model HTTP E2E exposed the main-refresh indexer metadata issue:
  `num_decode_tokens` was populated only for PCP, disabling native DCP fused store.
  Fixed in c1e82ee97; 35 indexer unit tests passed, then 9 HTTP requests/576 tokens
  passed with request-time and changed-input optimized-graph evidence.
- **Full 78-layer GLM-5.2 W4A8C8 trained weights**, including MoE, TP8/DCP8/EP8/DP1,
  no MTP/offload: three 1240-token prompts completed normally, generated 64/85/66
  tokens and correctly answered Beijing/Paris/Tokyo with coherent introductions.
  All eight ranks recorded 66 changed-input optimized-graph replays. Source hashes
  matched c1e82ee97. The current follow-up changes tests/docs only.

#### Fresh performance measurements on c1e82ee97

Registered O/LSE: same inputs, ON vs existing fallback OFF, 10 alternating
blocks ×100 graph replays; median of each block's slowest rank:

| T | OFF | ON | Effective replay latency reduction |
|---|---:|---:|---:|
|48|206.69 us|101.21 us|51.03%|
|192|569.19 us|220.02 us|61.35%|

Full trained-weight HTTP: **one completed OFF/ON pair**, 1920 input +128 output
tokens, no MTP/offload/prefix cache. OFF disables only query/store/O-LSE performance
eligibility on the same source; remap correctness fixes remain in both arms.
Both use scheduler budget4096, maxseq192 and KV6GiB. Optimization cap remains192.

| Concurrency | OFF mean TPOT(ms) | ON mean TPOT(ms) | Reduction | OFF / ON output throughput(tok/s) |
|---|---:|---:|---:|---:|
|1|48.74|47.46|2.63%|18.46 /18.88|
|4|62.56|60.05|4.01%|51.65 /53.25|
|192|655.25|635.78|2.97%|157.93 /161.34|

C192 cohort TPOT includes prefill/batch-filling interference. Within the common
interval after all192 first tokens arrived and before any request's last token,
median client inter-token latency was **173.51 ->144.80ms (-16.54%)**.
The windows were5.90/4.92s, extracted identically from raw SSE; this is not an
independent repeat, isolated kernel time or overall-request TPOT reduction.

Each rank verified34 actual unpadded T192 optimized replays in the ON measurement.
All197 measured requests per arm completed with128 output tokens, normal length
termination and zero preemptions. All197 paired token sequences matched.
The user requested stopping after one pair; later incomplete work is excluded.

#### Evidence limits

- 192 is manually selected; larger values are untested. Query/store retain their
  smaller bounds; the optimized path verified at T192 is O/LSE.
- Uniform-LSE graph checks do not resolve historical strict random CPU-BF16
  `atol=rtol=1e-3` failures in both compared exchanges. Thresholds remain unchanged;
  finite nonuniform-LSE timing inputs do not establish general precision acceptance.
- Serving used an isolated empty-target vLLM build at verified pin84030bbe,
  Torch2.10.0/torch-npu2.10.0.post4, Triton-Ascend3.2.2, CANN9.1.0 and image native
  libraries. FastAPI0.133.0/Starlette1.0.1 satisfy vLLM but conflict with Ascend's
  existing declaration; full pip check remains non-green. Not default-install acceptance.
- Single-pair HTTP results do not establish cross-run variance or confidence.
  No broad accuracy, 1M or SuperMem ON/OFF performance claim.
- #16349's synthetic release-image TPOT evidence is **reused release evidence**,
  not these main measurements. Its setup and numbers remain documented in `DCP_PORT.md`.

Evidence threads: [NPU](https://github.com/vllm-project/vllm-ascend/pull/16350#issuecomment-5759854639),
[reduced E2E](https://github.com/vllm-project/vllm-ascend/pull/16350#issuecomment-5763308847),
[full weights](https://github.com/vllm-project/vllm-ascend/pull/16350#issuecomment-5764536283),
[performance](https://github.com/vllm-project/vllm-ascend/pull/16350#issuecomment-5770334097).


- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
