### PR TITLE
[Doc][Model] Add Qwen3.8 Flash-Next deployment tutorial

### DIFF
--- a/docs/hooks/nav_titles.py
+++ b/docs/hooks/nav_titles.py
@@ -159,6 +159,10 @@ TITLES = {
         "zh": "Qwen3-Dense(0.6B/1.7B/4B/8B/14B/32B)",
     },
     "tutorials/models/Qwen3-Next.md": {"en": "Qwen3-Next", "zh": "Qwen3-Next"},
+    "tutorials/models/Qwen3.8-Flash-Next.md": {
+        "en": "Qwen3.8-Flash-Next",
+        "zh": "Qwen3.8-Flash-Next",
+    },
     "tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md": {
         "en": "Qwen3-Omni-30B-A3B-Thinking",
         "zh": "Qwen3-Omni-30B-A3B-Thinking",

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -1,0 +1,308 @@
+# Qwen3.8-Flash-Next
+
+## 1 Introduction
+
+Qwen3.8-Flash-Next is a multimodal Mixture-of-Experts (MoE) model and an experimental preview of the architecture that will underpin Qwen4. Its language model combines Gated DeltaNet and Qwen Sparse Attention (QSA), gated residual connections, Position Learning Enhancement (PLE), and a native Multi-Token Prediction (MTP) head.
+
+This tutorial describes the validated W8A8, language-model-only deployment on Ascend NPUs. The current vLLM Ascend implementation supports **Atlas 800 A3 only**. Atlas 800 A2 and Atlas inference products are not supported by this implementation.
+
+!!! warning
+
+    Automatic Prefix Caching is currently unavailable for Qwen3.8-Flash-Next. Keep `--no-enable-prefix-caching` in the startup command. Do not enable Prefix Caching for this model.
+
+## 2 Supported Features
+
+The following table summarizes the features covered by this tutorial.
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Hardware | Supported | Atlas 800 A3 only |
+| Text generation | Supported | Validated with an Ascend-compatible W8A8 checkpoint |
+| Tensor parallelism | Supported | TP8 is used in the validated configuration |
+| Expert parallelism | Supported | Enabled with `--enable-expert-parallel` |
+| MTP speculative decoding | Supported | Uses `qwen3_5_mtp` with three speculative tokens |
+| Full Decode ACLGraph | Supported | Uses `FULL_DECODE_ONLY`; the MTP proposer remains eager |
+| Function calling | Supported | Uses `qwen3_xml` |
+| Reasoning parsing | Supported | Uses `qwen3` |
+| Automatic Prefix Caching | **Unsupported** | `--no-enable-prefix-caching` is required |
+| Multimodal input | Not covered | The validated command uses `--language-model-only` |
+
+Refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the general model support matrix and the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration.
+
+## 3 Prerequisites
+
+### 3.1 Hardware
+
+The validated deployment uses eight NPUs on one Atlas 800 A3 node with DP1 × TP8. The example selects devices 8 through 15; replace `ASCEND_RT_VISIBLE_DEVICES` with any eight available A3 device IDs when necessary.
+
+### 3.2 Model Weight
+
+Download the original [Qwen3.8-Flash-Next model weight](https://modelscope.cn/models/Qwen/Qwen3.8-Flash-Next), then prepare an Ascend-compatible W8A8 checkpoint. The deployment below was validated with the W8A8 checkpoint and therefore requires `--quantization ascend`.
+
+Mount or copy the checkpoint into the container and set `MODEL_PATH` to its local path, for example:
+
+```bash
+export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
+```
+
+## 4 Installation
+
+### 4.1 Docker Image Installation
+
+Use the A3 image variant. The following command exposes all 16 devices on an Atlas 800 A3 node so that a group of eight can be selected inside the container.
+
+```bash
+export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+
+docker run --rm \
+    --name vllm-ascend-qwen38-flash-next \
+    --shm-size=1g \
+    --net=host \
+    --device /dev/davinci0 \
+    --device /dev/davinci1 \
+    --device /dev/davinci2 \
+    --device /dev/davinci3 \
+    --device /dev/davinci4 \
+    --device /dev/davinci5 \
+    --device /dev/davinci6 \
+    --device /dev/davinci7 \
+    --device /dev/davinci8 \
+    --device /dev/davinci9 \
+    --device /dev/davinci10 \
+    --device /dev/davinci11 \
+    --device /dev/davinci12 \
+    --device /dev/davinci13 \
+    --device /dev/davinci14 \
+    --device /dev/davinci15 \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/Ascend/driver/tools/hccn_tool:/usr/local/Ascend/driver/tools/hccn_tool \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /path/to/models:/models \
+    -it "$IMAGE" bash
+```
+
+After entering the container, verify the installation:
+
+```bash
+pip show vllm vllm-ascend
+```
+
+### 4.2 Source Code Installation
+
+Alternatively, install the release branch from source. The vLLM version must match the version required by vLLM Ascend.
+
+```bash
+git clone --branch releases/v0.26.0rc https://github.com/vllm-project/vllm-ascend.git
+cd vllm-ascend
+pip install -e .
+pip show vllm vllm-ascend
+```
+
+For complete environment preparation instructions, refer to [Installation](../../installation.md).
+
+## 5 Online Service Deployment
+
+### 5.1 Single-Node Online Deployment
+
+The following DP1 × TP8 command was validated with an Ascend-compatible W8A8 checkpoint on Atlas 800 A3. It enables QSA Lightning Indexer and QSA Expand E3, MTP speculative decoding, Function Calling, and reasoning parsing.
+
+```bash
+unset CPLUS_INCLUDE_PATH CPATH C_INCLUDE_PATH
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
+export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
+export VLLM_ASCEND_ENABLE_QSA_LIGHTNING_INDEXER=1
+export VLLM_ASCEND_ENABLE_QSA_E3V=1
+unset VLLM_ASCEND_FORCE_QSA_REFERENCE
+
+vllm serve "$MODEL_PATH" \
+    --host 0.0.0.0 \
+    --port 8088 \
+    --served-model-name qwen3.8-flash-next \
+    --trust-remote-code \
+    --quantization ascend \
+    --tensor-parallel-size 8 \
+    --data-parallel-size 1 \
+    --data-parallel-size-local 1 \
+    --data-parallel-start-rank 0 \
+    --enable-expert-parallel \
+    --max-model-len 135168 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 4096 \
+    --gpu-memory-utilization 0.95 \
+    --no-enable-prefix-caching \
+    --language-model-only \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_xml \
+    --reasoning-parser qwen3 \
+    --compilation-config '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32],"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}' \
+    --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
+```
+
+Key parameter descriptions:
+
+- `VLLM_ASCEND_ENABLE_QSA_LIGHTNING_INDEXER=1` enables the fused QSA Lightning Indexer path.
+- `VLLM_ASCEND_ENABLE_QSA_E3V=1` enables the fused QSA Expand E3 path.
+- `--quantization ascend` loads the Ascend-compatible W8A8 checkpoint.
+- `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the validated single-DP TP8 topology.
+- `--enable-expert-parallel` enables expert parallelism for the MoE layers.
+- `--no-enable-prefix-caching` is mandatory because Prefix Caching is currently unavailable for this model.
+- `--language-model-only` skips the vision encoder; this tutorial covers text serving only.
+- `--enable-auto-tool-choice --tool-call-parser qwen3_xml` enables automatic Function Calling with the Qwen3 XML parser.
+- `--reasoning-parser qwen3` separates reasoning from the final answer in the OpenAI-compatible response.
+- `--speculative-config` uses the model's MTP head to draft three tokens. `enforce_eager=true` keeps the MTP proposer in eager mode.
+- `--compilation-config` enables `FULL_DECODE_ONLY` ACLGraph for decode.
+- `fuse_norm_quant=false` selects the validated norm and quantization path for this W8A8 deployment.
+
+When the service is ready, the log contains `Application startup complete`. You can also check the model endpoint:
+
+```bash
+curl -sf http://127.0.0.1:8088/v1/models
+```
+
+## 6 Functional Verification
+
+### 6.1 Basic Chat Completion
+
+```bash
+curl http://127.0.0.1:8088/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.8-flash-next",
+        "messages": [
+            {"role": "user", "content": "Who are you?"}
+        ],
+        "max_tokens": 1024,
+        "temperature": 0
+    }'
+```
+
+Expected result: the service returns HTTP 200 and a non-empty `choices` field.
+
+### 6.2 Function Calling
+
+Function Calling requires the following startup options, which are already included in Section 5:
+
+```text
+--enable-auto-tool-choice --tool-call-parser qwen3_xml
+```
+
+Send a request containing the available tools and set `tool_choice` to `auto`:
+
+```bash
+curl http://127.0.0.1:8088/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.8-flash-next",
+        "messages": [
+            {
+                "role": "user",
+                "content": "What is the weather in Beijing?"
+            }
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "City name"
+                            }
+                        },
+                        "required": ["city"]
+                    }
+                }
+            }
+        ],
+        "tool_choice": "auto",
+        "max_tokens": 1024,
+        "temperature": 0
+    }'
+```
+
+When the model chooses the function, the parsed result appears in `choices[0].message.tool_calls`. The caller must execute the function and send its result back to the model in a follow-up message.
+
+### 6.3 Reasoning Parser and Thinking Control
+
+Reasoning parsing requires the following startup option, which is already included in Section 5:
+
+```text
+--reasoning-parser qwen3
+```
+
+Qwen3.8-Flash-Next uses thinking mode by default. To request reasoning explicitly, set `enable_thinking` to `true` (or omit it). The parser returns the reasoning separately from the final answer:
+
+```bash
+curl http://127.0.0.1:8088/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.8-flash-next",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Who are you?"
+            }
+        ],
+        "max_tokens": 1024,
+        "temperature": 0,
+        "top_p": 1,
+        "chat_template_kwargs": {
+            "enable_thinking": true
+        }
+    }'
+```
+
+The final answer is returned in `choices[0].message.content`, while the parsed reasoning is returned separately in the reasoning field of the response.
+
+To disable thinking and request a direct answer, use the validated non-thinking request:
+
+```bash
+curl http://127.0.0.1:8088/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.8-flash-next",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Who are you?"
+            }
+        ],
+        "max_tokens": 1024,
+        "temperature": 0,
+        "top_p": 1,
+        "chat_template_kwargs": {
+            "enable_thinking": false
+        }
+    }'
+```
+
+## 7 Accuracy Evaluation
+
+Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for evaluation setup and usage.
+
+The W8A8 deployment described in Section 5 was validated on GPQA Diamond with the following result:
+
+| Dataset | Metric | Score |
+| --- | --- | --- |
+| GPQA Diamond | Accuracy | 91.4 |
+
+## 8 Limitations
+
+- Only Atlas 800 A3 is currently supported.
+- Automatic Prefix Caching is currently unavailable. Always use `--no-enable-prefix-caching`.
+- The validated deployment is language-model-only and uses an Ascend-compatible W8A8 checkpoint.
+- Performance data is intentionally not included in this tutorial.

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -8,7 +8,9 @@ This tutorial describes the W8A8 deployment on Atlas 800 A3 and Ascend 950DT. Te
 
 !!! warning
 
-    Automatic Prefix Caching is currently unavailable for Qwen3.8-Flash-Next. Keep `--no-enable-prefix-caching` in the startup command. Do not enable Prefix Caching for this model.
+    Automatic Prefix Caching is experimental for Qwen3.8-Flash-Next. Enable it
+    with `--enable-prefix-caching --mamba-cache-mode align` and revalidate NPU
+    memory capacity for the target context length and concurrency.
 
 ## 2 Supported Features
 
@@ -24,7 +26,7 @@ The following table summarizes the features covered by this tutorial.
 | Full Decode ACLGraph | Supported | Uses `FULL_DECODE_ONLY`; the MTP proposer remains eager |
 | Function calling | Supported | Uses `qwen3_xml` |
 | Reasoning parsing | Supported | Uses `qwen3` |
-| Automatic Prefix Caching | **Unsupported** | `--no-enable-prefix-caching` is required |
+| Automatic Prefix Caching | Experimental | Uses aligned GDN and PLE state checkpoints and requires additional NPU memory |
 | Multimodal input | Supported | Image-and-text input has been validated on A3 and 950DT |
 
 Refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the general model support matrix and the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration.
@@ -186,8 +188,9 @@ vllm serve "$MODEL_PATH" \
     --max-model-len 135168 \
     --max-num-seqs 8 \
     --max-num-batched-tokens 4096 \
-    --gpu-memory-utilization 0.95 \
-    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.93 \
+    --enable-prefix-caching \
+    --mamba-cache-mode align \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_xml \
     --reasoning-parser qwen3 \
@@ -203,7 +206,7 @@ Key parameter descriptions:
 - `--quantization ascend` loads the Ascend-compatible W8A8 checkpoint.
 - `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the A3 single-DP TP8 topology.
 - `--enable-expert-parallel` enables expert parallelism for the MoE layers.
