### PR TITLE
[Perf][MoE] Fuse GELU-tanh activation on Ascend 950

### DIFF
--- a/benchmarks/benchmark_gemma4_geglu.py
+++ b/benchmarks/benchmark_gemma4_geglu.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Compare Gemma4's unfused and A5 fused activation using device graph timing.
+
+Example: ASCEND_RT_VISIBLE_DEVICES=2 python benchmarks/benchmark_gemma4_geglu.py
+Results cover only activation (optionally followed by MXFP4 quantization),
+not a full expert layer or end-to-end serving throughput.
+"""
+
+import argparse
+import json
+import statistics
+
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.device.device_config import is_950
+from vllm_ascend.utils import enable_custom_op
+
+
+@torch.inference_mode()
+def measure(fn, x, with_quant, iterations, repeats):
+    def compute():
+        y = fn(x)
+        if with_quant:
+            return torch_npu.npu_dynamic_mx_quant(y, dst_type=torch_npu.float4_e2m1fn_x2)
+        return y
+
+    for _ in range(5):
+        compute()
+    torch.npu.synchronize()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        for _ in range(iterations):
+            compute()
+    graph.replay()
+    torch.npu.synchronize()
+    durations = []
+    for _ in range(repeats):
+        start = torch.npu.Event(enable_timing=True)
+        end = torch.npu.Event(enable_timing=True)
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        durations.append(start.elapsed_time(end) * 1000 / iterations)
+    return statistics.median(durations)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, nargs="+", default=[1, 8, 32, 128, 512])
+    parser.add_argument("--width", type=int, default=704)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--repeats", type=int, default=7)
+    args = parser.parse_args()
+    if min(*args.rows, args.width, args.iterations, args.repeats) <= 0:
+        parser.error("rows, width, iterations, and repeats must be positive")
+    if not is_950():
+        parser.error("this benchmark requires Ascend 950")
+    torch.npu.set_device(0)
+    enable_custom_op()
+    # Import ops first to avoid the existing
+    # device_op -> ops -> moe_mlp -> device_op import cycle.
+    import vllm_ascend.ops  # noqa: F401
+    from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+    torch.manual_seed(0)
+    for rows in args.rows:
+        x = torch.randn(rows, 2 * args.width, dtype=torch.bfloat16).npu()
+        for with_quant in (False, True):
+            native = measure(BaseDeviceAdaptor.gelu_tanh_and_mul, x, with_quant, args.iterations, args.repeats)
+            fused = measure(A5DeviceAdaptor.gelu_tanh_and_mul, x, with_quant, args.iterations, args.repeats)
+            print(
+                json.dumps(
+                    {
+                        "rows": rows,
+                        "width": args.width,
+                        "with_mxfp4_quant": with_quant,
+                        "native_us": native,
+                        "fused_us": fused,
+                        "speedup": native / fused,
+                    }
+                ),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/tutorials/models/Gemma4.md
+++ b/docs/source/tutorials/models/Gemma4.md
@@ -260,6 +260,15 @@ Recommended tuning order:
 | Piecewise ACLGraph | `--compilation-config '{"cudagraph_mode": "PIECEWISE"}'` | Enables segmented graph execution. | Supported when piecewise graph execution is required. |
 | Tensor parallelism | `--tensor-parallel-size` | Splits model computation across multiple NPUs. | Adjust according to model size and available devices. |
 | Expert parallelism | `--enable-expert-parallel` | Distributes experts for MoE variants. | Enable only for MoE deployment plans that use EP. |
+| Fused GeGLU on Ascend 950 | Automatic for MoE `gelu_tanh` activation. | Combines GELU-tanh and multiplication in one operator. | Preserves the original expert dimensions; MXFP activation quantization remains a separate step. |
+
+To compare the unfused and fused activation, including the following MXFP4 quantization step, run this benchmark from the repository root on Ascend 950:
+
+```bash
+python benchmarks/benchmark_gemma4_geglu.py --rows 1 8 32 128 512 --width 704
+```
+
+The benchmark reports median device times under graph replay. These measurements cover the activation segment only; use a serving benchmark to measure end-to-end performance. GeGLU fusion does not enable MegaMoE or require `enable_fused_mc2`.
 
 ## 10 FAQ
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gemma4_geglu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gemma4_geglu.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Gemma4 expert activation, including TP partitions and ACLGraph replay."""
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.device.device_config import is_950
+from vllm_ascend.device.device_op import A5DeviceAdaptor
+
+pytestmark = pytest.mark.skipif(not is_950(), reason="A5 GeGlu implementation")
+
+
+def _reference(x):
+    gate, up = x.float().chunk(2, dim=-1)
+    return (torch.nn.functional.gelu(gate, approximate="tanh") * up).to(x.dtype)
+
+
+def _assert_close(actual, expected):
+    tolerance = max(2 * torch.finfo(actual.dtype).eps, 1e-5)
+    torch.testing.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+
+
+@pytest.mark.parametrize("width", [176, 352, 704])
+@pytest.mark.parametrize("rows", [0, 1, 8, 32, 128])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@torch.inference_mode()
+def test_gemma4_geglu(width, rows, dtype):
+    generator = torch.Generator().manual_seed(0)
+    x = (torch.randn(rows, 2 * width, generator=generator) * 3).to(dtype).npu()
+    actual = A5DeviceAdaptor.gelu_tanh_and_mul(x)
+    assert actual.shape == (rows, width)
+    _assert_close(actual, _reference(x))
+
+
+@pytest.mark.parametrize("strided", [False, True])
+@torch.inference_mode()
+def test_gemma4_geglu_batched_input(strided):
+    x = torch.randn(2, 3, 2816, dtype=torch.bfloat16).npu()
+    x = x[..., ::2] if strided else x[..., :1408].contiguous()
+    actual = A5DeviceAdaptor.gelu_tanh_and_mul(x)
+    _assert_close(actual, _reference(x))
+
+
+@torch.inference_mode()
+def test_gemma4_geglu_mxfp4_graph_replay():
+    x = torch.randn(8, 1408, dtype=torch.bfloat16).npu()
+
+    def compute():
+        activated = A5DeviceAdaptor.gelu_tanh_and_mul(x)
+        return torch_npu.npu_dynamic_mx_quant(activated, dst_type=torch_npu.float4_e2m1fn_x2)
+
+    for _ in range(3):
+        compute()
+    torch.npu.synchronize()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_quant, graph_scale = compute()
+    # A second input checks that replay reads current data, not capture values.
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    eager_quant, eager_scale = compute()
+    torch.npu.synchronize()
+    torch.testing.assert_close(graph_quant.view(torch.uint8), eager_quant.view(torch.uint8), rtol=0, atol=0)
+    torch.testing.assert_close(graph_scale.view(torch.uint8), eager_scale.view(torch.uint8), rtol=0, atol=0)

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,8 +1,32 @@
 from unittest import mock
 
