### PR TITLE
[CI] Reduce repeated work in vLLM interface analysis

### DIFF
--- a/tests/e2e/vllm_interface/README.md
+++ b/tests/e2e/vllm_interface/README.md
@@ -69,6 +69,23 @@ This keeps cross-module results deterministic. Use `--index-workers 1` to use th
 The CI implementation does not write or restore persistent repository-index or file-fragment data. This avoids relying
 on state that is not preserved by the job's ephemeral container.
 
+### Avoiding repeated work within a run
+
+The scope interpreter copies an already-normalized state when there is only one execution path, instead of sorting
+and merging every name again. Multiple paths still use the existing binding-alternative merge.
+
+Each base/head snapshot computes a module or class's final namespace once and reuses named bindings, fingerprints,
+and resolved API contracts. Call-contract reuse is keyed by the target expression, access kind, receiver type,
+member, and invocation kind; argument binding and return-use checks still run separately for every call site.
+Snapshots remain isolated between revisions and analysis branches.
+
+Import checks first resolve symbol presence without computing unused signatures or return contracts. Full endpoint
+details are still produced for findings, and all affected import locations are retained. Import discovery also reuses
+the already-parsed vllm-ascend module trees, with a source-reading fallback for files absent from the index.
+
+These are in-process optimizations only: no pickle files, persistent cache, new environment variables, or reduced
+analysis scope are required. Complete source indexing and input verification still run for every PR.
+
 ### Classification and result
 
 New incompatibilities are reported as introduced breaks. Historical incompatibilities are not attributed to the PR,

--- a/tests/e2e/vllm_interface/README.md
+++ b/tests/e2e/vllm_interface/README.md
@@ -79,9 +79,35 @@ and resolved API contracts. Call-contract reuse is keyed by the target expressio
 member, and invocation kind; argument binding and return-use checks still run separately for every call site.
 Snapshots remain isolated between revisions and analysis branches.
 
+Each snapshot lazily starts one `git cat-file --batch` process and requests source blobs only when needed, avoiding
+a separate `git show` process for every file. Responses are read as length-delimited binary data before decoding, so
+empty files, CRLF content, and non-ASCII source retain the previous behavior. Malformed or failed Git reads raise an
+analysis error rather than being treated as missing symbols. Git processes and temporary stderr streams are closed
+on successful completion and on exceptions. This does not introduce a persistent source cache or preload all files.
+
+Execution-path state copies also reuse their immutable binding tuples while retaining independent dictionaries.
+
+Repository indexing derives always-bound module names from the final namespace already computed for that module,
+instead of interpreting its body again. Decorator and direct-call resolution reuse namespace states for identical
+statement prefixes and version-guard settings. Each prefix memo is limited to 256 entries and is replaced for each
+module. It stores AST objects rather than numeric IDs and returns independent state dictionaries. Only namespace
+states are reused: expression resolution and caller-specific fallback rules still run for every query. Source trees
+are treated as immutable for the lifetime of the memo; nothing is shared between revisions, workers, or CI runs.
+
+Symbol alias resolution checks the full qualified name and successively shorter dot-delimited prefixes directly in
+the alias table. This preserves longest-prefix lookup and cycle protection without sorting and scanning all aliases
+for each query. The current table is read on every lookup, including while index finalization is updating aliases.
+
 Import checks first resolve symbol presence without computing unused signatures or return contracts. Full endpoint
 details are still produced for findings, and all affected import locations are retained. Import discovery also reuses
 the already-parsed vllm-ascend module trees, with a source-reading fallback for files absent from the index.
+
+Import presence is determined from the final module namespace, not from whether an assignment or import appeared
+earlier in the file. A later `del` removes a binding; an annotation without a value does not create one or remove an
+existing one. Constants, functions, classes, and re-exports that remain bound can be imported. A P1 requires presence
+at the PR base and absence at its head to be proven. Path-dependent bindings, star imports, and module `__getattr__`
+exports remain unresolved when their presence cannot be established, rather than being treated as definite removals.
+Package-submodule fallback is retained when a missing package attribute can still be imported as a submodule.
 
 These are in-process optimizations only: no pickle files, persistent cache, new environment variables, or reduced
 analysis scope are required. Complete source indexing and input verification still run for every PR.

--- a/tests/e2e/vllm_interface/vllm_interface_contracts/call_contracts.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/call_contracts.py
@@ -36,6 +36,7 @@ from .generator import (
     _function_scope_nodes,
     _inspect_signature,
     _scope_reference_variants,
+    _ScopePrefixCache,
     _statements_must_terminate,
     _tag_guard_names,
 )
@@ -864,6 +865,7 @@ class DirectCallDetector:
         ] = {}
         self._function_locals: dict[int, frozenset[str]] = {}
         self._scope_tag_guards: dict[int, set[str]] = {}
+        self._prefix_cache = _ScopePrefixCache()
 
     def _local_names(
         self,
@@ -1003,6 +1005,7 @@ class DirectCallDetector:
             module=module_info.name,
             is_package=module_info.is_package,
             fallback=self._no_fallback,
+            prefix_cache=self._prefix_cache,
         )
         concrete = {item for item in variants if item is not None}
         if len(variants) != 1 or len(concrete) != 1:
@@ -1229,6 +1232,7 @@ class DirectCallDetector:
             module=module_info.name,
             is_package=module_info.is_package,
             fallback=self._module_fallback(module_info, local_names),
+            prefix_cache=self._prefix_cache,
         )
         concrete = {item for item in variants if item is not None}
         if len(variants) != 1 or len(concrete) != 1:
@@ -1352,6 +1356,7 @@ class DirectCallDetector:
         dependencies: list[DirectCallDependency] = []
         self.historical_candidates = []
         for module_info in self.engine.downstream.modules.values():
+            self._prefix_cache = _ScopePrefixCache()
             tree = module_info.tree
             parents = _parents(tree)
             for node in ast.walk(tree):

--- a/tests/e2e/vllm_interface/vllm_interface_contracts/generator.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/generator.py
@@ -28,7 +28,7 @@ import builtins
 import inspect
 import json
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field, replace
@@ -246,7 +246,9 @@ _HANDLER_ALWAYS = "always"
 def _clone_scope_binding_state(
     state: dict[str, tuple[_ScopeBinding, ...]],
 ) -> dict[str, tuple[_ScopeBinding, ...]]:
-    return {name: tuple(values) for name, values in state.items()}
+    # Alternatives are immutable tuples; only the name-to-binding map is owned
+    # by each execution path.
+    return dict(state)
 
 
 def _scope_state_key(
@@ -840,10 +842,40 @@ def _scope_final_bindings(
     return _scope_final_binding_state(statements, tag_guard_names) or {}
 
 
+class _ScopePrefixCache:
+    """Bounded namespace memo for one immutable module's analysis.
+
+    Keys retain the actual AST statements, not process-local numeric IDs.
+    Equal prefixes share a state even when queries use different line numbers.
+    Returned dictionaries are independent; binding alternatives are immutable.
+    """
+
+    def __init__(self, max_entries: int = 256):
+        if max_entries < 1:
+            raise ValueError("max_entries must be at least 1")
+        self.max_entries = max_entries
+        self._states: OrderedDict[
+            tuple[tuple[ast.stmt, ...], frozenset[str]],
+            dict[str, tuple[_ScopeBinding, ...]],
+        ] = OrderedDict()
+
+    def resolve(self, prefix: tuple[ast.stmt, ...], tag_guard_names: set[str]) -> dict[str, tuple[_ScopeBinding, ...]]:
+        key = (prefix, frozenset(tag_guard_names))
+        if key not in self._states:
+            state = _scope_final_binding_state(prefix, tag_guard_names) or {}
+            self._states[key] = state
+            if len(self._states) > self.max_entries:
+                self._states.popitem(last=False)
+        self._states.move_to_end(key)
+        return dict(self._states[key])
+
+
 def _scope_state_before(
     statements: Sequence[ast.stmt],
     line: int,
     tag_guard_names: set[str],
+    *,
+    prefix_cache: _ScopePrefixCache | None = None,
 ) -> dict[str, tuple[_ScopeBinding, ...]]:
     """Return bindings after statements that finish before ``line``.
 
@@ -854,11 +886,13 @@ def _scope_state_before(
     those rules, so descriptor resolution reuses its state.
     """
 
-    prefix = [
+    prefix = tuple(
         statement
         for statement in statements
         if getattr(statement, "end_lineno", getattr(statement, "lineno", 0)) < line
-    ]
+    )
+    if prefix_cache is not None:
+        return prefix_cache.resolve(prefix, tag_guard_names)
     return _scope_final_binding_state(prefix, tag_guard_names) or {}
 
 
@@ -900,6 +934,7 @@ def _scope_reference_variants(
     is_package: bool,
     fallback: Callable[[ast.AST], set[str | None]] | None = None,
     seen: frozenset[tuple[str, int]] = frozenset(),
+    prefix_cache: _ScopePrefixCache | None = None,
 ) -> set[str | None]:
     """Resolve one expression on every normal path reaching ``line``.
 
@@ -914,7 +949,7 @@ def _scope_reference_variants(
     if expression is None:
         return {None}
     root, separator, remainder = expression.partition(".")
-    state = _scope_state_before(statements, line, tag_guard_names)
+    state = _scope_state_before(statements, line, tag_guard_names, prefix_cache=prefix_cache)
     bindings = state.get(root, ())
 
     def fallback_references() -> set[str | None]:
@@ -956,6 +991,7 @@ def _scope_reference_variants(
                     is_package=is_package,
                     fallback=fallback,
                     seen=frozenset((*seen, recursion_key)),
+                    prefix_cache=prefix_cache,
                 )
                 references.update(
                     (f"{item}.{remainder}" if item is not None and separator else item) for item in nested
@@ -990,6 +1026,7 @@ def _scope_decorator_reference_tuple(
     tag_guard_names: set[str],
     module: str,
     is_package: bool,
+    prefix_cache: _ScopePrefixCache | None = None,
 ) -> tuple[str | None, ...]:
     """Resolve function decorators against their enclosing module scope."""
 
@@ -1007,6 +1044,7 @@ def _scope_decorator_reference_tuple(
                 tag_guard_names=tag_guard_names,
                 module=module,
                 is_package=is_package,
+                prefix_cache=prefix_cache,
             ),
         )
     )
@@ -1555,30 +1593,6 @@ def _definition_descriptor_kind(
         reference_resolver=reference_resolver,
     )
     return kinds[0] if len(kinds) == 1 else "unknown"
-
-
-def _scope_must_bound_names(
-    statements: Sequence[ast.stmt],
-    tag_guard_names: set[str],
-    incoming: set[str] | None = None,
-) -> set[str]:
-    """Return names present after every normally completing active-main path."""
-
-    initial: dict[str, tuple[_ScopeBinding, ...]] = {
-        name: (_scope_binding("value", ast.Pass()),) for name in incoming or ()
-    }
-    final = _scope_final_binding_state(
-        statements,
-        tag_guard_names,
-        initial,
-    )
-    if final is None:
-        return set()
-    return {
-        name
-        for name, alternatives in final.items()
-        if alternatives and all(alternative.kind != "unbound" for alternative in alternatives)
-    }
 
 
 def _main_module_statement_records(
@@ -2286,6 +2300,7 @@ class RepositoryIndex:
             star_imports: list[str] = []
             annotated_exports: list[tuple[str, str]] = []
             tag_guard_names = _tag_guard_names(tree.body)
+            prefix_cache = _ScopePrefixCache()
             module_final_bindings = _scope_final_bindings(
                 tree.body,
                 tag_guard_names,
@@ -2293,10 +2308,11 @@ class RepositoryIndex:
             self.final_bindings.update(
                 {f"{module}.{name}": alternatives for name, alternatives in module_final_bindings.items()}
             )
-            module_must_names = _scope_must_bound_names(
-                tree.body,
-                tag_guard_names,
-            )
+            module_must_names = {
+                name
+                for name, alternatives in module_final_bindings.items()
+                if alternatives and all(alternative.kind != "unbound" for alternative in alternatives)
+            }
             module_statements = list(
                 _main_module_statements(
                     tree.body,
@@ -2405,6 +2421,7 @@ class RepositoryIndex:
                         active_tag_guards: set[str] = tag_guard_names,
                         current_module: str = module,
                         current_is_package: bool = is_package,
+                        prefix_cache: _ScopePrefixCache = prefix_cache,
                     ) -> set[str | None]:
                         return _scope_reference_variants(
                             expression,
@@ -2413,6 +2430,7 @@ class RepositoryIndex:
                             tag_guard_names=active_tag_guards,
                             module=current_module,
                             is_package=current_is_package,
+                            prefix_cache=prefix_cache,
                         )
 
                     def class_reference_resolver(
@@ -2422,6 +2440,7 @@ class RepositoryIndex:
                         active_tag_guards: set[str] = tag_guard_names,
                         current_class: str = qualified_name,
                         module_fallback: Callable[[ast.AST], set[str | None]] = module_reference_resolver,
+                        prefix_cache: _ScopePrefixCache = prefix_cache,
                     ) -> set[str | None]:
                         return _scope_reference_variants(
                             expression,
@@ -2431,6 +2450,7 @@ class RepositoryIndex:
                             module=current_class,
                             is_package=False,
                             fallback=module_fallback,
+                            prefix_cache=prefix_cache,
                         )
 
                     class_functions = sorted(
@@ -2460,6 +2480,7 @@ class RepositoryIndex:
                         current_imports: dict[str, str] = imports,
                         local_classes: dict[str, ClassInfo] = classes,
                         local_functions: dict[str, CallableInfo] = functions,
+                        prefix_cache: _ScopePrefixCache = prefix_cache,
                     ) -> ast.AST | None:
                         expression = _expression_name(expression_node)
                         if expression is None:
@@ -2469,6 +2490,7 @@ class RepositoryIndex:
                                 class_node.body,
                                 line,
                                 active_tag_guards,
+                                prefix_cache=prefix_cache,
                             )
                             local_nodes = {
                                 alternative.node
@@ -2531,6 +2553,7 @@ class RepositoryIndex:
                             node.body,
                             function_line,
                             tag_guard_names,
+                            prefix_cache=prefix_cache,
                         )
                         for alternatives in class_state.values():
                             for alternative in alternatives:
@@ -2741,6 +2764,7 @@ class RepositoryIndex:
                         tag_guard_names=tag_guard_names,
                         module=module,
                         is_package=is_package,
+                        prefix_cache=prefix_cache,
                     )
                     self._decorator_references_by_node[id(node)] = decorator_references
                     function_info = CallableInfo(
@@ -2798,6 +2822,7 @@ class RepositoryIndex:
                         tag_guard_names=tag_guard_names,
                         module=module,
                         is_package=is_package,
+                        prefix_cache=prefix_cache,
                     )
                     self._decorator_references_by_node[id(candidate)] = decorator_references
                     variants_list.append(
@@ -2839,6 +2864,7 @@ class RepositoryIndex:
                     tag_guard_names=tag_guard_names,
                     module=module,
                     is_package=is_package,
+                    prefix_cache=prefix_cache,
                 )
                 self._decorator_references_by_node.setdefault(
                     id(walked_node),
@@ -3454,19 +3480,22 @@ class RepositoryIndex:
         visited_aliases: set[str] = set()
         while result not in visited:
             visited.add(result)
-            replacement = None
-            for alias in sorted(self.aliases, key=len, reverse=True):
-                if result == alias or result.startswith(f"{alias}."):
-                    if alias in visited_aliases:
-                        # An alias can only match again when another alias maps
-                        # back to it or when it expands into its own namespace.
-                        # Neither chain has one statically provable canonical
-                        # target, so fail closed instead of growing forever.
-                        return qualified_name
-                    visited_aliases.add(alias)
-                    replacement = f"{self.aliases[alias]}{result[len(alias) :]}"
+            # Only dot-delimited prefixes can match. Check the longest first
+            # instead of sorting and scanning every alias in the repository.
+            # Read the live table: aliases can change during index finalization.
+            alias = result
+            while alias not in self.aliases:
+                if "." not in alias:
                     break
-            if replacement is None or replacement == result:
+                alias = alias.rsplit(".", 1)[0]
+            if alias not in self.aliases:
+                break
+            if alias in visited_aliases:
+                # Preserve cycle and self-expansion handling from alias lookup.
+                return qualified_name
+            visited_aliases.add(alias)
+            replacement = f"{self.aliases[alias]}{result[len(alias) :]}"
+            if replacement == result:
                 break
             result = replacement
         return result

--- a/tests/e2e/vllm_interface/vllm_interface_contracts/generator.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/generator.py
@@ -192,6 +192,10 @@ def _merge_scope_binding_states(
     live_states = [state for state in states if state is not None]
     if not live_states:
         return None
+    if len(live_states) == 1:
+        # Interpreter states already contain sorted, unique alternatives.
+        # Preserve ownership without rebuilding every name's alternative set.
+        return dict(live_states[0])
     names = {name for state in live_states for name in state}
     merged: dict[str, tuple[_ScopeBinding, ...]] = {}
     for name in names:
@@ -256,9 +260,10 @@ def _compact_scope_states(
 ) -> list[dict[str, tuple[_ScopeBinding, ...]]]:
     """Merge path states without losing any per-name binding alternative."""
 
-    unique = {_scope_state_key(state): state for state in states}
-    if not unique:
-        return []
+    candidates = list(states)
+    if len(candidates) < 2:
+        return [dict(state) for state in candidates]
+    unique = {_scope_state_key(state): state for state in candidates}
     merged = _merge_scope_binding_states(list(unique.values()))
     return [merged] if merged is not None else []
 

--- a/tests/e2e/vllm_interface/vllm_interface_contracts/range_analysis.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/range_analysis.py
@@ -28,13 +28,15 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from collections import Counter
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, cast
 
 from .analysis_plans import resolve_analysis_plan
 from .call_contracts import (
@@ -75,7 +77,8 @@ from .models import (
 )
 
 RANGE_SCHEMA_VERSION = 11
-RANGE_ANALYZER_VERSION = "2.1.0"
+RANGE_ANALYZER_VERSION = "2.1.1"
+_GIT_BATCH_CLOSE_TIMEOUT_SECONDS = 5
 CLASSIFICATIONS = (
     "introduced_break",
     "compatibility_warning",
@@ -548,6 +551,10 @@ class GitSnapshot:
     def __init__(self, root: Path, revision: str):
         self.root = root
         self.revision = revision
+        self._batch_process: subprocess.Popen[bytes] | None = None
+        self._batch_stderr: BinaryIO | None = None
+        self._batch_resources = ExitStack()
+        self._closed = False
         self._files: set[str] | None = None
         self._source: dict[str, str | None] = {}
         self._trees: dict[str, ast.Module | None] = {}
@@ -559,7 +566,8 @@ class GitSnapshot:
         self._owners: dict[tuple[ast.Module, str], ast.ClassDef | None] = {}
         self._endpoints: dict[tuple[str, str | None, str], SourceEndpoint] = {}
         self._call_endpoints: dict[tuple[str, str, str | None, str | None, str], SourceEndpoint] = {}
-        self._import_presence: dict[tuple[str, str], bool] = {}
+        self._import_presence: dict[tuple[str, str], bool | None] = {}
+        self._dynamic_import_exports: dict[ast.Module, bool] = {}
         self._keyword_call_candidates: dict[
             tuple[tuple[str, ...], str],
             list[tuple[str, ast.Call, str | None, str]],
@@ -582,13 +590,85 @@ class GitSnapshot:
             if normalized not in self.files:
                 self._source[normalized] = None
             else:
-                raw = subprocess.run(
-                    ["git", "-C", str(self.root), "show", f"{self.revision}:{normalized}"],
-                    check=True,
-                    capture_output=True,
-                ).stdout
+                raw = self._read_blob(normalized)
                 self._source[normalized] = raw.decode("utf-8", errors="replace")
         return self._source[normalized]
+
+    def _read_blob(self, file_name: str) -> bytes:
+        """Read on demand through one binary Git pipe per analysis snapshot."""
+        if self._closed:
+            raise ValueError("cannot read from a closed Git snapshot")
+        # The batch protocol is line-delimited. Keep the original Git path
+        # handling for unusual names rather than splitting a request in two.
+        if "\n" in file_name or "\r" in file_name:
+            return subprocess.run(
+                ["git", "-C", str(self.root), "show", f"{self.revision}:{file_name}"],
+                check=True,
+                capture_output=True,
+            ).stdout
+        try:
+            if self._batch_process is None:
+                # A file avoids a full stderr pipe blocking Git while Python
+                # reads stdout, including partial-clone lazy-fetch diagnostics.
+                self._batch_stderr = cast(
+                    BinaryIO,
+                    self._batch_resources.enter_context(
+                        tempfile.TemporaryFile(mode="w+b")  # noqa: SIM115 - owned by the snapshot's ExitStack
+                    ),
+                )
+                self._batch_process = subprocess.Popen(
+                    ["git", "-C", str(self.root), "cat-file", "--batch"],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=self._batch_stderr,
+                )
+            process = self._batch_process
+            assert process.stdin is not None and process.stdout is not None
+            if process.poll() is not None:
+                raise ValueError(f"Git batch process exited with code {process.returncode}")
+            process.stdin.write(f"{self.revision}:{file_name}\n".encode())
+            process.stdin.flush()
+            header = process.stdout.readline().split()
+            if len(header) != 3 or header[1] != b"blob":
+                raise ValueError(f"unexpected Git batch header: {header!r}")
+            size = int(header[2])
+            if size < 0:
+                raise ValueError(f"invalid Git blob size: {size}")
+            content = process.stdout.read(size)
+            if len(content) != size or process.stdout.read(1) != b"\n":
+                raise ValueError("incomplete Git batch blob response")
+            return content
+        except (OSError, ValueError) as error:
+            diagnostic = ""
+            if self._batch_stderr is not None:
+                self._batch_stderr.seek(0)
+                diagnostic = self._batch_stderr.read().decode("utf-8", errors="replace").strip()
+            self.close()
+            raise ValueError(
+                f"Git batch read failed for {self.revision}:{file_name}: {error}"
+                + (f"\n{diagnostic}" if diagnostic else "")
+            ) from error
+
+    def close(self) -> None:
+        """Release the lazy Git process on both successful and failed runs."""
+        self._closed = True
+        process = self._batch_process
+        try:
+            if process is not None:
+                if process.stdin is not None:
+                    with suppress(BrokenPipeError):
+                        process.stdin.close()
+                try:
+                    process.wait(timeout=_GIT_BATCH_CLOSE_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                if process.stdout is not None:
+                    process.stdout.close()
+        finally:
+            self._batch_resources.close()
+            self._batch_stderr = None
+            self._batch_process = None
 
     def tree(self, file_name: str) -> ast.Module | None:
         normalized = file_name.replace("\\", "/")
@@ -628,25 +708,36 @@ class GitSnapshot:
             return _NamedBinding(None, "missing")
         return self._scope_named_binding(class_node, name)
 
-    def has_import_symbol(self, file_name: str, name: str) -> bool:
-        """Use the import detector's presence rules without building a contract.
+    def has_import_symbol(self, file_name: str, name: str) -> bool | None:
+        """Resolve final namespace presence; None means path-dependent/unknown.
 
-        Full endpoints (including fingerprints and return contracts) are still
-        built for findings, so their evidence is unchanged.
+        An earlier assignment or import does not survive a later deletion.
+        An annotation without a value does not create a runtime binding.
         """
         key = (file_name, name)
         if key not in self._import_presence:
             tree = self.tree(file_name)
-            present = False
+            present: bool | None = False if file_name not in self.files else None
             if tree is not None:
                 alternatives = self._scope_bindings(tree).get(name, ())
-                present = (
-                    len(alternatives) == 1
-                    and alternatives[0].kind in {"function", "class"}
-                    and getattr(alternatives[0].node, "lineno", None) is not None
-                ) or _top_level_import_binding(tree, name) is not None
+                kinds = {binding.kind for binding in alternatives}
+                if kinds and kinds <= {"function", "class", "value", "alias"}:
+                    present = True
+                elif not kinds or kinds == {"unbound"}:
+                    present = None if self._has_dynamic_import_exports(tree) else False
+                else:
+                    present = None
             self._import_presence[key] = present
         return self._import_presence[key]
+
+    def _has_dynamic_import_exports(self, tree: ast.Module) -> bool:
+        if tree not in self._dynamic_import_exports:
+            getter = self._scope_bindings(tree).get("__getattr__", ())
+            self._dynamic_import_exports[tree] = any(binding.kind != "unbound" for binding in getter) or any(
+                isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+                for node in ast.walk(tree)
+            )
+        return self._dynamic_import_exports[tree]
 
     def _module_bindings(self, file_name: str) -> dict[str, str]:
         normalized = file_name.replace("\\", "/")
@@ -2279,28 +2370,19 @@ def discover_imports(
     return [unique[key] for key in ordered]
 
 
-def _top_level_import_binding(tree: ast.Module | None, name: str) -> int | None:
-    if tree is not None:
-        for node in tree.body:
-            names: list[str] = []
-            if isinstance(node, (ast.Assign, ast.AnnAssign)):
-                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-                names = [item.id for target in targets for item in ast.walk(target) if isinstance(item, ast.Name)]
-            elif isinstance(node, (ast.Import, ast.ImportFrom)):
-                names = [alias.asname or alias.name.rsplit(".", 1)[-1] for alias in node.names]
-            if name in names:
-                return node.lineno
-    return None
-
-
 def _top_level_symbol(snapshot: GitSnapshot, file_name: str, name: str) -> SourceEndpoint:
+    if snapshot.has_import_symbol(file_name, name) is not True:
+        return SourceEndpoint(file=None, owner=None, name=name)
     endpoint = snapshot.endpoint(file_name, None, name)
     if endpoint.line is not None:
         return endpoint
-    line = _top_level_import_binding(snapshot.tree(file_name), name)
-    if line is not None:
-        return SourceEndpoint(file=file_name, owner=None, name=name, line=line)
-    return SourceEndpoint(file=None, owner=None, name=name)
+    tree = snapshot.tree(file_name)
+    assert tree is not None
+    # Constants and re-exports are importable even without a callable contract.
+    # Keep evidence on a surviving binding, not a deleted earlier assignment.
+    bindings = snapshot._scope_bindings(tree)[name]
+    line = min(binding.line for binding in bindings)
+    return SourceEndpoint(file=file_name, owner=None, name=name, line=line)
 
 
 def _import_findings(
@@ -2338,10 +2420,14 @@ def _import_findings(
             old_endpoint = SourceEndpoint(file=old_file, owner=None, name=None)
             new_endpoint = SourceEndpoint(file=new_file, owner=None, name=None)
         elif symbol and "." not in symbol:
-            if not old_snapshot.has_import_symbol(old_file, symbol):
+            if old_snapshot.has_import_symbol(old_file, symbol) is not True:
                 continue
-            if new_file is not None and new_snapshot.has_import_symbol(new_file, symbol):
-                continue
+            if new_file is not None:
+                # A missing package attribute can still resolve as a submodule.
+                if new_file.endswith("/__init__.py") and new_snapshot.resolve_module(f"{reference.module}.{symbol}"):
+                    continue
+                if new_snapshot.has_import_symbol(new_file, symbol) is not False:
+                    continue
             old_endpoint = _top_level_symbol(old_snapshot, old_file, symbol)
             new_endpoint = (
                 _top_level_symbol(new_snapshot, new_file, symbol)
@@ -2721,6 +2807,30 @@ def analyze_range(
     index_workers: int = 1,
 ) -> dict[str, Any]:
     """Run the vLLM PR interface analysis for an exact range."""
+    with ExitStack() as resources:
+        return _analyze_range(
+            vllm_root=vllm_root,
+            ascend_root=ascend_root,
+            old=old,
+            new=new,
+            expect_ascend_sha=expect_ascend_sha,
+            analysis_workers=analysis_workers,
+            index_workers=index_workers,
+            resources=resources,
+        )
+
+
+def _analyze_range(
+    *,
+    vllm_root: Path,
+    ascend_root: Path,
+    old: str,
+    new: str,
+    expect_ascend_sha: str,
+    analysis_workers: int,
+    index_workers: int,
+    resources: ExitStack,
+) -> dict[str, Any]:
     analysis_started = time.perf_counter()
     phase_started = time.perf_counter()
     timings: dict[str, float | None] = {}
@@ -2746,8 +2856,10 @@ def analyze_range(
     relations = generator.generate(plan)
     timings.update({f"relation_generation.{name}": duration for name, duration in generator.phase_timings.items()})
     phase_started = time.perf_counter()
-    old_snapshot = GitSnapshot(vllm_root, old_sha)
-    new_snapshot = GitSnapshot(vllm_root, new_sha)
+    snapshots = [GitSnapshot(vllm_root, sha) for sha in (old_sha, new_sha) * 3]
+    for snapshot in snapshots:
+        resources.callback(snapshot.close)
+    old_snapshot, new_snapshot, import_old, import_new, call_old, call_new = snapshots
     old_to_new, new_to_old = _rename_maps(vllm_root, old_sha, new_sha)
     changed_upstream_files = _changed_python_files(vllm_root, old_sha, new_sha)
     registered_overrides = _registered_oot_overrides(generator)
@@ -2783,8 +2895,8 @@ def analyze_range(
         started = time.perf_counter()
         branch_findings = _import_findings(
             ascend_root,
-            GitSnapshot(vllm_root, old_sha),
-            GitSnapshot(vllm_root, new_sha),
+            import_old,
+            import_new,
             old_to_new,
             trees={module.file: module.tree for module in generator.downstream.modules.values()},
         )
@@ -2796,8 +2908,8 @@ def analyze_range(
         float,
         float,
     ]:
-        branch_old_snapshot = GitSnapshot(vllm_root, old_sha)
-        branch_new_snapshot = GitSnapshot(vllm_root, new_sha)
+        branch_old_snapshot = call_old
+        branch_new_snapshot = call_new
         discovery_started = time.perf_counter()
         direct_call_detector = DirectCallDetector(generator)
         discovered_direct_calls = direct_call_detector.discover()

--- a/tests/e2e/vllm_interface/vllm_interface_contracts/range_analysis.py
+++ b/tests/e2e/vllm_interface/vllm_interface_contracts/range_analysis.py
@@ -65,6 +65,7 @@ from .generator import (
     _import_binding_reference,
     _jsonable_signature,
     _scope_final_bindings,
+    _ScopeBinding,
     _tag_guard_names,
 )
 from .models import (
@@ -267,7 +268,7 @@ class _ResolvedCallBinding:
     receiver_class: str | None = None
 
 
-def _body_named_binding(body: list[ast.stmt], name: str) -> _NamedBinding:
+def _binding_from_alternatives(alternatives: tuple[_ScopeBinding, ...]) -> _NamedBinding:
     """Return one final runtime namespace binding, or fail closed.
 
     The shared scope-flow interpreter handles overload stubs followed by a
@@ -275,7 +276,6 @@ def _body_named_binding(body: list[ast.stmt], name: str) -> _NamedBinding:
     A path-dependent final binding is ``unknown`` rather than ``missing``.
     """
 
-    alternatives = _scope_final_bindings(body, _tag_guard_names(body)).get(name, ())
     if not alternatives:
         return _NamedBinding(None, "missing")
     fingerprint = hashlib.sha256(
@@ -301,20 +301,6 @@ def _body_named_binding(body: list[ast.stmt], name: str) -> _NamedBinding:
     if binding.kind in {"alias", "value"}:
         return _NamedBinding(binding.node, "non_callable", fingerprint)
     return _NamedBinding(None, "unknown", fingerprint)
-
-
-def _named_binding(tree: ast.Module, owner: str | None, name: str) -> _NamedBinding:
-    if owner:
-        class_node = _owner_node(tree, owner)
-        if class_node is None:
-            return _NamedBinding(None, "missing")
-        return _body_named_binding(class_node.body, name)
-    return _body_named_binding(tree.body, name)
-
-
-def _named_node(tree: ast.Module, owner: str | None, name: str) -> ast.AST | None:
-    binding = _named_binding(tree, owner, name)
-    return binding.node if binding.status == "exact" else None
 
 
 def _node_fingerprint(node: ast.AST | None) -> str | None:
@@ -566,6 +552,14 @@ class GitSnapshot:
         self._source: dict[str, str | None] = {}
         self._trees: dict[str, ast.Module | None] = {}
         self._bindings: dict[str, dict[str, str]] = {}
+        # These memo tables belong to one immutable Git revision and one
+        # analysis branch. Nothing is persisted or shared between CI runs.
+        self._scopes: dict[ast.Module | ast.ClassDef, dict[str, tuple[_ScopeBinding, ...]]] = {}
+        self._named_bindings: dict[tuple[ast.Module | ast.ClassDef, str], _NamedBinding] = {}
+        self._owners: dict[tuple[ast.Module, str], ast.ClassDef | None] = {}
+        self._endpoints: dict[tuple[str, str | None, str], SourceEndpoint] = {}
+        self._call_endpoints: dict[tuple[str, str, str | None, str | None, str], SourceEndpoint] = {}
+        self._import_presence: dict[tuple[str, str], bool] = {}
         self._keyword_call_candidates: dict[
             tuple[tuple[str, ...], str],
             list[tuple[str, ast.Call, str | None, str]],
@@ -612,6 +606,48 @@ class GitSnapshot:
     def resolve_module(self, module: str) -> str | None:
         return next((candidate for candidate in _module_file(module) if candidate in self.files), None)
 
+    def _scope_bindings(self, scope: ast.Module | ast.ClassDef) -> dict[str, tuple[_ScopeBinding, ...]]:
+        if scope not in self._scopes:
+            self._scopes[scope] = _scope_final_bindings(scope.body, _tag_guard_names(scope.body))
+        return self._scopes[scope]
+
+    def _scope_named_binding(self, scope: ast.Module | ast.ClassDef, name: str) -> _NamedBinding:
+        key = (scope, name)
+        if key not in self._named_bindings:
+            self._named_bindings[key] = _binding_from_alternatives(self._scope_bindings(scope).get(name, ()))
+        return self._named_bindings[key]
+
+    def named_binding(self, tree: ast.Module, owner: str | None, name: str) -> _NamedBinding:
+        if not owner:
+            return self._scope_named_binding(tree, name)
+        key = (tree, owner)
+        if key not in self._owners:
+            self._owners[key] = _owner_node(tree, owner)
+        class_node = self._owners[key]
+        if class_node is None:
+            return _NamedBinding(None, "missing")
+        return self._scope_named_binding(class_node, name)
+
+    def has_import_symbol(self, file_name: str, name: str) -> bool:
+        """Use the import detector's presence rules without building a contract.
+
+        Full endpoints (including fingerprints and return contracts) are still
+        built for findings, so their evidence is unchanged.
+        """
+        key = (file_name, name)
+        if key not in self._import_presence:
+            tree = self.tree(file_name)
+            present = False
+            if tree is not None:
+                alternatives = self._scope_bindings(tree).get(name, ())
+                present = (
+                    len(alternatives) == 1
+                    and alternatives[0].kind in {"function", "class"}
+                    and getattr(alternatives[0].node, "lineno", None) is not None
+                ) or _top_level_import_binding(tree, name) is not None
+            self._import_presence[key] = present
+        return self._import_presence[key]
+
     def _module_bindings(self, file_name: str) -> dict[str, str]:
         normalized = file_name.replace("\\", "/")
         if normalized in self._bindings:
@@ -621,7 +657,7 @@ class GitSnapshot:
         bindings: dict[str, str] = {}
         pending: dict[str, str] = {}
         if tree is not None:
-            final = _scope_final_bindings(tree.body, _tag_guard_names(tree.body))
+            final = self._scope_bindings(tree)
             for name, alternatives in final.items():
                 if len(alternatives) != 1:
                     continue
@@ -661,7 +697,7 @@ class GitSnapshot:
                     elif reference.startswith("vllm."):
                         bindings[name] = reference
                         changed = True
-                    elif _body_named_binding(tree.body, root).status == "exact":
+                    elif self._scope_named_binding(tree, root).status == "exact":
                         bindings[name] = f"{module}.{reference}"
                         changed = True
         self._bindings[normalized] = bindings
@@ -693,7 +729,7 @@ class GitSnapshot:
             tree = self.tree(file_name)
             if tree is None:
                 return _QualifiedBinding(file_name, owner, suffix[-1], None, "unknown")
-            binding = _named_binding(tree, owner, suffix[-1])
+            binding = self.named_binding(tree, owner, suffix[-1])
             return _QualifiedBinding(
                 file_name,
                 owner,
@@ -760,7 +796,7 @@ class GitSnapshot:
                 "unknown",
                 _node_fingerprint(class_node),
             )
-        direct = _body_named_binding(class_node.body, member)
+        direct = self._scope_named_binding(class_node, member)
         if direct.status != "missing":
             return _QualifiedBinding(
                 resolved.file,
@@ -840,7 +876,7 @@ class GitSnapshot:
             if (
                 expression in {"classmethod", "property", "staticmethod"}
                 and (tree := self.tree(file_name)) is not None
-                and _body_named_binding(tree.body, expression).status == "missing"
+                and self._scope_named_binding(tree, expression).status == "missing"
             ):
                 return f"builtins.{expression}"
             return f"{module}.{expression}"
@@ -1039,8 +1075,14 @@ class GitSnapshot:
         return evidence
 
     def endpoint(self, file_name: str, owner: str | None, name: str) -> SourceEndpoint:
+        key = (file_name, owner, name)
+        if key not in self._endpoints:
+            self._endpoints[key] = self._build_endpoint(file_name, owner, name)
+        return self._endpoints[key]
+
+    def _build_endpoint(self, file_name: str, owner: str | None, name: str) -> SourceEndpoint:
         tree = self.tree(file_name)
-        binding = _named_binding(tree, owner, name) if tree is not None else _NamedBinding(None, "unknown")
+        binding = self.named_binding(tree, owner, name) if tree is not None else _NamedBinding(None, "unknown")
         node = binding.node if binding.status == "exact" else None
         return_contract = infer_return_contract(
             node,
@@ -1074,6 +1116,28 @@ class GitSnapshot:
         )
 
     def call_endpoint(
+        self,
+        expression: str,
+        access_kind: str,
+        *,
+        receiver_type: str | None = None,
+        member: str | None = None,
+        invocation_kind: str = "python_call",
+    ) -> SourceEndpoint:
+        # Argument binding and return-use checks remain per call site. Only
+        # the target contract is reusable, with every dispatch input in the key.
+        key = (expression, access_kind, receiver_type, member, invocation_kind)
+        if key not in self._call_endpoints:
+            self._call_endpoints[key] = self._build_call_endpoint(
+                expression,
+                access_kind,
+                receiver_type=receiver_type,
+                member=member,
+                invocation_kind=invocation_kind,
+            )
+        return self._call_endpoints[key]
+
+    def _build_call_endpoint(
         self,
         expression: str,
         access_kind: str,
@@ -1567,7 +1631,10 @@ def _relation_endpoints(
     )
     if _relation_symbol_presence(new_endpoint) is False:
         old_tree = old_snapshot.tree(old_file)
-        old_node = _named_node(old_tree, relation.upstream_owner, relation.upstream_name) if old_tree else None
+        old_binding = (
+            old_snapshot.named_binding(old_tree, relation.upstream_owner, relation.upstream_name) if old_tree else None
+        )
+        old_node = old_binding.node if old_binding is not None and old_binding.status == "exact" else None
         renamed = new_snapshot.unique_rename(
             relation.upstream_file,
             relation.upstream_owner,
@@ -2187,14 +2254,20 @@ class _ImportVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def discover_imports(ascend_root: Path) -> list[ImportReference]:
+def discover_imports(
+    ascend_root: Path,
+    *,
+    trees: dict[str, ast.Module] | None = None,
+) -> list[ImportReference]:
     references: list[ImportReference] = []
     for path in sorted((ascend_root / "vllm_ascend").rglob("*.py")):
         relative = path.relative_to(ascend_root).as_posix()
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
-        except (OSError, SyntaxError, UnicodeError):
-            continue
+        tree = trees.get(relative) if trees is not None else None
+        if tree is None:
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+            except (OSError, SyntaxError, UnicodeError):
+                continue
         visitor = _ImportVisitor(relative)
         visitor.visit(tree)
         references.extend(visitor.references)
@@ -2206,11 +2279,7 @@ def discover_imports(ascend_root: Path) -> list[ImportReference]:
     return [unique[key] for key in ordered]
 
 
-def _top_level_symbol(snapshot: GitSnapshot, file_name: str, name: str) -> SourceEndpoint:
-    endpoint = snapshot.endpoint(file_name, None, name)
-    if endpoint.line is not None:
-        return endpoint
-    tree = snapshot.tree(file_name)
+def _top_level_import_binding(tree: ast.Module | None, name: str) -> int | None:
     if tree is not None:
         for node in tree.body:
             names: list[str] = []
@@ -2220,7 +2289,17 @@ def _top_level_symbol(snapshot: GitSnapshot, file_name: str, name: str) -> Sourc
             elif isinstance(node, (ast.Import, ast.ImportFrom)):
                 names = [alias.asname or alias.name.rsplit(".", 1)[-1] for alias in node.names]
             if name in names:
-                return SourceEndpoint(file=file_name, owner=None, name=name, line=node.lineno)
+                return node.lineno
+    return None
+
+
+def _top_level_symbol(snapshot: GitSnapshot, file_name: str, name: str) -> SourceEndpoint:
+    endpoint = snapshot.endpoint(file_name, None, name)
+    if endpoint.line is not None:
+        return endpoint
+    line = _top_level_import_binding(snapshot.tree(file_name), name)
+    if line is not None:
+        return SourceEndpoint(file=file_name, owner=None, name=name, line=line)
     return SourceEndpoint(file=None, owner=None, name=name)
 
 
@@ -2229,9 +2308,11 @@ def _import_findings(
     old_snapshot: GitSnapshot,
     new_snapshot: GitSnapshot,
     old_to_new: dict[str, str],
+    *,
+    trees: dict[str, ast.Module] | None = None,
 ) -> list[RangeFinding]:
     findings: list[RangeFinding] = []
-    for reference in discover_imports(ascend_root):
+    for reference in discover_imports(ascend_root, trees=trees):
         old_file = old_snapshot.resolve_module(reference.module)
         new_file = new_snapshot.resolve_module(reference.module)
         # For ``import vllm; vllm.a.b.symbol`` resolve the longest module prefix.
@@ -2257,6 +2338,10 @@ def _import_findings(
             old_endpoint = SourceEndpoint(file=old_file, owner=None, name=None)
             new_endpoint = SourceEndpoint(file=new_file, owner=None, name=None)
         elif symbol and "." not in symbol:
+            if not old_snapshot.has_import_symbol(old_file, symbol):
+                continue
+            if new_file is not None and new_snapshot.has_import_symbol(new_file, symbol):
+                continue
             old_endpoint = _top_level_symbol(old_snapshot, old_file, symbol)
             new_endpoint = (
                 _top_level_symbol(new_snapshot, new_file, symbol)
@@ -2701,6 +2786,7 @@ def analyze_range(
             GitSnapshot(vllm_root, old_sha),
             GitSnapshot(vllm_root, new_sha),
             old_to_new,
+            trees={module.file: module.tree for module in generator.downstream.modules.values()},
         )
         return branch_findings, time.perf_counter() - started
 


### PR DESCRIPTION
### What this PR does / why we need it?

Reduce repeated work in the CI-only vLLM PR compatibility analyzer introduced by #14560, and fix import-presence checks for deleted or annotation-only names. Changes stay under `tests/e2e/vllm_interface/`.

The pytest entry, PR base/head resolution, complete source indexing, three analysis branches, deterministic summary, and failure policy remain in place. No persistent cache, pickle files, new environment variables, additional CI jobs, or main2main/monkey-patch analysis are introduced.

#### Execution flow and implementation details

1. **Resolve and verify inputs.** The existing pytest entry resolves the vLLM PR base/head and records the vllm-ascend revision. Commit and checkout verification remains enabled.
2. **Index source trees.** `InterfaceBoundaryGenerator` indexes the complete source trees and finalizes the indexes. Single-path namespace merges copy an already-normalized state instead of repeatedly rebuilding sorted keys and alternative sets. State dictionaries remain independent; immutable binding tuples can be shared.
3. **Resolve aliases and namespace states.** `RepositoryIndex.canonical_name()` checks successively shorter dot-delimited prefixes in the live alias table instead of sorting/scanning every alias per lookup. Longest-prefix behavior and cycle protection remain. Always-bound module names are derived from the final namespace already computed. Decorator and direct-call resolution reuse identical statement-prefix states through a per-module, 256-entry LRU keyed by actual AST statements and guard names. The memo returns independent dictionaries; expression resolution and caller-specific fallback still run for each query. It is not shared across revisions or CI runs.
4. **Discover dependencies.** Override and exact-call discovery retains affected call sites and inherited implementation locations. Import discovery reuses the already-parsed vllm-ascend ASTs, with a source-reading fallback for files absent from the index. Triton launch invocation kinds remain distinct.
5. **Read base/head source.** Each analysis branch retains separate base/head `GitSnapshot` instances. Each snapshot lazily uses one `git cat-file --batch` process rather than launching `git show` per file. Binary response framing preserves empty files, CRLF and non-ASCII source. Invalid or failed reads raise analysis errors, not missing-symbol findings. An `ExitStack` closes processes and temporary stderr streams on success or exceptions. This is not a persistent source cache.
6. **Resolve contracts and compare usage.** Snapshots reuse module/class namespace states, named bindings, owner lookup and resolved API contracts. Call-contract keys include target expression, access kind, receiver type, member and invocation kind. Argument binding and return-use checks still execute separately at every call site; one site's compatibility result is never reused for another.
7. **Check import presence.** Import checks resolve presence before constructing unused signature/return details. Presence now follows the final namespace: a later `del` removes a binding; an annotation without a value does not create a name or erase an existing value. Constants and re-exports that remain bound are retained. A P1 requires proven presence at the base and proven absence at the head. Ambiguous bindings, star imports, dynamic module exports and unparseable source are not treated as proven removals. Package-submodule fallback is preserved. Full endpoint details are still built for findings.
8. **Merge and print.** The three branches merge and sort findings deterministically. The CI entry prints the summary directly; it does not create report artifacts. Historical findings remain subject to the existing PR-only filtering policy.

### Does this PR introduce _any_ user-facing change?

Reduced analyzer runtime and more accurate detection of imports whose names were deleted or became annotation-only. This is therefore not exclusively a performance-only change. Analyzer version advances to `2.1.1`. CLI options and CI log wording are unchanged; existing dynamic-dispatch and return-dataflow limitations remain.

### How was this patch tested?

#### Local regressions

- 123 local tests passed: Git batch-reader lifecycle/error handling, alias equivalence, final import bindings, callable/return contracts, serial/parallel fixture equivalence, pytest-entry integration, and scope-prefix isolation/eviction.
- Included 12,000 synthetic alias comparisons and 196 generated scope-flow combinations. Deleted and annotation-only imports were exercised through actual CLI runs against temporary Git repositories.
- The pytest integration fixtures launch the analyzer subprocess; the analyzer is not mocked. Historical replay scans described below call the analyzer core directly, not the hardware E2E suite.
- Ruff, formatting, compileall and mypy checks passed in local validation. Full repository formatting was previously attempted; some hooks require Linux shell tools unavailable on this Windows host. Full Linux CI and NPU workloads are not claimed as locally verified.
- Regression/replay harnesses remain outside the E2E collection path, as requested; no analyzer unit-test directory is reintroduced into vLLM PR jobs.

#### Latest paired performance measurement

Windows / Python 3.11, four indexing processes and three analysis threads, fixed source SHAs, fresh processes, sequential scans and no persistent analyzer cache. Times below are analyzer time, excluding network range discovery and hardware tests.

| vLLM PR | Before latest scope reuse | After | Reduction | Result on both sides |
| --- | ---: | ---: | ---: | --- |
| #39568 | 73.6 s | 61.9 s | 15.9% | 1 P1 |
| #50685 | 100.3 s | 82.0 s | 18.2% | 3 P1 impacts / 1 root cause |
| #50620 | 100.4 s | 81.8 s | 18.5% | PASS |

This baseline already includes the earlier Git batching, alias optimization and import fix; it is **not** the original pre-optimization implementation. Full reports matched after removing only timing metadata, stdout matched byte-for-byte, and expected exit codes were 1/1/0. These are single paired measurements, not statistical benchmarks or Linux CI speed guarantees.

#### Expanded accuracy replay

Eight additional cases were each run against the frozen pre-scope-reuse baseline and current code: 16 actual scans. All eight full reports matched except timing, and all eight stdout logs were byte-identical.

| Fixed historical input | P1 impacts | P1 roots | Review findings |
| --- | ---: | ---: | ---: |
| vllm-ascend #11709 range | 5 | 5 | 6 |
| vllm-ascend #12020 range | 2 | 1 | 0 |
| vllm-ascend #12420 range | 0 | 0 | 0 |
| vllm-ascend #12502 range | 33 | 20 | 0 |
| vllm-ascend #12648 range | 0 | 0 | 5 |
| vllm-ascend #13358 range | 5 | 4 | 11 |
| vLLM #47808 | 2 | 2 | 5 |
| vLLM #50504 | 0 | 0 | 0 |

The upgrade ranges are fixed CI-analyzer inputs, not a full main2main mode. #12648 uses its adapted vllm-ascend head; the other upgrade cases use their pre-adaptation baselines. The earlier three cases above were reused only after verifying current source hashes, giving 11 distinct cases overall. There were not 22 new scans in the expanded round.

29 semantic/history assertions passed. Previously confirmed P1 findings remained. #47808 matches the newer August 28 historical log (2 P1), not the older August 17 report (1 P1). #11709's six review items already existed in the frozen baseline; they are not introduced by scope reuse.

Known limitations are not hidden by these results: #12648's `compute_slot_mappings(out=...)` remains review-only because its dispatch requires monkey-patch/field propagation; broader return-value consumption is still outside the exact dependency model. Regression equivalence does not establish universal precision/recall.

#### Fresh verification of the published PR head

After pushing commit `2e31d3bcbdc82960bc0a1956abdd412f6ef1f27b`, fetched `refs/pull/16364/head` from `vllm-project/vllm-ascend` and checked it out in a separate, clean detached worktree. The fetched commit and all nine analyzer source hashes matched the validated version.

Three additional fresh scans used that fetched code:

| vLLM PR | Result | Analyzer time | Process wall time | Exit code |
| --- | --- | ---: | ---: | ---: |
| #39568 | 1 P1 | 59.8 s | 61.0 s | 1 |
| #50685 | 3 P1 impacts / 1 root cause | 82.2 s | 83.7 s | 1 |
| #50620 | PASS | 79.8 s | 81.3 s | 0 |

All three complete reports were identical to the pre-push reports after excluding only timing metadata; raw stdout was byte-identical. Exit 1 is the expected detected-break outcome, not an analyzer crash. These runs are separate from the earlier paired measurements and expanded regression round.

The 123 local tests passed again before pushing. Ruff, formatting, spelling and Markdown checks passed; several shell-based repository hooks could not execute on Windows. The fetched code also passed mypy with the Python 3.10/Linux target. This is static type checking, not execution on Linux.

These historical scans execute `analyze_range()` and the production summary renderer directly. They do not run the full upstream pytest job or NPU workloads. The actual pytest entry is covered separately by the local integration fixtures.

Published-head verification details: https://github.com/vllm-project/vllm-ascend/pull/16364#issuecomment-5634503539

#### Reproduce a pinned case

With this PR's analyzer checked out, prepare separate clean source worktrees at the following head/revision:

| vLLM PR | vLLM base | vLLM head | vllm-ascend revision |
| --- | --- | --- | --- |
| #39568 | `ce29c26b31d432b1b4bc028c46bb2c3b07a667d8` | `c7560af42487b1570c4e6f4cea5df1605a4d59fc` | `60f0238b0eec4c91fe466497ae8862daf521aecc` |
| #50685 | `1be36283678a9a94fc8fdaad6c95c2896d6b4015` | `c05d75aaa95cf89f547503044c1921625905085d` | `f258cbbd898f2b05f38d96b20d1530d5e10f7923` |
| #50620 | `c05d75aaa95cf89f547503044c1921625905085d` | `653cc6faca6885e36760bf35a25bb63442519b14` | `f258cbbd898f2b05f38d96b20d1530d5e10f7923` |

The analyzer checkout supplies the tool; `--vllm-root` and `--ascend-root` supply the pinned source trees being analyzed. They do not need to be the analyzer checkout itself. Existing repositories can be reused when the head/revision and required base objects match the table; no model installation or NPU is required for this static CLI scan.

For example, run #39568 from this PR's analyzer checkout after preparing the two source paths at the revisions above:

```bash
VLLM_INTERFACE_TIMINGS=1 python -u -m tests.e2e.vllm_interface.vllm_interface_contracts analyze-range \
  --vllm-root /path/to/vllm-source \
  --ascend-root /path/to/vllm-ascend-source \
  --old ce29c26b31d432b1b4bc028c46bb2c3b07a667d8 \
  --new c7560af42487b1570c4e6f4cea5df1605a4d59fc \
  --expect-ascend-sha 60f0238b0eec4c91fe466497ae8862daf521aecc \
  --index-workers 4 --analysis-workers 3 --fail-on introduced
```

PowerShell equivalent (replace the two source directory paths):

```powershell
$env:VLLM_INTERFACE_TIMINGS = "1"
python -u -m tests.e2e.vllm_interface.vllm_interface_contracts analyze-range `
  --vllm-root "C:\path\to\vllm-source" `
  --ascend-root "C:\path\to\vllm-ascend-source" `
  --old ce29c26b31d432b1b4bc028c46bb2c3b07a667d8 `
  --new c7560af42487b1570c4e6f4cea5df1605a4d59fc `
  --expect-ascend-sha 60f0238b0eec4c91fe466497ae8862daf521aecc `
  --index-workers 4 --analysis-workers 3 --fail-on introduced
Write-Host "Analyzer exit code: $LASTEXITCODE"
```

Timing diagnostics are printed as phases finish, followed by the compatibility summary; this is not per-file progress. #39568 reports `BREAKS FOUND`: vLLM removes `SchedulerInterface._get_routed_experts`, still called at `vllm_ascend/core/recompute_scheduler.py:907` in the pinned baseline. Expected exit: 1 for #39568/#50685 (detected P1), 0 for #50620.

These commands use the PR's CLI, not pytest: they bypass PR-range network discovery and parent `conftest.py` dependency loading while exercising the same analysis engine. Base objects must already exist locally to avoid Git fetching missing objects. The SHAs are replay inputs, not analyzer constants. Raw logs and full comparison evidence are retained locally; the CI entry itself still prints logs without creating report artifacts.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