-- `--no-enable-prefix-caching` is mandatory because Prefix Caching is currently unavailable for this model.
+- `--enable-prefix-caching --mamba-cache-mode align` enables Prefix Caching with aligned GDN and PLE state checkpoints.
 - The validated command does not set `--language-model-only`, so the vision encoder remains enabled and the service accepts both text and multimodal requests. For a text-only deployment, you may add `--language-model-only` to skip loading the vision encoder.
 - `--enable-auto-tool-choice --tool-call-parser qwen3_xml` enables automatic Function Calling with the Qwen3 XML parser.
 - `--reasoning-parser qwen3` separates reasoning from the final answer in the OpenAI-compatible response.
@@ -245,7 +248,8 @@ vllm serve "$MODEL_PATH" \
     --max-num-seqs 8 \
     --max-num-batched-tokens 4096 \
     --gpu-memory-utilization 0.95 \
-    --no-enable-prefix-caching \
+    --enable-prefix-caching \
+    --mamba-cache-mode align \
     --compilation-config '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32],"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}' \
     --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
@@ -254,7 +258,19 @@ vllm serve "$MODEL_PATH" \
 - `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this 950DT setup, including cache-clearing support.
 - `SOC_VERSION=ascend950dt_9582` selects the 950DT SoC target used by the image.
 - `--language-model-only` is optional. Add it only when a text-only service is desired and the vision encoder should not be loaded.
-- Prefix Caching remains unavailable on 950DT, so `--no-enable-prefix-caching` is required.
+- `--enable-prefix-caching --mamba-cache-mode align` enables Prefix Caching.
+  Revalidate memory headroom on the target 950DT deployment rather than reusing
+  the A3 memory-utilization observation as a fixed value.
+
+Prefix Caching stores aligned GDN and PLE state checkpoints in addition to the
+reusable attention cache, so it consumes additional NPU memory. The exact
+overhead depends on the maximum context length, concurrency, and cache layout.
+If memory is tight, reduce `--gpu-memory-utilization`, `--max-model-len`, or
+`--max-num-seqs`, and then repeat the real-weight capacity validation. In one A3
+DP1 × TP8 correctness validation, `--gpu-memory-utilization 0.95` left
+insufficient QSA workspace headroom and caused an out-of-memory error, while
+`0.93` passed. This is a workload-specific A3 observation, not a universal
+recommended value or a 950DT validation result.
 
 The minimal 950DT command above does not enable automatic Function Calling or reasoning parsing. To use the verification requests in Sections 6.3 and 6.4, add:
 
@@ -437,6 +453,8 @@ The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond wi
 ## 8 Limitations
 
 - Atlas 800 A3 and Ascend 950DT are currently supported.
-- Automatic Prefix Caching is currently unavailable. Always use `--no-enable-prefix-caching`.
+- Automatic Prefix Caching is experimental and consumes additional NPU memory.
+  Use `--enable-prefix-caching --mamba-cache-mode align` and validate memory
+  capacity for the target workload.
 - Text and multimodal input have been validated on A3 and 950DT. Add `--language-model-only` only for an optional text-only deployment.
 - The GPQA Diamond score in this tutorial was measured on A3 and must not be treated as a 950DT accuracy result.

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -4,7 +4,7 @@
 
 Qwen3.8-Flash-Next is a multimodal Mixture-of-Experts (MoE) model and an experimental preview of the architecture that will underpin Qwen4. Its language model combines Gated DeltaNet and Qwen Sparse Attention (QSA), gated residual connections, Position Learning Enhancement (PLE), and a native Multi-Token Prediction (MTP) head.
 
-This tutorial describes the W8A8 deployment on Atlas 800 A3 and Atlas 800 A5. Text and multimodal input have been validated on A3. The A5 example in this tutorial starts a text-only service. Atlas 800 A2 and Atlas inference products are not supported by this implementation.
+This tutorial describes the W8A8 deployment on Atlas 800 A3 and Ascend 950DT. Text and multimodal input have been validated on A3. The 950DT example in this tutorial starts a text-only service.
 
 !!! warning
 
@@ -16,9 +16,9 @@ The following table summarizes the features covered by this tutorial.
 
 | Feature | Status | Notes |
 | --- | --- | --- |
-| Hardware | Supported | Atlas 800 A3 and Atlas 800 A5 |
-| Text generation | Supported | Validated with an Ascend-compatible W8A8 checkpoint on A3 and A5 |
-| Tensor parallelism | Supported | A3 uses TP8; A5 uses TP4 in the examples below |
+| Hardware | Supported | Atlas 800 A3 and Ascend 950DT |
+| Text generation | Supported | Validated with an Ascend-compatible W8A8 checkpoint on A3 and 950DT |
+| Tensor parallelism | Supported | A3 uses TP8; 950DT uses TP4 in the examples below |
 | Expert parallelism | Supported | Enabled with `--enable-expert-parallel` |
 | MTP speculative decoding | Supported | Uses `qwen3_5_mtp` with three speculative tokens |
 | Full Decode ACLGraph | Supported | Uses `FULL_DECODE_ONLY`; the MTP proposer remains eager |
@@ -33,18 +33,18 @@ Refer to the [Supported Features List](../../user_guide/support_matrix/supported
 
 ### 3.1 Hardware
 
-The A3 deployment uses eight NPUs on one node with DP1 × TP8. No visible-device environment variable is required: vLLM uses the first eight devices by default.
+The A3 deployment uses eight NPUs on one node with DP1 × TP8.
 
-The A5 deployment uses four NPUs on one node with DP1 × TP4. Its example explicitly exposes devices 0 through 3.
+The 950DT deployment uses four NPUs on one node with DP1 × TP4.
 
 ### 3.2 Model Weight
 
-Download the Ascend-compatible quantized checkpoint for the target hardware. Both checkpoints include the MTP weights and require `--quantization ascend`.
+Download the Ascend-compatible quantized checkpoint for the target hardware. Both checkpoints require `--quantization ascend`.
 
 | Hardware | Quantization | ModelScope checkpoint |
 | --- | --- | --- |
-| Atlas 800 A3 | W8A8 + MTP | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp) |
-| Atlas 800 A5 | W8A8 MXFP8 + MTP | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp) |
+| Atlas 800 A3 | W8A8 | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp) |
+| Ascend 950DT | W8A8 MXFP8 | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp) |
 
 Mount or copy the selected checkpoint into the container. For example, set the A3 checkpoint path as follows:
 
@@ -109,9 +109,9 @@ After entering the container, verify the installation:
 pip show vllm vllm-ascend
 ```
 
