### PR TITLE
[BugFix][KV Pool] Clarify layerwise reuse load logging

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -146,6 +146,40 @@ class TestKVPoolScheduler(unittest.TestCase):
                 self.assertEqual((need, is_async), (expected, load_async and expected > 0))
                 self.assertEqual("r1" in scheduler.load_specs, expected > 0)
 
+    def test_layer_reuse_logs_independent_and_reused_load_tokens(self):
+        config = self._make_config(
+            extra_config={
+                "backend": "memcache",
+                "layerwise_num_shared_buffers": 1,
+            }
+        )
+        config.model_config.get_num_layers.return_value = 4
+        scheduler = KVPoolScheduler(config, use_layerwise=True)
+        self.assertTrue(scheduler.layerwise_offload)
+        scheduler._get_layerwise_hit_tokens = MagicMock(return_value=48)
+        request = MagicMock(
+            prompt_token_ids=list(range(64)),
+            num_tokens=64,
+            request_id="r1",
+            block_hashes=[b"h"] * 4,
+        )
+
+        with patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.logger.info") as mock_info:
+            scheduler.get_num_new_matched_tokens(request, 16)
+
+        mock_info.assert_called_once_with(
+            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, usable hit tokens: %d, "
+            "need to allocate: %d, independent layer load tokens per layer: %d, "
+            "reused layer load tokens per layer: %d",
+            "r1",
+            64,
+            48,
+            48,
+            32,
+            32,
+            48,
+        )
+
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_all_hit(self, mock_client_cls):
         config = self._make_config(block_size=16)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -718,13 +718,30 @@ class KVPoolScheduler:
         else:
             need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
-        logger.info(
-            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
-            request.request_id,
-            request.num_tokens,
-            num_external_hit_tokens,
-            need_to_allocate,
-        )
+        if self.layerwise_offload:
+            # Reused layers must restore the whole pooled prefix.
+            layerwise_load_tokens = num_external_hit_tokens if self.use_eagle else store_skip_tokens
+            independent_layer_load_tokens = max(0, layerwise_load_tokens - num_computed_tokens)
+            logger.info(
+                "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, usable hit tokens: %d, "
+                "need to allocate: %d, independent layer load tokens per layer: %d, "
+                "reused layer load tokens per layer: %d",
+                request.request_id,
+                request.num_tokens,
+                store_skip_tokens,
+                num_external_hit_tokens,
+                need_to_allocate,
+                independent_layer_load_tokens,
+                layerwise_load_tokens,
+            )
+        else:
+            logger.info(
+                "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
+                request.request_id,
+                request.num_tokens,
+                num_external_hit_tokens,
+                need_to_allocate,
+            )
 
         # In layerwise mode, even when vLLM has local cached tokens, we still
         # need to load KV cache from the pool because layerwise transfer loads


### PR DESCRIPTION
### What this PR does / why we need it?

When layerwise KV cache buffer reuse is enabled, the existing log reports `need_to_allocate` as `need to load`. That value only represents scheduler allocation and does not describe the different per-layer load behavior.

This PR:

- keeps the existing log unchanged when layer reuse is disabled;
- reports raw and usable KV pool hit tokens separately when reuse is active;
- reports scheduler allocation separately from independent-layer and reused-layer load tokens per layer;
- adds a focused unit test for the new log calculation.

### Does this PR introduce _any_ user-facing change?

Yes. Informational KV pool logs are more precise when layerwise buffer reuse is enabled. Runtime behavior and public APIs are unchanged.

### How was this patch tested?

- `ruff check vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_scheduler.py`
- `ruff format --check vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_scheduler.py`
- `python -m py_compile vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_scheduler.py`

The focused pytest file could not run in the local environment because the upstream `vllm` Python package is not installed; CI should execute the added unit test.
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
