### PR TITLE
[Performance][v0.23.0] Backport DCP decode query-gather layout optimization

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_query_gather_prep.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_query_gather_prep.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.query_gather_prep import prep_query_head_major
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("tokens,heads", [(1, 1), (7, 8), (32, 16), (0, 8)])
+@torch.inference_mode()
+def test_query_gather_prep_matches_torch(dtype, tokens, heads):
+    ql_nope = torch.randn(tokens, heads, 512, dtype=dtype, device="npu")
+    q_pe = torch.randn(tokens, heads, 64, dtype=dtype, device="npu")
+    actual = prep_query_head_major(ql_nope, q_pe)
+    expected = torch.cat((ql_nope, q_pe), dim=-1).permute(1, 0, 2).contiguous()
+    assert actual is not None
+    assert actual.is_contiguous()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@torch.inference_mode()
+def test_query_gather_prep_falls_back_for_unsafe_tail():
+    ql_nope = torch.randn(3, 2, 512, dtype=torch.float16, device="npu")
+    q_pe = torch.randn(3, 2, 48, dtype=torch.float16, device="npu")
+    assert prep_query_head_major(ql_nope, q_pe) is None

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -13,6 +13,7 @@
 # This file is a part of the vllm-ascend project.
 #
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -1488,6 +1489,26 @@ class TestAscendSFACPImpl(TestBase):
 
 
 class TestAscendSFADCPImpl(TestBase):
+    def test_finish_dcp_gather_restore_layout(self):
+        gathered = torch.arange(3 * 2 * 12).reshape(3, 2, 12)
+        for keep_view in (False, True):
+            with self.subTest(keep_view=keep_view):
+                handle = MagicMock()
+                context = SimpleNamespace(
+                    gathered=gathered,
+                    handle=handle,
+                    restore_perm=(1, 0, 2),
+                    split_sizes=(8, 4),
+                )
+                result = AscendSFADCPImpl._finish_dcp_gather(context, keep_view=keep_view)
+                expected = gathered.permute(1, 0, 2).contiguous().split((8, 4), dim=-1)
+                handle.wait.assert_called_once_with()
+                for actual, reference in zip(result, expected):
+                    torch.testing.assert_close(actual, reference)
+                    self.assertEqual(
+                        actual.untyped_storage().data_ptr() == gathered.untyped_storage().data_ptr(), keep_view
+                    )
+
     @staticmethod
     def _make_dsa_cp_context(
         *,
@@ -1663,7 +1684,8 @@ class TestAscendSFADCPImpl(TestBase):
         self.assertEqual(impl._start_dcp_gather.call_args.kwargs["split_sizes"], (16,))
         self.assertIs(attn_metadata.dcp_context.gather_context, gather_context)
 
-    def test_execute_sparse_flash_attention_process_uses_c8_device_operator_lse(self):
+    @patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_force_tmajor_restore", return_value=False)
+    def test_execute_sparse_flash_attention_process_uses_c8_device_operator_lse(self, mock_restore):
         impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
         impl.dcp_group = MagicMock()
         impl.dcp_size = 2
@@ -1677,7 +1699,7 @@ class TestAscendSFADCPImpl(TestBase):
 
         ql_nope = torch.randn(2, 2, 8)
         q_pe = torch.randn(2, 2, 4)
-        impl._finish_dcp_gather = MagicMock(side_effect=lambda _ctx: (ql_nope, q_pe))
+        impl._finish_dcp_gather = MagicMock(side_effect=lambda _ctx, **kwargs: (ql_nope, q_pe))
         kv_cache = (torch.empty(4, 1, 1, 16, dtype=torch.int8),)
         topk_indices = torch.zeros(2, 1, dtype=torch.int32)
         actual_seq_lengths_query = torch.tensor([2], dtype=torch.int32)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -59,6 +59,7 @@ class TestAscendConfig(TestBase):
         test_vllm_config = VllmConfig()
         # No additional config given, check the default value here.
         ascend_config = init_ascend_config(test_vllm_config)
+        self.assertFalse(ascend_config.sfa_dcp_force_tmajor_restore)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
 
@@ -79,6 +80,7 @@ class TestAscendConfig(TestBase):
             "ascend_fusion_config": {
                 "fusion_ops_gmmswigluquant": False,
             },
+            "sfa_dcp_force_tmajor_restore": True,
             "multistream_overlap_shared_expert": True,
             "eplb_config": {"num_redundant_experts": 2},
             "refresh": True,
@@ -86,6 +88,7 @@ class TestAscendConfig(TestBase):
         }
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertEqual(ascend_config.eplb_config.num_redundant_experts, 2)
+        self.assertTrue(ascend_config.sfa_dcp_force_tmajor_restore)
         self.assertTrue(ascend_config.multistream_overlap_shared_expert)
 
         ascend_compilation_config = ascend_config.ascend_compilation_config

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -32,6 +32,7 @@ class AscendConfig:
     def __init__(self, vllm_config: "VllmConfig"):
         self.vllm_config = vllm_config
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
+        self.sfa_dcp_force_tmajor_restore = additional_config.get("sfa_dcp_force_tmajor_restore", False)
         self._check_mooncake_c8_kv_cache_quant(vllm_config)
 
         xlite_graph_config = additional_config.get("xlite_graph_config", {})

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -27,6 +27,7 @@ from vllm_ascend.distributed.utils import (
     all_gather_async,
 )
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
+from vllm_ascend.utils import enable_sfa_dcp_force_tmajor_restore
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -1053,12 +1054,15 @@ class AscendSFADCPImpl(AscendSFAImpl):
     @staticmethod
     def _finish_dcp_gather(
         context: DCPGatherContext,
+        keep_view: bool = False,
     ) -> tuple[torch.Tensor, ...]:
         if context.handle is not None:
             context.handle.wait()
         gathered = context.gathered
         if context.restore_perm is not None:
-            gathered = gathered.permute(context.restore_perm).contiguous()
+            gathered = gathered.permute(context.restore_perm)
+            if not keep_view:
+                gathered = gathered.contiguous()
         return torch.split(gathered, context.split_sizes, dim=-1)
 
     def _all_gather_dim_async(
@@ -1209,6 +1213,24 @@ class AscendSFADCPImpl(AscendSFAImpl):
         # fragments. On Ascend the separate gathers can leave SFA with an
         # incomplete stream dependency on the first prefill. DSA-CP restores
         # token shards on dim 0; native DCP restores query shards on dim 1.
+        if query_gather_dim == 1 and getattr(ql_nope, "is_npu", False):
+            try:
+                from vllm_ascend.ops.triton.query_gather_prep import prep_query_head_major
+
+                head_major = prep_query_head_major(ql_nope, q_pe)
+            except Exception:
+                # Hard kernel failure: route to the torch assembly below.
+                head_major = None
+            if head_major is not None:
+                gathered, handle = all_gather_async(head_major, self.dcp_group)
+                return DCPGatherContext(
+                    gathered=gathered,
+                    handle=handle,
+                    restore_perm=(1, 0, 2),
+                    split_sizes=(ql_nope.shape[-1], q_pe.shape[-1]),
+                )
+            # prep_query_head_major returned None (shape not provably legal
+            # for the fast kernel): fall back to the torch assembly below.
         fused_q = torch.cat([ql_nope, q_pe], dim=-1).contiguous()
         return self._start_dcp_gather(
             fused_q,
@@ -1289,7 +1311,14 @@ class AscendSFADCPImpl(AscendSFAImpl):
             # DCP-local KV shard.
             topk_indices = self.dcp_group.all_gather(topk_indices.contiguous(), dim=0)
         topk_indices = self._remap_sparse_indices(topk_indices)
-        ql_nope, q_pe = self._finish_dcp_gather(gather_context)
+        # Keep the query as a strided view of the head-major gather output.
+        # The SFA query fragments are already strided views after torch.split.
+        # Set sfa_dcp_force_tmajor_restore=true in additional-config to
+        # materialize token-major storage for comparison runs.
+        ql_nope, q_pe = self._finish_dcp_gather(
+            gather_context,
+            keep_view=not enable_sfa_dcp_force_tmajor_restore(),
+        )
         sfa_output, softmax_lse = DeviceOperator.execute_sparse_flash_attention_process(
             self,
             ql_nope,

--- a/vllm_ascend/ops/triton/query_gather_prep.py
+++ b/vllm_ascend/ops/triton/query_gather_prep.py
@@ -1,0 +1,179 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+# Fused head-major assembly of the DCP query-gather input.
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "num_heads",
+        "nope_dim",
+        "rope_dim",
+        "total_dim",
+        "qn_stride_t",
+        "qn_stride_h",
+        "qp_stride_t",
+        "qp_stride_h",
+    ]
+)
+def _q_gather_prep_head_major_kernel(
+    qn_ptr,  # [T, H, nope_dim] ql_nope (any non-negative strides)
+    qp_ptr,  # [T, H, rope_dim] q_pe (any non-negative strides)
+    out_ptr,  # [H, T, nope_dim + rope_dim] contiguous, head-major gather input
+    num_tokens,
+    num_heads,
+    nope_dim,
+    rope_dim,
+    total_dim,
+    qn_stride_t,
+    qn_stride_h,
+    qp_stride_t,
+    qp_stride_h,
+    BLOCK_N: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    """Assemble the fused query directly in head-major layout.
+
+    One program per (head, token) row of the output. Writes the fused row
+    ``[nope | rope]`` into ``out[h, t, :]`` (contiguous), producing exactly
+    the buffer that ``all_gather_into_tensor`` needs for the native-DCP head
+    gather. This replaces the torch ``cat -> permute -> contiguous`` chain
+    with a single kernel.
+
+    Each fragment uses its own ``tl.arange`` index space, so pointer
+    arithmetic is never negative (no ``offs - nope_dim``) and no per-lane
+    offset selects are required. The wrapper only launches this kernel for
+    shapes it can prove legal (all addresses, including masked tail lanes,
+    inside the tensor storages); any other shape falls back to the torch
+    assembly in the caller (``prep_query_head_major`` raises).
+    """
+    row = tl.program_id(0)
+    head_idx = row // num_tokens
+    token_idx = row % num_tokens
+    dst_base = row * total_dim
+    src_base_n = token_idx * qn_stride_t + head_idx * qn_stride_h
+    src_base_p = token_idx * qp_stride_t + head_idx * qp_stride_h
+
+    offs_n = tl.arange(0, BLOCK_N)
+    n_mask = offs_n < nope_dim
+    qn = tl.load(qn_ptr + src_base_n + offs_n, mask=n_mask, other=0)
+    tl.store(out_ptr + dst_base + offs_n, qn, mask=n_mask)
+
+    offs_p = tl.arange(0, BLOCK_R)
+    p_mask = offs_p < rope_dim
+    qp = tl.load(qp_ptr + src_base_p + offs_p, mask=p_mask, other=0)
+    tl.store(out_ptr + dst_base + nope_dim + offs_p, qp, mask=p_mask)
+
+
+def _qualifies_fast_path(
+    ql_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    block_n: int,
+    block_r: int,
+    rope_dim: int,
+    total_dim: int,
+) -> bool:
+    """Host-side proof that every address the fast kernel computes is legal.
+
+    Loads and stores only use non-negative offsets (per-fragment index
+    spaces), so the remaining risk is a masked tail lane pointing past the
+    end of a tensor storage. Returns True iff no such lane exists for any
+    (head, token) row:
+      - strides are non-negative (no mirrored views);
+      - the two store tails stay inside the [H, T, total] allocation, i.e.
+        BLOCK_N <= total_dim and nope_dim + BLOCK_R <= total_dim;
+      - loads: the last row base + BLOCK - 1 never passes the storage end,
+        for both fragments.
+    """
+    if ql_nope.stride(0) < 0 or ql_nope.stride(1) < 0 or q_pe.stride(0) < 0 or q_pe.stride(1) < 0:
+        return False
+    if block_n > total_dim or ql_nope.shape[-1] + block_r > total_dim:
+        return False
+    num_tokens, num_heads = ql_nope.shape[:2]
+    for tensor, block in ((ql_nope, block_n), (q_pe, block_r)):
+        last_base = (num_tokens - 1) * tensor.stride(0) + (num_heads - 1) * tensor.stride(1)
+        if last_base + block > tensor.numel():
+            return False
+    return True
+
+
+def prep_query_head_major(
+    ql_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+) -> torch.Tensor | None:
+    """Return the fused query as a contiguous [H, T, nope+rope] tensor.
+
+    Args:
+        ql_nope: [T, H, nope_dim] partial query (rope-excluded).
+        q_pe: [T, H, rope_dim] rope part.
+
+    Returns:
+        [H, T, nope_dim + rope_dim] contiguous tensor, in the layout
+        ``all_gather_into_tensor`` produces for a head gather (each rank's
+        head chunk is contiguous along dim 0); or ``None`` when the shapes
+        cannot be proven legal for the kernel (see ``_qualifies_fast_path``),
+        in which case callers fall back to the torch ``cat -> permute ->
+        contiguous`` assembly. No guarded Triton kernel is used.
+
+    Raises:
+        RuntimeError: on genuinely invalid inputs (mismatched (T, H) or
+        dtype); those cannot be assembled by the torch fallback either.
+    """
+    if ql_nope.shape[:2] != q_pe.shape[:2]:
+        raise RuntimeError(
+            f"query gather prep requires matching (T, H), got {tuple(ql_nope.shape)} and {tuple(q_pe.shape)}"
+        )
+    if ql_nope.dtype != q_pe.dtype:
+        raise RuntimeError("query gather prep requires ql_nope and q_pe to share a dtype")
+    num_tokens, num_heads, nope_dim = ql_nope.shape
+    rope_dim = q_pe.shape[-1]
+    total_dim = nope_dim + rope_dim
+
+    out = torch.empty(
+        (num_heads, num_tokens, total_dim),
+        dtype=ql_nope.dtype,
+        device=ql_nope.device,
+    )
+    if num_tokens == 0 or num_heads == 0:
+        return out
+    block_n = next_power_of_2(nope_dim)
+    block_r = next_power_of_2(rope_dim)
+    if not _qualifies_fast_path(ql_nope, q_pe, block_n, block_r, rope_dim, total_dim):
+        return None
+    grid = (num_tokens * num_heads,)
+    _q_gather_prep_head_major_kernel[grid](
+        ql_nope,
+        q_pe,
+        out,
+        num_tokens,
+        num_heads,
+        nope_dim,
+        rope_dim,
+        total_dim,
+        ql_nope.stride(0),
+        ql_nope.stride(1),
+        q_pe.stride(0),
+        q_pe.stride(1),
+        BLOCK_N=block_n,
+        BLOCK_R=block_r,
+        multibuffer=False,
+    )
+    return out

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1511,6 +1511,13 @@ def singleton(cls):
     return get_instance
 
 
+def enable_sfa_dcp_force_tmajor_restore() -> bool:
+    # Read the query restore option from the release AscendConfig singleton.
+    from vllm_ascend.ascend_config import get_ascend_config
+
+    return get_ascend_config().sfa_dcp_force_tmajor_restore
+
+
 @lru_cache(maxsize=1)
 def enable_dsa_cp() -> bool:
     from vllm.config import get_current_vllm_config


### PR DESCRIPTION
### What this PR does / why we need it?

Backport #15970 (source head `456500c764fa3f8e6016be00c76fd8e9c59732a9`) to `releases/v0.23.0`.

The native DCP decode path assembles the query directly into a contiguous head-major buffer with a Triton kernel, retaining the torch assembly fallback. After gathering, SFA consumes the restored query view to avoid the token-major materialization copy.

Adapt the configuration option to this release's `AscendConfig` constructor and preserve its C8/LSE device-operator interface. Add regression coverage for the configuration default/override, restored values and storage sharing, and NPU kernel equivalence and unsafe-tail fallback.

### Does this PR introduce _any_ user-facing change?

Adds `sfa_dcp_force_tmajor_restore` to `--additional-config`, defaulting to `false`. Set `--additional-config '{"sfa_dcp_force_tmajor_restore": true}'` to materialize token-major query storage for comparison runs.

### How was this patch tested?

Passed on the changed files:
- Ruff lint and formatting checks.
- Python AST parsing.
- Git whitespace checks with `cr-at-eol` for the existing CRLF test file.

`bash format.sh ci` was attempted but interrupted while installing the actionlint environment; the full lint suite has not completed.

This is a draft: the added tests and NPU runtime validation have not been executed for this backport. Pending coverage includes the targeted config/attention tests, kernel dtype/shape/layout checks, DCP multi-rank eager/model correctness, graph correctness, and performance comparison. The source PR's reported GSM8K result has not been reproduced on this release branch.

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