-### 4.2 A5 Image and Container
+### 4.2 950DT Image and Container
 
-Use the following x86_64 image for Atlas 800 A5:
+Use the following x86_64 image for Ascend 950DT:
 
 ```bash
 export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a5-ubuntu-34178549844-2-amd64-temp
@@ -121,7 +121,7 @@ docker pull "$IMAGE"
 docker run --runtime=runc \
     -u root \
     -it -d \
-    --name vllm-ascend-qwen38-flash-next-a5 \
+    --name vllm-ascend-qwen38-flash-next-950dt \
     --net=host \
     --privileged=true \
     --shm-size=500g \
@@ -201,7 +201,7 @@ Key parameter descriptions:
 - `VLLM_ASCEND_ENABLE_QSA_LIGHTNING_INDEXER=1` enables the fused QSA Lightning Indexer path.
 - `VLLM_ASCEND_ENABLE_QSA_E3V=1` enables the fused QSA Expand E3 path.
 - `--quantization ascend` loads the Ascend-compatible W8A8 checkpoint.
-- `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the A3 single-DP TP8 topology. With no visible-device environment variable, vLLM uses the first eight devices.
+- `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the A3 single-DP TP8 topology.
 - `--enable-expert-parallel` enables expert parallelism for the MoE layers.
 - `--no-enable-prefix-caching` is mandatory because Prefix Caching is currently unavailable for this model.
 - The validated command does not set `--language-model-only`, so the vision encoder remains enabled and the service accepts both text and multimodal requests. For a text-only deployment, you may add `--language-model-only` to skip loading the vision encoder.
@@ -217,9 +217,9 @@ When the service is ready, the log contains `Application startup complete`. You 
 curl -sf http://127.0.0.1:8088/v1/models
 ```
 