+import pytest
 import torch
 
-from vllm_ascend.device.device_op import BaseDeviceAdaptor
+from vllm_ascend.device.device_op import A5DeviceAdaptor, Ascend310PDeviceAdaptor, BaseDeviceAdaptor
+
+
+@pytest.mark.parametrize("adaptor", [BaseDeviceAdaptor, Ascend310PDeviceAdaptor])
+@pytest.mark.parametrize("rows", [0, 3])
+def test_gelu_tanh_and_mul_fallback(adaptor, rows):
+    # Distinct halves catch accidentally activating up instead of gate.
+    x = torch.linspace(-3, 5, rows * 1408).reshape(rows, 1408)
+    gate, up = x.chunk(2, dim=-1)
+    expected = torch.nn.functional.gelu(gate, approximate="tanh") * up
+    torch.testing.assert_close(adaptor.gelu_tanh_and_mul(x), expected)
+
+
+def test_a5_gelu_tanh_and_mul_activates_gate_and_discards_auxiliary_output():
+    x = torch.randn(3, 1408)
+    expected = torch.randn(3, 704)
+    with mock.patch(
+        "vllm_ascend.device.device_op.torch_npu.npu_geglu",
+        create=True,
+        return_value=(expected, torch.empty_like(expected)),
+    ) as geglu:
+        out = A5DeviceAdaptor.gelu_tanh_and_mul(x)
+    geglu.assert_called_once_with(x, dim=-1, approximate=1, activate_left=True)
+    assert out is expected
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -521,11 +521,14 @@ class TestUnifiedApplyActivation(unittest.TestCase):
 
     def test_gelu_tanh_matches_torch_reference(self):
         hidden_states = torch.randn(4, 8)
-        out = _unified_apply_activation(
-            _mlp_compute_input(activation=MoEActivation.GELU_TANH), hidden_states.clone(), self._quant_method()
-        )
         gate, up = hidden_states.chunk(2, dim=-1)
