### PR TITLE
[BugFix][MRV2] Fix rejection resampling RNG coupling

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -270,3 +270,55 @@ def test_placeholder_draft_tokens_are_rejected(has_draft_logits: bool):
 
     gc.collect()
     torch.npu.empty_cache()
+@pytest.mark.parametrize("case", ["one_hot_standard", "one_hot_synthetic", "full_draft_standard"])
+@torch.inference_mode()
+def test_rejection_sample_residual_rng_is_independent_from_acceptance_rng(case):
+    """Rejected-token resampling must use RNG independent from acceptance."""
+    torch.manual_seed(1234)
+    device = "npu"
+    num_trials = 4096
+    num_speculative_steps = 1
+
+    if case == "full_draft_standard":
+        target_probs = torch.tensor([0.35, 0.30, 0.20, 0.10, 0.05], dtype=torch.float32)
+        draft_probs = torch.tensor([0.10, 0.35, 0.15, 0.15, 0.25], dtype=torch.float32)
+        inputs = _build_rejection_sample_inputs(
+            target_probs.log().to(device),
+            draft_probs.log().to(device),
+            num_speculative_steps,
+            temperature=1.0,
+            num_trials=num_trials,
+        )
+        synthetic_conditional_rates = None
+    else:
+        target_probs = torch.tensor([0.50, 0.25, 0.15, 0.10], dtype=torch.float32)
+        inputs = _build_rejection_sample_inputs(
+            target_probs.log().to(device),
+            target_probs.log().to(device),
+            num_speculative_steps,
+            temperature=1.0,
+            num_trials=num_trials,
+        )
+
+        # One-hot draft: every request proposes token 0 at speculative step 0.
+        inputs["draft_logits"] = None
+        draft_rows = inputs["draft_sampled"].view(num_trials, num_speculative_steps + 1)
+        draft_rows[:, 1] = 0
+
+        if case == "one_hot_synthetic":
+            synthetic_conditional_rates = torch.tensor([0.5], dtype=torch.float32, device=device)
+        else:
+            synthetic_conditional_rates = None
+
+    sampled, _ = rejection_sample(
+        **inputs,
+        num_speculative_steps=num_speculative_steps,
+        synthetic_conditional_rates=synthetic_conditional_rates,
+    )
+
+    counts = torch.bincount(sampled[:, 0].cpu(), minlength=target_probs.numel()).to(torch.float64)
+    observed = counts / counts.sum()
+    torch.testing.assert_close(observed, target_probs.to(torch.float64), rtol=0.0, atol=0.03)
+
+    gc.collect()
+    torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -270,6 +270,8 @@ def test_placeholder_draft_tokens_are_rejected(has_draft_logits: bool):
 
     gc.collect()
     torch.npu.empty_cache()
+
+
 @pytest.mark.parametrize("case", ["one_hot_standard", "one_hot_synthetic", "full_draft_standard"])
 @torch.inference_mode()
 def test_rejection_sample_residual_rng_is_independent_from_acceptance_rng(case):

--- a/vllm_ascend/ops/triton/v2/spec_decode/resample.py
+++ b/vllm_ascend/ops/triton/v2/spec_decode/resample.py
@@ -193,6 +193,8 @@ def _categorical_finalize_kernel(
     # One random value defines one point on the whole vocabulary-mass interval.
     seed = tl.load(seed_ptr + req_state_idx)
     position = tl.load(pos_ptr + resample_token_idx).to(tl.int32)
+    # Keep residual-resampling RNG independent from the acceptance draw.
+    position += tl.where(is_random_residual, 1 << 29, 0)
     uniform = tl.max(tl.rand(tl.randint(seed, position), tl.arange(0, 1)).to(tl.float32), axis=0)
 
     stored_block_mass = tl.load(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an RNG coupling bug in the MRV2 probabilistic rejection sampling path introduced after categorical residual resampling was adopted.

During verification, the acceptance decision draws one uniform random value from `(seed, pos)`:

```python
u_pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
u_seed = tl.randint(seed, u_pos)
u = tl.max(tl.rand(u_seed, tl.arange(0, 1)).to(tl.float32), axis=0)
```

Before this fix, rejected-token resampling derived its categorical threshold from the same `(seed, pos)` pair:

```python
position = tl.load(pos_ptr + resample_token_idx).to(tl.int32)
uniform = tl.max(tl.rand(tl.randint(seed, position), tl.arange(0, 1)).to(tl.float32), axis=0)
```

At the first rejected speculative step, `resample_token_idx == logit_idx`, so the acceptance decision and residual resampling consumed the same Philox draw.

If the acceptance threshold is `h`, rejection means `u >= h`. Reusing that same `u` for inverse-CDF categorical resampling therefore makes the resampling threshold distributed as `U(h, 1)` instead of an independent `U(0, 1)`. The acceptance rate itself remains correct, but the final sampled-token distribution is biased.

The fix gives random residual resampling a separate Philox counter domain:

```python
position += tl.where(is_random_residual, 1 << 29, 0)
```

The RNG domains are therefore separated as follows:

- acceptance: `pos`
- residual resampling: `pos + (1 << 29)`
- draft sampling: `pos + (1 << 30)`

Only random residual resampling is changed. Random bonus sampling keeps the existing RNG mapping because bonus tokens do not have a preceding acceptance draw.

This is intentionally a minimal correctness fix: no API, workspace, probability-mass computation, or kernel structure is changed.

Affected paths include random rejected-token resampling for full-draft, one-hot draft, and synthetic verification modes. Greedy rejection and bonus-token sampling are not affected by this RNG coupling.

### Does this PR introduce _any_ user-facing change?

Yes.

For probabilistic speculative decoding, the exact rejected-token sequence for the same `seed` and `pos` may change because residual resampling now uses an independent RNG stream.

This restores the intended rejection-sampling distribution. Acceptance probabilities and public APIs are unchanged. Greedy behavior and bonus-token RNG behavior are unchanged.

### How was this patch tested?

Validated with a full-chain `rejection_sample()` statistical regression rather than testing `resample()` in isolation.

The regression uses a `K=1` one-hot draft case with target distribution:

```text
[0.50, 0.25, 0.15, 0.10]
```

and checks the final first-token histogram across 4096 requests against the target distribution (`rtol=0`, `atol=0.03`). This exercises the complete path:

```text
acceptance RNG -> rejection -> residual resampling -> final sampled token
```

The standalone `resample()` distribution tests are not sufficient to detect this issue because the coupling only appears when the verification and resampling kernels are executed together.

The regression is intended to live in:

```text
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
```

- Related categorical resampling PR: #15573

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