-### 5.2 A5 Single-Node Online Deployment
+### 5.2 950DT Single-Node Online Deployment
 
-The following command starts a DP1 × TP4 text-only service on Atlas 800 A5. It uses the A5 MXFP8 checkpoint and the first four devices.
+The following command starts a DP1 × TP4 text-only service on Ascend 950DT. It uses the 950DT MXFP8 checkpoint.
 
 ```bash
 unset CPLUS_INCLUDE_PATH CPATH C_INCLUDE_PATH
@@ -229,11 +229,12 @@ source /usr/local/Ascend/nnal/atb/set_env.sh
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export VLLM_SERVER_DEV_MODE=1
 export SOC_VERSION=ascend950dt_9582
+export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8-mxfp8
 
-vllm serve /mnt/share/l30070400/183_device/output/Qwen3.8-Flash-Next-w8a8-mxfp8 \
+vllm serve "$MODEL_PATH" \
     --host 0.0.0.0 \
     --port 8089 \
-    --served-model-name qwen38-flash-next-a5 \
+    --served-model-name qwen38-flash-next-950dt \
     --trust-remote-code \
     --quantization ascend \
     --tensor-parallel-size 4 \
@@ -252,19 +253,19 @@ vllm serve /mnt/share/l30070400/183_device/output/Qwen3.8-Flash-Next-w8a8-mxfp8 
     --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
 ```
 
-- `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3` restricts the A5 service to the first four devices.
-- `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this A5 setup, including cache-clearing support.
-- `SOC_VERSION=ascend950dt_9582` selects the A5 SoC target used by the image.
-- `--language-model-only` makes this A5 example text-only and skips the vision encoder.
-- Prefix Caching remains unavailable on A5, so `--no-enable-prefix-caching` is required.
+- `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3` restricts the 950DT service to the first four devices.
+- `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this 950DT setup, including cache-clearing support.
+- `SOC_VERSION=ascend950dt_9582` selects the 950DT SoC target used by the image.
+- `--language-model-only` makes this 950DT example text-only and skips the vision encoder.
+- Prefix Caching remains unavailable on 950DT, so `--no-enable-prefix-caching` is required.
 
-The minimal A5 command above does not enable automatic Function Calling or reasoning parsing. To use the verification requests in Sections 6.3 and 6.4, add:
+The minimal 950DT command above does not enable automatic Function Calling or reasoning parsing. To use the verification requests in Sections 6.3 and 6.4, add:
 
 ```text
 --enable-auto-tool-choice --tool-call-parser qwen3_xml --reasoning-parser qwen3
 ```
 
-When the service is ready, verify the A5 endpoint with:
+When the service is ready, verify the 950DT endpoint with:
 
 ```bash
 curl -sf http://127.0.0.1:8089/v1/models
@@ -272,7 +273,7 @@ curl -sf http://127.0.0.1:8089/v1/models
 
 ## 6 Functional Verification
 
-The requests below target the A3 example at port `8088` with served model name `qwen3.8-flash-next`. For A5, use port `8089` and model name `qwen38-flash-next-a5`. The multimodal request in Section 6.2 applies to the validated A3 deployment; the A5 example is started with `--language-model-only`.
+The requests below target the A3 example at port `8088` with served model name `qwen3.8-flash-next`. For 950DT, use port `8089` and model name `qwen38-flash-next-950dt`. The multimodal request in Section 6.2 applies to the validated A3 deployment; the 950DT example is started with `--language-model-only`.
 
 ### 6.1 Basic Chat Completion
 
@@ -430,7 +431,7 @@ curl http://127.0.0.1:8088/v1/chat/completions \
 
 Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for evaluation setup and usage.
 
-The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond with the following result. This score is an A3 result; no A5 accuracy result is reported here.
+The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond with the following result. This score is an A3 result; no 950DT accuracy result is reported here.
 
 | Hardware | Dataset | Metric | Score |
 | --- | --- | --- | --- |
@@ -438,8 +439,8 @@ The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond wi
 
 ## 8 Limitations
 
-- Atlas 800 A3 and Atlas 800 A5 are currently supported; Atlas 800 A2 and Atlas inference products are not covered.
+- Atlas 800 A3 and Ascend 950DT are currently supported.
 - Automatic Prefix Caching is currently unavailable. Always use `--no-enable-prefix-caching`.
-- Text and multimodal input have been validated on A3. The A5 example is text-only because it uses `--language-model-only`.
-- The GPQA Diamond score in this tutorial was measured on A3 and must not be treated as an A5 accuracy result.
+- Text and multimodal input have been validated on A3. The 950DT example is text-only because it uses `--language-model-only`.
+- The GPQA Diamond score in this tutorial was measured on A3 and must not be treated as a 950DT accuracy result.
 - Performance data is intentionally not included in this tutorial.

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -226,7 +226,6 @@ unset CPLUS_INCLUDE_PATH CPATH C_INCLUDE_PATH
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 source /usr/local/Ascend/nnal/atb/set_env.sh
 
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export VLLM_SERVER_DEV_MODE=1
 export SOC_VERSION=ascend950dt_9582
 export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8-mxfp8
@@ -253,7 +252,6 @@ vllm serve "$MODEL_PATH" \
     --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
 ```
 