-        self.assertTrue(torch.allclose(out, torch.nn.functional.gelu(gate, approximate="tanh") * up))
+        expected = torch.nn.functional.gelu(gate, approximate="tanh") * up
+        with patch(f"{MOE_MLP}.DeviceOperator.gelu_tanh_and_mul", return_value=expected) as activation:
+            out = _unified_apply_activation(
+                _mlp_compute_input(activation=MoEActivation.GELU_TANH), hidden_states, self._quant_method()
+            )
+        activation.assert_called_once_with(hidden_states)
+        self.assertIs(out, expected)
 
     def test_situ_matches_reference(self):
         hidden_states = torch.randn(4, 8)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -288,6 +288,11 @@ class BaseDeviceAdaptor:
         )[0]
 
     @staticmethod
+    def gelu_tanh_and_mul(hidden_states: torch.Tensor) -> torch.Tensor:
+        gate, up = hidden_states.chunk(2, dim=-1)
+        return F.gelu(gate, approximate="tanh") * up
+
+    @staticmethod
     def clipped_swiglu(
         hidden_states: torch.Tensor,
         swiglu_limit: float,
@@ -771,6 +776,13 @@ class BaseDeviceAdaptor:
 
 
 class A5DeviceAdaptor(BaseDeviceAdaptor):
+    @staticmethod
+    def gelu_tanh_and_mul(hidden_states: torch.Tensor) -> torch.Tensor:
+        # Gemma's packed projection stores gate before up. GeGlu activates
+        # the right half by default, so activate_left must be explicit.
+        out, _ = torch_npu.npu_geglu(hidden_states, dim=-1, approximate=1, activate_left=True)
+        return out
+
     @classmethod
     def npu_fused_infer_attention_score(
         cls,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -85,8 +85,7 @@ def _unified_apply_activation(
         gate, up = hidden_states.chunk(2, dim=-1)
         hidden_states = torch.nn.functional.gelu(gate) * up
     elif activation == MoEActivation.GELU_TANH:
-        gate, up = hidden_states.chunk(2, dim=-1)
-        hidden_states = torch.nn.functional.gelu(gate, approximate="tanh") * up
+        hidden_states = DeviceOperator.gelu_tanh_and_mul(hidden_states)
     else:
         if mlp_compute_input.swiglu_limit > 0:
             gate, up = hidden_states.chunk(2, dim=-1)


### PR DESCRIPTION
### What this PR does / why we need it?

Gemma4 MoE's `GELU_TANH` activation currently evaluates GELU and multiplication separately. Route this activation through the device adaptor and use `torch_npu.npu_geglu` on Ascend 950, explicitly activating the left (gate) half of the packed projection. Other devices retain the existing implementation.

The change preserves expert dimensions and the separate MXFP activation quantization step. It adds fallback/routing unit tests, NPU numerical and graph-replay tests, an activation benchmark, and documentation. It does not enable MegaMoE / `enable_fused_mc2`.

### Does this PR introduce _any_ user-facing change?

Ascend 950 automatically uses fused GeGLU for MoE GELU-tanh activations; no new configuration is required. Fusion changes intermediate rounding, so bitwise equivalence with the unfused BF16 path is not guaranteed. End-to-end accuracy and performance comparison remain pending; this PR is a draft.

### How was this patch tested?

On Ascend 950DT, with PyTorch 2.10.0 and torch_npu 2.10.0.post4:

```bash
python -m pytest -q tests/ut/device/test_device_op.py tests/ut/ops/test_moe_mlp.py
# 38 passed
python -m pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/test_gemma4_geglu.py
# 48 passed
```

NPU coverage includes FP16/BF16/FP32, empty inputs, expert widths 176/352/704, multidimensional/noncontiguous inputs, and GeGLU followed by MXFP4 quantization under graph replay with updated input. Width coverage alone does not establish distributed TP/EP support.

Real Gemma4 26B-A4B quantized weights (MoE W4A4_MXFP4, vision W8A8_MXFP8) passed six text smoke assertions, a red-image recognition request, and two 128-token decode requests using TP1 and FULL_DECODE_ONLY graph mode. The integration environment used vLLM `2cf0a69` and vllm-ascend `a18ecba30` with this runtime patch applied; the PR itself is based on upstream main `9e5fc3dcf`.

Service parameters: `--tensor-parallel-size 1 --max-model-len 131072 --max-num-seqs 16 --max-num-batched-tokens 2048 --gpu-memory-utilization 0.8 --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8,16]}'`. Actual 128k requests and 16 concurrent 128k sequences were not tested.

Ruff check/format, markdownlint and `git diff --check` passed. Full `bash format.sh ci` was attempted but blocked during pre-commit Go toolchain installation by `BadZipFile: File is not a zip file`; it still needs a successful run in CI/Linux.

Pending before ready for review: representative text/multimodal accuracy A/B, warmed end-to-end performance A/B and profiling, broader deployment/hardware regression coverage, and full formatting checks. No end-to-end speedup is claimed from the smoke tests.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