-- `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3` restricts the 950DT service to the first four devices.
 - `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this 950DT setup, including cache-clearing support.
 - `SOC_VERSION=ascend950dt_9582` selects the 950DT SoC target used by the image.
 - `--language-model-only` makes this 950DT example text-only and skips the vision encoder.

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -4,7 +4,7 @@
 
 Qwen3.8-Flash-Next is a multimodal Mixture-of-Experts (MoE) model and an experimental preview of the architecture that will underpin Qwen4. Its language model combines Gated DeltaNet and Qwen Sparse Attention (QSA), gated residual connections, Position Learning Enhancement (PLE), and a native Multi-Token Prediction (MTP) head.
 
-This tutorial describes the W8A8 deployment on Atlas 800 A3 and Ascend 950DT. Text and multimodal input have been validated on A3. The 950DT example in this tutorial starts a text-only service.
+This tutorial describes the W8A8 deployment on Atlas 800 A3 and Ascend 950DT. Text and multimodal input have been validated on both hardware platforms.
 
 !!! warning
 
@@ -25,7 +25,7 @@ The following table summarizes the features covered by this tutorial.
 | Function calling | Supported | Uses `qwen3_xml` |
 | Reasoning parsing | Supported | Uses `qwen3` |
 | Automatic Prefix Caching | **Unsupported** | `--no-enable-prefix-caching` is required |
-| Multimodal input | Supported | Image-and-text input has been validated on A3 |
+| Multimodal input | Supported | Image-and-text input has been validated on A3 and 950DT |
 
 Refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the general model support matrix and the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration.
 
@@ -111,10 +111,10 @@ pip show vllm vllm-ascend
 
 ### 4.2 950DT Image and Container
 
-Use the following x86_64 image for Ascend 950DT:
+The following example uses the ARM64 image for Ascend 950DT:
 
 ```bash
-export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a5-ubuntu-34178549844-2-amd64-temp
+export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a5-ubuntu-34178549844-2-arm64-temp
 
 docker pull "$IMAGE"
 
@@ -219,7 +219,7 @@ curl -sf http://127.0.0.1:8088/v1/models
 
 ### 5.2 950DT Single-Node Online Deployment
 
-The following command starts a DP1 × TP4 text-only service on Ascend 950DT. It uses the 950DT MXFP8 checkpoint.
+The following command starts a DP1 × TP4 service on Ascend 950DT. It uses the 950DT MXFP8 checkpoint and supports both text and multimodal input.
 
 ```bash
 unset CPLUS_INCLUDE_PATH CPATH C_INCLUDE_PATH
@@ -246,7 +246,6 @@ vllm serve "$MODEL_PATH" \
     --max-num-batched-tokens 4096 \
     --gpu-memory-utilization 0.95 \
     --no-enable-prefix-caching \
-    --language-model-only \
     --compilation-config '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32],"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}' \
     --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
@@ -254,7 +253,7 @@ vllm serve "$MODEL_PATH" \
 
 - `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this 950DT setup, including cache-clearing support.
 - `SOC_VERSION=ascend950dt_9582` selects the 950DT SoC target used by the image.
-- `--language-model-only` makes this 950DT example text-only and skips the vision encoder.
+- `--language-model-only` is optional. Add it only when a text-only service is desired and the vision encoder should not be loaded.
 - Prefix Caching remains unavailable on 950DT, so `--no-enable-prefix-caching` is required.
 
 The minimal 950DT command above does not enable automatic Function Calling or reasoning parsing. To use the verification requests in Sections 6.3 and 6.4, add:
@@ -271,7 +270,7 @@ curl -sf http://127.0.0.1:8089/v1/models
 
 ## 6 Functional Verification
 
-The requests below target the A3 example at port `8088` with served model name `qwen3.8-flash-next`. For 950DT, use port `8089` and model name `qwen38-flash-next-950dt`. The multimodal request in Section 6.2 applies to the validated A3 deployment; the 950DT example is started with `--language-model-only`.
+The requests below target the A3 example at port `8088` with served model name `qwen3.8-flash-next`. For 950DT, use port `8089` and model name `qwen38-flash-next-950dt`. The multimodal request in Section 6.2 has been validated on both hardware platforms.
 
 ### 6.1 Basic Chat Completion
 
@@ -439,6 +438,5 @@ The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond wi
 
 - Atlas 800 A3 and Ascend 950DT are currently supported.
 - Automatic Prefix Caching is currently unavailable. Always use `--no-enable-prefix-caching`.
-- Text and multimodal input have been validated on A3. The 950DT example is text-only because it uses `--language-model-only`.
+- Text and multimodal input have been validated on A3 and 950DT. Add `--language-model-only` only for an optional text-only deployment.
 - The GPQA Diamond score in this tutorial was measured on A3 and must not be treated as a 950DT accuracy result.
-- Performance data is intentionally not included in this tutorial.

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -45,14 +45,21 @@ Mount or copy the checkpoint into the container and set `MODEL_PATH` to its loca
 export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
 ```
 
-## 4 Installation
+## 4 Environment Preparation
 
-### 4.1 Docker Image Installation
+### 4.1 Pre-built Qwen3.8 Image
 
-Use the A3 image variant. The following command exposes all 16 devices on an Atlas 800 A3 node so that a group of eight can be selected inside the container.
+A pre-built Qwen3.8 image is available in the [vllm-atlas-temp repository](https://quay.io/repository/atlas-ci/vllm-atlas-temp?tab=tags&tag=latest). Select the image that matches the host CPU architecture:
+
+- AArch64: `quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-arm64-temp`
+- x86_64: `quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-amd64-temp`
+
+The following example uses the AArch64 image and exposes all 16 devices on an Atlas 800 A3 node so that a group of eight can be selected inside the container. Replace `IMAGE` with the x86_64 image on an x86_64 host.
 
 ```bash
-export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-arm64-temp
+
+docker pull "$IMAGE"
 
 docker run --rm \
     --name vllm-ascend-qwen38-flash-next \
@@ -95,12 +102,31 @@ pip show vllm vllm-ascend
 
 ### 4.2 Source Code Installation
 
-Alternatively, install the release branch from source. The vLLM version must match the version required by vLLM Ascend.
+Alternatively, build the validated source stack from the following exact components:
+
+- vLLM `v0.26.0`;
+- vLLM Ascend v0.26.0 release commit `3047bd476c77c8676231b39e5a1e6cffc9f29b5a`;
+- the complete change from [vLLM Ascend PR #15162](https://github.com/vllm-project/vllm-ascend/pull/15162) applied on top of that release commit.
+
+Install vLLM first:
 
 ```bash
-git clone --branch releases/v0.26.0rc https://github.com/vllm-project/vllm-ascend.git
+git clone https://github.com/vllm-project/vllm.git
+cd vllm
+git checkout v0.26.0
+VLLM_TARGET_DEVICE=empty pip install --no-deps -v -e .
+cd ..
+```
+
+Then install vLLM Ascend from the release commit with PR #15162 applied. The pull-request head is a descendant of the specified release commit, so `--ff-only` preserves the exact PR history and fails instead of silently creating an unintended merge if that relationship changes.
+
+```bash
+git clone https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend
-pip install -e .
+git checkout -b qwen38-flash-next 3047bd476c77c8676231b39e5a1e6cffc9f29b5a
+git fetch origin pull/15162/head:pr-15162
+git merge --ff-only pr-15162
+pip install -v -e .
 pip show vllm vllm-ascend
 ```
 

--- a/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
+++ b/docs/source/tutorials/models/Qwen3.8-Flash-Next.md
@@ -4,7 +4,7 @@
 
 Qwen3.8-Flash-Next is a multimodal Mixture-of-Experts (MoE) model and an experimental preview of the architecture that will underpin Qwen4. Its language model combines Gated DeltaNet and Qwen Sparse Attention (QSA), gated residual connections, Position Learning Enhancement (PLE), and a native Multi-Token Prediction (MTP) head.
 
-This tutorial describes the validated W8A8, language-model-only deployment on Ascend NPUs. The current vLLM Ascend implementation supports **Atlas 800 A3 only**. Atlas 800 A2 and Atlas inference products are not supported by this implementation.
+This tutorial describes the W8A8 deployment on Atlas 800 A3 and Atlas 800 A5. Text and multimodal input have been validated on A3. The A5 example in this tutorial starts a text-only service. Atlas 800 A2 and Atlas inference products are not supported by this implementation.
 
 !!! warning
 
@@ -16,16 +16,16 @@ The following table summarizes the features covered by this tutorial.
 
 | Feature | Status | Notes |
 | --- | --- | --- |
-| Hardware | Supported | Atlas 800 A3 only |
-| Text generation | Supported | Validated with an Ascend-compatible W8A8 checkpoint |
-| Tensor parallelism | Supported | TP8 is used in the validated configuration |
+| Hardware | Supported | Atlas 800 A3 and Atlas 800 A5 |
+| Text generation | Supported | Validated with an Ascend-compatible W8A8 checkpoint on A3 and A5 |
+| Tensor parallelism | Supported | A3 uses TP8; A5 uses TP4 in the examples below |
 | Expert parallelism | Supported | Enabled with `--enable-expert-parallel` |
 | MTP speculative decoding | Supported | Uses `qwen3_5_mtp` with three speculative tokens |
 | Full Decode ACLGraph | Supported | Uses `FULL_DECODE_ONLY`; the MTP proposer remains eager |
 | Function calling | Supported | Uses `qwen3_xml` |
 | Reasoning parsing | Supported | Uses `qwen3` |
 | Automatic Prefix Caching | **Unsupported** | `--no-enable-prefix-caching` is required |
-| Multimodal input | Not covered | The validated command uses `--language-model-only` |
+| Multimodal input | Supported | Image-and-text input has been validated on A3 |
 
 Refer to the [Supported Features List](../../user_guide/support_matrix/supported_models.md) for the general model support matrix and the [Feature Guide](../../user_guide/feature_guide/index.md) for feature configuration.
 
@@ -33,13 +33,20 @@ Refer to the [Supported Features List](../../user_guide/support_matrix/supported
 
 ### 3.1 Hardware
 
-The validated deployment uses eight NPUs on one Atlas 800 A3 node with DP1 × TP8. The example selects devices 8 through 15; replace `ASCEND_RT_VISIBLE_DEVICES` with any eight available A3 device IDs when necessary.
+The A3 deployment uses eight NPUs on one node with DP1 × TP8. No visible-device environment variable is required: vLLM uses the first eight devices by default.
+
+The A5 deployment uses four NPUs on one node with DP1 × TP4. Its example explicitly exposes devices 0 through 3.
 
 ### 3.2 Model Weight
 
-Download the original [Qwen3.8-Flash-Next model weight](https://modelscope.cn/models/Qwen/Qwen3.8-Flash-Next), then prepare an Ascend-compatible W8A8 checkpoint. The deployment below was validated with the W8A8 checkpoint and therefore requires `--quantization ascend`.
+Download the Ascend-compatible quantized checkpoint for the target hardware. Both checkpoints include the MTP weights and require `--quantization ascend`.
 
-Mount or copy the checkpoint into the container and set `MODEL_PATH` to its local path, for example:
+| Hardware | Quantization | ModelScope checkpoint |
+| --- | --- | --- |
+| Atlas 800 A3 | W8A8 + MTP | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mtp) |
+| Atlas 800 A5 | W8A8 MXFP8 + MTP | [Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp](https://www.modelscope.cn/models/Eco-Tech/Qwen3.8-Flash-Next-w8a8-mxfp8-mtp) |
+
+Mount or copy the selected checkpoint into the container. For example, set the A3 checkpoint path as follows:
 
 ```bash
 export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
@@ -47,14 +54,16 @@ export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
 
 ## 4 Environment Preparation
 
-### 4.1 Pre-built Qwen3.8 Image
+Only pre-built images are supported by this tutorial. Source installation is not provided.
 
-A pre-built Qwen3.8 image is available in the [vllm-atlas-temp repository](https://quay.io/repository/atlas-ci/vllm-atlas-temp?tab=tags&tag=latest). Select the image that matches the host CPU architecture:
+### 4.1 A3 Image and Container
+
+A pre-built Qwen3.8 A3 image is available in the [vllm-atlas-temp repository](https://quay.io/repository/atlas-ci/vllm-atlas-temp?tab=tags&tag=latest). Select the image that matches the host CPU architecture:
 
 - AArch64: `quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-arm64-temp`
 - x86_64: `quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-amd64-temp`
 
-The following example uses the AArch64 image and exposes all 16 devices on an Atlas 800 A3 node so that a group of eight can be selected inside the container. Replace `IMAGE` with the x86_64 image on an x86_64 host.
+The following example uses the AArch64 image and exposes all 16 devices on an Atlas 800 A3 node. The service command later uses the first eight devices by default. Replace `IMAGE` with the x86_64 image on an x86_64 host.
 
 ```bash
 export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a3-ubuntu-34178549844-2-arm64-temp
@@ -100,41 +109,56 @@ After entering the container, verify the installation:
 pip show vllm vllm-ascend
 ```
 
-### 4.2 Source Code Installation
+### 4.2 A5 Image and Container
 
-Alternatively, build the validated source stack from the following exact components:
-
-- vLLM `v0.26.0`;
-- vLLM Ascend v0.26.0 release commit `3047bd476c77c8676231b39e5a1e6cffc9f29b5a`;
-- the complete change from [vLLM Ascend PR #15162](https://github.com/vllm-project/vllm-ascend/pull/15162) applied on top of that release commit.
-
-Install vLLM first:
+Use the following x86_64 image for Atlas 800 A5:
 
 ```bash
-git clone https://github.com/vllm-project/vllm.git
-cd vllm
-git checkout v0.26.0
-VLLM_TARGET_DEVICE=empty pip install --no-deps -v -e .
-cd ..
+export IMAGE=quay.io/atlas-ci/vllm-atlas-temp:qwen3.8-next-a5-ubuntu-34178549844-2-amd64-temp
+
+docker pull "$IMAGE"
+
+docker run --runtime=runc \
+    -u root \
+    -it -d \
+    --name vllm-ascend-qwen38-flash-next-a5 \
+    --net=host \
+    --privileged=true \
+    --shm-size=500g \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/ummu \
+    --device=/dev/uburma \
+    --device=/dev/davinci0 \
+    --device=/dev/davinci1 \
+    --device=/dev/davinci2 \
+    --device=/dev/davinci3 \
+    --device=/dev/davinci4 \
+    --device=/dev/davinci5 \
+    --device=/dev/davinci6 \
+    --device=/dev/davinci7 \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/firmware:/usr/local/Ascend/firmware \
+    -v /root/host:/root/host \
+    -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /var/log/npu:/usr/slog \
+    -v /mnt:/mnt \
+    -v /data:/data \
+    -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+    -v /usr/lib64:/usr/lib64 \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /home:/home \
+    -v /etc/hixlep:/etc/hixlep \
+    "$IMAGE" bash
 ```
 
-Then install vLLM Ascend from the release commit with PR #15162 applied. The pull-request head is a descendant of the specified release commit, so `--ff-only` preserves the exact PR history and fails instead of silently creating an unintended merge if that relationship changes.
-
-```bash
-git clone https://github.com/vllm-project/vllm-ascend.git
-cd vllm-ascend
-git checkout -b qwen38-flash-next 3047bd476c77c8676231b39e5a1e6cffc9f29b5a
-git fetch origin pull/15162/head:pr-15162
-git merge --ff-only pr-15162
-pip install -v -e .
-pip show vllm vllm-ascend
-```
-
-For complete environment preparation instructions, refer to [Installation](../../installation.md).
+The command removes the duplicate `npu-smi` mount from the original example and fixes the `/home` and `/etc/hixlep` mount syntax.
 
 ## 5 Online Service Deployment
 
-### 5.1 Single-Node Online Deployment
+### 5.1 A3 Single-Node Online Deployment
 
 The following DP1 × TP8 command was validated with an Ascend-compatible W8A8 checkpoint on Atlas 800 A3. It enables QSA Lightning Indexer and QSA Expand E3, MTP speculative decoding, Function Calling, and reasoning parsing.
 
@@ -144,7 +168,6 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 source /usr/local/Ascend/nnal/atb/set_env.sh
 
 export MODEL_PATH=/models/Qwen3.8-Flash-Next-w8a8
-export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11,12,13,14,15
 export VLLM_ASCEND_ENABLE_QSA_LIGHTNING_INDEXER=1
 export VLLM_ASCEND_ENABLE_QSA_E3V=1
 unset VLLM_ASCEND_FORCE_QSA_REFERENCE
@@ -165,7 +188,6 @@ vllm serve "$MODEL_PATH" \
     --max-num-batched-tokens 4096 \
     --gpu-memory-utilization 0.95 \
     --no-enable-prefix-caching \
-    --language-model-only \
     --enable-auto-tool-choice \
     --tool-call-parser qwen3_xml \
     --reasoning-parser qwen3 \
@@ -179,10 +201,10 @@ Key parameter descriptions:
 - `VLLM_ASCEND_ENABLE_QSA_LIGHTNING_INDEXER=1` enables the fused QSA Lightning Indexer path.
 - `VLLM_ASCEND_ENABLE_QSA_E3V=1` enables the fused QSA Expand E3 path.
 - `--quantization ascend` loads the Ascend-compatible W8A8 checkpoint.
-- `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the validated single-DP TP8 topology.
+- `--tensor-parallel-size 8` and `--data-parallel-size 1` configure the A3 single-DP TP8 topology. With no visible-device environment variable, vLLM uses the first eight devices.
 - `--enable-expert-parallel` enables expert parallelism for the MoE layers.
 - `--no-enable-prefix-caching` is mandatory because Prefix Caching is currently unavailable for this model.
-- `--language-model-only` skips the vision encoder; this tutorial covers text serving only.
+- The validated command does not set `--language-model-only`, so the vision encoder remains enabled and the service accepts both text and multimodal requests. For a text-only deployment, you may add `--language-model-only` to skip loading the vision encoder.
 - `--enable-auto-tool-choice --tool-call-parser qwen3_xml` enables automatic Function Calling with the Qwen3 XML parser.
 - `--reasoning-parser qwen3` separates reasoning from the final answer in the OpenAI-compatible response.
 - `--speculative-config` uses the model's MTP head to draft three tokens. `enforce_eager=true` keeps the MTP proposer in eager mode.
@@ -195,7 +217,62 @@ When the service is ready, the log contains `Application startup complete`. You 
 curl -sf http://127.0.0.1:8088/v1/models
 ```
 
+### 5.2 A5 Single-Node Online Deployment
+
+The following command starts a DP1 × TP4 text-only service on Atlas 800 A5. It uses the A5 MXFP8 checkpoint and the first four devices.
+
+```bash
+unset CPLUS_INCLUDE_PATH CPATH C_INCLUDE_PATH
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+export VLLM_SERVER_DEV_MODE=1
+export SOC_VERSION=ascend950dt_9582
+
+vllm serve /mnt/share/l30070400/183_device/output/Qwen3.8-Flash-Next-w8a8-mxfp8 \
+    --host 0.0.0.0 \
+    --port 8089 \
+    --served-model-name qwen38-flash-next-a5 \
+    --trust-remote-code \
+    --quantization ascend \
+    --tensor-parallel-size 4 \
+    --data-parallel-size 1 \
+    --data-parallel-size-local 1 \
+    --data-parallel-start-rank 0 \
+    --enable-expert-parallel \
+    --max-model-len 135168 \
+    --max-num-seqs 8 \
+    --max-num-batched-tokens 4096 \
+    --gpu-memory-utilization 0.95 \
+    --no-enable-prefix-caching \
+    --language-model-only \
+    --compilation-config '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32],"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    --speculative-config '{"method":"qwen3_5_mtp","num_speculative_tokens":3,"enforce_eager":true}' \
+    --additional-config '{"enable_cpu_binding":true,"ascend_compilation_config":{"fuse_norm_quant":false}}'
+```
+
+- `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3` restricts the A5 service to the first four devices.
+- `VLLM_SERVER_DEV_MODE=1` enables the server development mode required by this A5 setup, including cache-clearing support.
+- `SOC_VERSION=ascend950dt_9582` selects the A5 SoC target used by the image.
+- `--language-model-only` makes this A5 example text-only and skips the vision encoder.
+- Prefix Caching remains unavailable on A5, so `--no-enable-prefix-caching` is required.
+
+The minimal A5 command above does not enable automatic Function Calling or reasoning parsing. To use the verification requests in Sections 6.3 and 6.4, add:
+
+```text
+--enable-auto-tool-choice --tool-call-parser qwen3_xml --reasoning-parser qwen3
+```
+
+When the service is ready, verify the A5 endpoint with:
+
+```bash
+curl -sf http://127.0.0.1:8089/v1/models
+```
+
 ## 6 Functional Verification
+
+The requests below target the A3 example at port `8088` with served model name `qwen3.8-flash-next`. For A5, use port `8089` and model name `qwen38-flash-next-a5`. The multimodal request in Section 6.2 applies to the validated A3 deployment; the A5 example is started with `--language-model-only`.
 
 ### 6.1 Basic Chat Completion
 
@@ -214,7 +291,40 @@ curl http://127.0.0.1:8088/v1/chat/completions \
 
 Expected result: the service returns HTTP 200 and a non-empty `choices` field.
 
-### 6.2 Function Calling
+### 6.2 Multimodal Chat Completion
+
+The validated deployment accepts image-and-text input. Replace `<IMAGE_URL>` with an image URL accessible from the serving environment:
+
+```bash
+curl http://127.0.0.1:8088/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "qwen3.8-flash-next",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "<IMAGE_URL>"
+                        }
+                    },
+                    {
+                        "type": "text",
+                        "text": "Describe this image."
+                    }
+                ]
+            }
+        ],
+        "max_tokens": 1024,
+        "temperature": 0
+    }'
+```
+
+Expected result: the service returns HTTP 200 and describes the supplied image in `choices[0].message.content`.
+
+### 6.3 Function Calling
 
 Function Calling requires the following startup options, which are already included in Section 5:
 
@@ -262,7 +372,7 @@ curl http://127.0.0.1:8088/v1/chat/completions \
 
 When the model chooses the function, the parsed result appears in `choices[0].message.tool_calls`. The caller must execute the function and send its result back to the model in a follow-up message.
 
-### 6.3 Reasoning Parser and Thinking Control
+### 6.4 Reasoning Parser and Thinking Control
 
 Reasoning parsing requires the following startup option, which is already included in Section 5:
 
@@ -320,15 +430,16 @@ curl http://127.0.0.1:8088/v1/chat/completions \
 
 Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) for evaluation setup and usage.
 
-The W8A8 deployment described in Section 5 was validated on GPQA Diamond with the following result:
+The A3 W8A8 deployment described in Section 5.1 was validated on GPQA Diamond with the following result. This score is an A3 result; no A5 accuracy result is reported here.
 
-| Dataset | Metric | Score |
-| --- | --- | --- |
-| GPQA Diamond | Accuracy | 91.4 |
+| Hardware | Dataset | Metric | Score |
+| --- | --- | --- | --- |
+| Atlas 800 A3 | GPQA Diamond | Accuracy | 91.4 |
 
 ## 8 Limitations
 
-- Only Atlas 800 A3 is currently supported.
+- Atlas 800 A3 and Atlas 800 A5 are currently supported; Atlas 800 A2 and Atlas inference products are not covered.
 - Automatic Prefix Caching is currently unavailable. Always use `--no-enable-prefix-caching`.
-- The validated deployment is language-model-only and uses an Ascend-compatible W8A8 checkpoint.
+- Text and multimodal input have been validated on A3. The A5 example is text-only because it uses `--language-model-only`.
+- The GPQA Diamond score in this tutorial was measured on A3 and must not be treated as an A5 accuracy result.
 - Performance data is intentionally not included in this tutorial.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,6 +215,7 @@ nav:
         - tutorials/models/Qwen3-Reranker.md
         - tutorials/models/Qwen3-VL-Reranker.md
         - tutorials/models/Qwen3-Next.md
+        - tutorials/models/Qwen3.8-Flash-Next.md
         - tutorials/models/Qwen3-Omni-30B-A3B-Thinking.md
         - tutorials/models/Qwen3.5-27B-Qwen3.6-27B.md
         - tutorials/models/Qwen3.5-Dense.md


### PR DESCRIPTION
## Summary

Forward-ports the documentation-only changes from #16142 to `main`.

- add the Qwen3.8-Flash-Next deployment tutorial, including A3 and A5 guidance;
- add the tutorial to MkDocs navigation and bilingual navigation-title metadata;
- document serving, multimodal, function-calling, reasoning, and prefix-caching configuration.

## Validation

- `git diff --check upstream/main...HEAD`
- `mkdocs build --strict`
- `markdownlint-cli@0.45.0 docs/source/tutorials/models/Qwen3.8-Flash-Next.md`

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
