### PR TITLE
[Refactor][KV Pool] Rework layerwise transfer scheduling and lifecycle

### DIFF
--- a/tests/ut/distributed/ascend_store/test_layerwise_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_transfer.py
@@ -1,0 +1,282 @@
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401
+from tests.ut.distributed.ascend_store.test_kv_transfer import TestGVALayerTransferFailures as _GVALayerTransferFailures
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import attention_fence
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import get_layerwise_protocol
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_transfer import (
+    LayerTransferArrayBuilder,
+    LayerwiseTransferPreparer,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    LayerBlockRange,
+    LayerSaveTask,
+    LayerTransferTask,
+    LayerwisePreparation,
+    LoadSpec,
+    ReqMeta,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import KVPoolWorker
+
+
+def make_preparer(backend, groups=1):
+    return LayerwiseTransferPreparer(
+        backend,
+        "model",
+        0,
+        16,
+        enabled=True,
+        can_allocate=True,
+        block_sizes=[16] * groups,
+        group_block_len={group: [16, 16] for group in range(groups)},
+        page_size_bytes=16,
+        layerwise_offload=True,
+        protocol=get_layerwise_protocol("memcache"),
+        record_invalid_blocks=MagicMock(),
+    )
+
+
+def make_request(req_id="r1", groups=1, hashes=None):
+    hashes = [b"a", b"b"] if hashes is None else hashes
+    ids = [np.arange(1, len(hashes) + 1, dtype=np.int64) for _ in range(groups)]
+    return ReqMeta(
+        req_id,
+        token_len_chunk=16 * len(hashes),
+        can_save=True,
+        block_ids_by_group=[group.tolist() for group in ids],
+        block_ids_by_group_np=ids,
+        block_hashes=hashes,
+        load_spec=LoadSpec(0, 16 * len(hashes), can_load=True),
+        is_last_chunk=True,
+    )
+
+
+def key_info(gva):
+    return SimpleNamespace(size=lambda: 32, gva_list=lambda: [gva])
+
+
+def test_variable_layout_array_offsets():
+    database = SimpleNamespace(
+        group_block_len={0: [10, 2, 20]},
+        group_kv_caches_base_addr={0: [100, 200, 300]},
+        group_block_stride={0: [1000, 2000, 3000]},
+        group_layer_cache_entry_offsets={0: [0, 2, 3]},
+    )
+    builder = LayerTransferArrayBuilder(database, 2)
+    ids, gvas = np.asarray([1]), np.asarray([10000])
+    addresses, sizes, remote = builder._build_transfer_arrays(ids, gvas, 0)
+    np.testing.assert_array_equal(addresses, [1100, 2200])
+    np.testing.assert_array_equal(sizes, [10, 2])
+    np.testing.assert_array_equal(remote, [10000, 10010])
+    np.testing.assert_array_equal(builder._build_transfer_arrays(ids, gvas, 1)[2], [10012])
+    database.group_layer_cache_entry_offsets = {0: [0, 1, 2]}
+    with pytest.raises(ValueError, match="Invalid layerwise offsets"):
+        LayerTransferArrayBuilder(database, 2)
+
+
+def test_preparation_runs_once_for_competing_transfer_threads():
+    callback = MagicMock()
+    preparation = LayerwisePreparation(callback)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(lambda _: preparation.ensure_ready(), range(8)))
+    callback.assert_called_once()
+
+
+def test_preparation_replays_failure_without_retrying_backend():
+    callback = MagicMock(side_effect=RuntimeError("failed"))
+    preparation = LayerwisePreparation(callback)
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="failed"):
+            preparation.ensure_ready()
+    callback.assert_called_once()
+
+
+def test_load_queries_once_and_shared_lease_survives_first_completion():
+    backend = MagicMock()
+    backend.batch_get_key_info.return_value = [key_info(100)]
+    backend.batch_add_lease.return_value = [0]
+    backend.batch_remove_lease.return_value = 0
+    preparer = make_preparer(backend)
+    preparer._prepare_load_gvas([make_request("a", hashes=[b"x"]), make_request("b", hashes=[b"x"])])
+    backend.batch_get_key_info.assert_called_once()
+    assert len(backend.batch_get_key_info.call_args.args[0]) == 1
+    backend.batch_add_lease.assert_called_once()
+    preparer.release_finished_load_leases({"a"})
+    backend.batch_remove_lease.assert_not_called()
+    preparer.release_finished_load_leases({"b"})
+    backend.batch_remove_lease.assert_called_once()
+    assert not preparer.load_lease_refcounts
+
+
+@pytest.mark.parametrize("results", [[0], [0, 9]])
+def test_lease_failure_rolls_back_acquired_keys(results):
+    backend = MagicMock()
+    backend.batch_get_key_info.return_value = [key_info(100), key_info(200)]
+    backend.batch_add_lease.return_value = results
+    backend.batch_remove_lease.return_value = 0
+    preparer = make_preparer(backend, groups=2)
+    with pytest.raises(RuntimeError):
+        preparer._prepare_load_gvas([make_request(groups=2, hashes=[b"x"])])
+    backend.batch_remove_lease.assert_called_once()
+    assert len(backend.batch_remove_lease.call_args.args[0]) == 1
+    assert not preparer.load_lease_refcounts
+
+
+@pytest.mark.parametrize("infos", [[], [SimpleNamespace(size=lambda: 32, gva_list=lambda: [])]])
+def test_malformed_metadata_fails_before_lease_acquisition(infos):
+    backend = MagicMock()
+    backend.batch_get_key_info.return_value = infos
+    preparer = make_preparer(backend)
+    with pytest.raises(RuntimeError):
+        preparer._prepare_load_gvas([make_request(hashes=[b"x"])])
+    backend.batch_add_lease.assert_not_called()
+
+
+def test_saves_allocate_one_batch_and_deduplicate_shared_keys():
+    backend = MagicMock()
+    backend.batch_alloc.return_value = [100, 200]
+    preparer = make_preparer(backend, groups=2)
+    requests = [make_request("a", groups=2, hashes=[b"x"]), make_request("b", groups=2, hashes=[b"x"])]
+    for request in requests:
+        request.load_spec = None
+    preparer._alloc_gvas_for_save(requests)
+    backend.batch_alloc.assert_called_once()
+    assert len(backend.batch_alloc.call_args.args[0]) == 2
+    assert requests[0].block_gvas_by_group_np[0].tolist() == [100]
+    assert requests[0].block_gvas_by_group_np[1].tolist() == [200]
+    assert requests[1].block_gvas_by_group_np[0].tolist() == [0]
+    assert requests[1].save_keys == []
+
+
+def test_invalid_allocation_never_prepares_a_successful_save():
+    backend = MagicMock()
+    backend.batch_alloc.return_value = []
+    preparer = make_preparer(backend)
+    request = make_request(hashes=[b"x"])
+    request.load_spec = None
+    with pytest.raises(RuntimeError, match="batch_alloc returned invalid GVAs"):
+        preparer._alloc_gvas_for_save([request])
+    assert request.save_keys is None
+
+
+def test_indexed_gate_records_mtp_mapping_and_resets():
+    attention_fence.reset_attention_compute_start_gates(3, {"mtp.layers.0.attn": 2})
+    try:
+        gate = attention_fence.get_attention_compute_start_gate(2)
+        gate.record = MagicMock()
+        attention_fence.record_attention_compute_start("mtp.layers.0.attn")
+        gate.record.assert_called_once()
+        assert attention_fence.get_attention_compute_start_gate(0)._event is None
+        attention_fence.reset_attention_compute_start_gates(3)
+        assert attention_fence.get_attention_compute_start_gate(2) is not gate
+    finally:
+        attention_fence.reset_attention_compute_start_gate()
+
+
+def test_adjacent_reused_layer_does_not_wait_on_its_own_attention():
+    worker = KVPoolWorker.__new__(KVPoolWorker)
+    worker.kv_recv_thread = MagicMock()
+    worker.use_layerwise_transfer = True
+    worker.current_layer = 0
+    worker.num_layers = 2
+    worker.next_layer_to_submit = 0
+    worker.num_prefetch_layers = 2
+    worker.prefetch_layer_map = {1: 0}
+    worker.layer_load_tasks = [[], [LayerTransferTask(1, [])]]
+    worker._layer_load_preparation = None
+    worker._submit_ready_layer_loads()
+    task = worker.kv_recv_thread.add_request.call_args.args[0]
+    assert task.layer_id == 1
+    assert task.wait_for_save_layer == 0
+    assert task.attention_start_gate is None
+
+
+def test_last_actual_group_task_owns_request_completion():
+    request = make_request()
+    first = LayerTransferTask(0, [LayerBlockRange(request, 0, 2)])
+    last = LayerTransferTask(1, [LayerBlockRange(request, 0, 2)], group_id=1)
+    KVPoolWorker._mark_last_layer_tasks([[first], [last], []])
+    assert first.finished_req_ids == set()
+    assert last.finished_req_ids == {request.req_id}
+
+
+def test_control_only_save_waits_for_attention_before_slot_reuse():
+    thread, _, finished, _ = _GVALayerTransferFailures()._make_sending_thread()
+    thread._wait_attention_done = MagicMock(side_effect=lambda _: pytest.fail("attention failed"))
+    with pytest.raises(pytest.fail.Exception):
+        thread._handle_request(LayerSaveTask(0, []))
+    assert not finished.is_set()
+    thread._wait_attention_done = MagicMock()
+    thread._handle_request(LayerSaveTask(0, []))
+    thread._wait_attention_done.assert_called_once_with(0)
+    assert finished.is_set()
+
+
+def test_failed_copy_keeps_request_count_and_slot_owned():
+    thread, _, finished, task = _GVALayerTransferFailures()._make_sending_thread()
+    thread._batch_copy_with_limits = MagicMock(return_value=7)
+    with pytest.raises(RuntimeError, match="batch_copy failed"):
+        thread._handle_request(LayerSaveTask(0, [task]))
+    assert not finished.is_set()
+    assert thread.stored_requests["r1"] == 1
+    assert not thread.get_and_clear_finished_requests()
+
+
+def test_worker_prepares_load_before_save_and_only_once():
+    worker = KVPoolWorker.__new__(KVPoolWorker)
+    worker.backend_name = "memcache"
+    worker.use_block_key_layerwise = False
+    worker.use_layerwise_transfer = True
+    worker.use_eagle = False
+    worker.num_layers = 1
+    worker.physical_layer_to_group_layers = {0: [(0, 0)]}
+    worker.kv_send_thread = MagicMock()
+    worker.kv_recv_thread = MagicMock()
+    worker._compute_reachable_store_masks = MagicMock(return_value=None)
+    worker._compute_reachable_load_masks = MagicMock(return_value=None)
+    worker._build_shared_save_data = MagicMock()
+    worker._build_shared_load_data = MagicMock()
+    request = make_request()
+    block_range = LayerBlockRange(request, 0, 2)
+    worker._process_save_for_layer_batch = lambda *args: worker.layer_save_tasks[0].append(
+        LayerTransferTask(0, [block_range])
+    )
+    worker._process_load_for_layer_batch = lambda *args: worker.layer_load_tasks[0].append(
+        LayerTransferTask(0, [block_range])
+    )
+    calls = []
+    preparer = MagicMock()
+    preparer._prepare_load_gvas.side_effect = lambda _: calls.append("lease")
+    preparer._alloc_gvas_for_save.side_effect = lambda _: calls.append("allocate")
+    worker._get_layerwise_transfer_preparer = lambda: preparer
+    worker.process_layer_data([request])
+    assert calls == []
+    save_preparation = worker.kv_send_thread.add_request.call_args.args[0]
+    load_preparation = worker.kv_recv_thread.add_request.call_args.args[0]
+    save_preparation.ensure_ready()
+    load_preparation.ensure_ready()
+    assert calls == ["lease", "allocate"]
+    worker._build_shared_save_data.assert_called_once()
+    worker._build_shared_load_data.assert_called_once()
+
+
+def test_full_and_hbm_tail_loads_have_distinct_shared_arrays():
+    from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import KVCacheStoreLayerRecvingThread
+
+    worker = KVPoolWorker.__new__(KVPoolWorker)
+    worker.kv_recv_thread = MagicMock(spec=KVCacheStoreLayerRecvingThread)
+    full, tail = object(), object()
+    worker.kv_recv_thread.build_shared_data.side_effect = [tail, full]
+    first = LayerTransferTask(0, [], uses_hbm_tail=True)
+    second = LayerTransferTask(1, [], uses_hbm_tail=False)
+    third = LayerTransferTask(2, [], uses_hbm_tail=False)
+    worker.layer_load_tasks = [[first], [second], [third]]
+    worker._build_shared_load_data()
+    assert first.shared_block_data is tail
+    assert second.shared_block_data is third.shared_block_data is full
+    assert worker.kv_recv_thread.build_shared_data.call_count == 2

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -977,14 +977,7 @@ class TestKVPoolSchedulerGetLayerwiseHitTokens(unittest.TestCase):
         for hash_count, hits, token_count, computed_tokens, expected in cases:
             with self.subTest(hits=hits, computed_tokens=computed_tokens):
                 scheduler = self._make_scheduler()
-                key_infos = []
-                for hit in hits:
-                    info = MagicMock()
-                    info.size.return_value = int(hit)
-                    if hit:
-                        info.gva_list.return_value = [0x1000]
-                    key_infos.append(info)
-                scheduler.store_scheduler.batch_get_key_info.return_value = key_infos
+                scheduler.store_scheduler.batch_is_exist.return_value = [int(hit) for hit in hits]
                 request = MagicMock()
                 request.block_hashes = [b"\xaa"] * hash_count
                 result = scheduler._get_layerwise_hit_tokens(request, token_count, computed_tokens)
@@ -1150,7 +1143,7 @@ class TestKVPoolSchedulerLayerwiseReachableLookup(unittest.TestCase):
         return info
 
     def _stub_pool(self, scheduler, num_blocks: int, pool_layout: dict[int, list[int]]):
-        """Mock batch_get_key_info so a block exists iff it is in pool_layout.
+        """Mock batch_is_exist so a block exists iff it is in pool_layout.
 
         Layerwise hit-check keys use the multi-group format model@group@hash@rank,
         so the stub decodes the group and block index from each key.
@@ -1163,10 +1156,10 @@ class TestKVPoolSchedulerLayerwiseReachableLookup(unittest.TestCase):
                 parts = key.split("@")
                 group_id = int(parts[1])
                 block_idx = hash_hex_by_idx[parts[2]]
-                infos.append(self._key_info(block_idx in pool_layout.get(group_id, [])))
+                infos.append(int(block_idx in pool_layout.get(group_id, [])))
             return infos
 
-        scheduler.store_scheduler.batch_get_key_info.side_effect = get_key_info
+        scheduler.store_scheduler.batch_is_exist.side_effect = get_key_info
 
     @staticmethod
     def _request(num_blocks: int):
@@ -1185,7 +1178,7 @@ class TestKVPoolSchedulerLayerwiseReachableLookup(unittest.TestCase):
         hit = scheduler._get_layerwise_hit_tokens(self._request(4), 64, 0)
 
         self.assertEqual(hit, 64)
-        queried_keys = scheduler.store_scheduler.batch_get_key_info.call_args_list
+        queried_keys = scheduler.store_scheduler.batch_is_exist.call_args_list
         # Only the 4 FA keys + 2 sparsely-stored SWA keys are queried.
         self.assertEqual(sum(len(call.args[0]) for call in queried_keys), 6)
 
@@ -1211,12 +1204,12 @@ class TestKVPoolSchedulerLayerwiseReachableLookup(unittest.TestCase):
     def test_without_coordinator_falls_back_to_contiguous(self):
         scheduler = self._make_scheduler()
         scheduler.cache_coordinator = None
-        infos = [self._key_info(True), self._key_info(False)]
+        infos = [1, 0]
 
         def get_key_info(keys):
-            return infos[: len(keys)]
+            return [infos[index % 2] for index in range(len(keys))]
 
-        scheduler.store_scheduler.batch_get_key_info.side_effect = get_key_info
+        scheduler.store_scheduler.batch_is_exist.side_effect = get_key_info
 
         hit = scheduler._get_layerwise_hit_tokens(self._request(2), 32, 0)
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -201,6 +201,7 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.layer_load_finished_events = [threading.Event()]
         worker.kv_recv_thread = MagicMock()
         worker.external_slot_release_waiter = MagicMock()
+        worker.use_layerwise_transfer = False
         worker._submit_ready_layer_loads = MagicMock()
 
         worker.wait_for_layer_load()
@@ -1516,10 +1517,7 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         missing_info = MagicMock()
         missing_info.size.return_value = 0
         missing_info.gva_list.return_value = []
-        worker.m_store.batch_get_key_info.side_effect = [
-            [valid_info],
-            [missing_info],
-        ]
+        worker.m_store.batch_get_key_info.return_value = [valid_info, missing_info]
         worker.m_store.batch_add_lease.return_value = [0]
         request = self._make_gva_request(
             num_groups=2,

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1890,7 +1890,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         if self.compress_ratio <= 1:
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(swa_metadata.req_metadata.sas_metadata))
-            record_attention_compute_start()
+            record_attention_compute_start(layer_name)
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1906,7 +1906,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(req_metadata.sas_metadata))
-            record_attention_compute_start()
+            record_attention_compute_start(layer_name)
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,
@@ -1926,7 +1926,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
             wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(compressor_req_metadata.sas_metadata))
-            record_attention_compute_start()
+            record_attention_compute_start(layer_name)
             attn_output = attn_op(
                 q,
                 ori_kv=swa_kv_cache,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2178,7 +2178,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         notify_kv_cache_written(layer_name)
         wait_for_device_metadata(DeviceMetadataStage.ATTENTION, id(common_metadata.sas_metadata))
-        record_attention_compute_start()
+        record_attention_compute_start(layer_name)
         kv_plan = get_dsa_attn_kv_plan(self.vllm_config)
         attn_op = kv_plan.get_dsa_sparse_attn_op()
         attn_kwargs = kv_plan.get_dsa_sparse_attn_base_kwargs()

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1347,7 +1347,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             "actual_seq_lengths": actual_seq_lengths_q,
             "actual_seq_lengths_kv": actual_seq_lengths_kv,
         }
-        record_attention_compute_start()
+        record_attention_compute_start(self.layer_name or "")
 
         if self.head_padding > 0:
             query = torch.cat((q_nope, q_pe), dim=-1)

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1490,7 +1490,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         # Open the prefetch gate for every SFA layer. Some GLM-5.2 layers
         # reuse cached top-k indices and have no indexer, so recording this
         # inside the indexer's forward would leave their gate closed.
-        record_attention_compute_start()
+        record_attention_compute_start(self.layer_name or "")
 
         attn_output = self._execute_sparse_flash_attention_process(
             ql_nope,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -299,6 +299,17 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         self.connector_worker.save_kv_layer(self._get_connector_metadata())
 
+    def on_kv_cache_written(self, layer_name: str = "") -> None:
+        """Dispatch a layerwise save as soon as its KV scatter completes."""
+        if not self.use_layerwise or not is_kv_save_role(self.kv_role, self.consumer_is_to_put):
+            return
+        if not self.has_connector_metadata():
+            return
+        worker = getattr(self, "connector_worker", None)
+        if worker is None:
+            return
+        worker.on_kv_cache_written(layer_name)
+
     def wait_for_save(self):
         if not is_kv_save_role(self.kv_role, self.consumer_is_to_put):
             # Don't do save if the role is kv_consumer

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/attention_fence.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/attention_fence.py
@@ -18,10 +18,14 @@ from __future__ import annotations
 
 import threading
 
+import regex as re
 import torch
 
 _lock = threading.RLock()
 _attention_compute_start_gate: AttentionComputeStartGate | None = None
+_gates: list[AttentionComputeStartGate] = []
+_layer_indices: dict[str, int] = {}
+_record_cursor = 0
 
 
 class AttentionComputeStartGate:
@@ -68,24 +72,49 @@ def reset_attention_compute_start_gate() -> AttentionComputeStartGate:
     they were submitted. The attention path opens that same gate when attention
     compute is about to be launched.
     """
-    global _attention_compute_start_gate
+    global _attention_compute_start_gate, _gates
     gate = AttentionComputeStartGate()
     with _lock:
         _attention_compute_start_gate = gate
+        _gates = []
     return gate
 
 
-def get_attention_compute_start_gate() -> AttentionComputeStartGate:
+def get_attention_compute_start_gate(layer_idx: int | None = None) -> AttentionComputeStartGate | None:
     with _lock:
+        if layer_idx is not None:
+            return _gates[layer_idx] if 0 <= layer_idx < len(_gates) else None
         gate = _attention_compute_start_gate
     if gate is None:
         gate = reset_attention_compute_start_gate()
     return gate
 
 
-def record_attention_compute_start() -> None:
-    """Record the compute-stream boundary immediately before attention."""
+def record_attention_compute_start(layer_name: str = "") -> None:
+    """Open the gate bound to this physical layer's attention boundary."""
+    global _record_cursor
     with _lock:
-        gate = _attention_compute_start_gate
+        if not _gates:
+            gate = _attention_compute_start_gate
+        else:
+            if layer_name:
+                idx = _layer_indices.get(layer_name)
+                if idx is None:
+                    match = re.search(r"layers\.(\d+)", layer_name)
+                    idx = int(match.group(1)) if match is not None else -1
+            else:
+                idx = _record_cursor
+                _record_cursor += 1
+            gate = _gates[idx] if 0 <= idx < len(_gates) else None
     if gate is not None:
         gate.record()
+
+
+def reset_attention_compute_start_gates(num_layers: int, layer_indices: dict[str, int] | None = None) -> None:
+    """Bind one gate per physical layer for an entire forward step."""
+    global _gates, _layer_indices, _record_cursor, _attention_compute_start_gate
+    with _lock:
+        _gates = [AttentionComputeStartGate() for _ in range(num_layers)]
+        _layer_indices = dict(layer_indices or {})
+        _record_cursor = 0
+        _attention_compute_start_gate = None

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -21,13 +21,15 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base impor
     Backend,
     require_aligned_batch_results,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_transfer import LayerBatchBuilder
 
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     ChunkedTokenDatabase,
     LayerBatchReqMeta,
-    LayerBlockRange,
     LayerLoadTask,
+    LayerSaveTask,
+    LayerwisePreparation,
     LayerRangeReqMeta,
     LayerTransferTask,
     ReqMeta,
@@ -106,404 +108,6 @@ class _LayerRevokeTask:
     keys: tuple[str, ...]
 
 
-class LayerBatchBuilder:
-    def __init__(
-        self,
-        token_database: ChunkedTokenDatabase,
-        page_size_bytes: int,
-        num_layers: int,
-        group_id: int = 0,
-    ) -> None:
-        self.page_size_bytes = page_size_bytes
-        self.num_layers = num_layers
-        self.group_id = group_id
-        self._block_len_np = np.asarray(token_database.group_block_len[group_id], dtype=np.int64)
-        self._kv_caches_base_addr_np = np.asarray(
-            token_database.group_kv_caches_base_addr[group_id],
-            dtype=np.int64,
-        )
-        group_block_stride = token_database.group_block_stride.get(group_id, token_database.group_block_len[group_id])
-        self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
-        layer_cache_entry_offsets = token_database.group_layer_cache_entry_offsets.get(group_id)
-        if layer_cache_entry_offsets is None:
-            caches_per_layer = max(1, self._block_len_np.shape[0] // max(1, num_layers))
-            layer_cache_entry_offsets = [
-                min(layer * caches_per_layer, self._block_len_np.shape[0]) for layer in range(num_layers + 1)
-            ]
-        self._layer_cache_entry_offsets_np = np.asarray(layer_cache_entry_offsets, dtype=np.int64)
-        self._block_ids_buf: np.ndarray | None = None
-        self._block_gvas_buf: np.ndarray | None = None
-
-    def _ensure_buf(self, capacity: int) -> tuple[np.ndarray, np.ndarray]:
-        if self._block_ids_buf is None or len(self._block_ids_buf) < capacity:
-            self._block_ids_buf = np.empty(capacity, dtype=np.int64)
-            self._block_gvas_buf = np.empty(capacity, dtype=np.int64)
-        assert self._block_ids_buf is not None and self._block_gvas_buf is not None
-        return self._block_ids_buf[:capacity], self._block_gvas_buf[:capacity]
-
-    @staticmethod
-    def _dedupe_transfer_blocks(
-        block_ids_arr: np.ndarray,
-        block_gvas_arr: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        if block_ids_arr.size <= 1:
-            return block_ids_arr, block_gvas_arr
-
-        block_transfer_array = np.column_stack((block_ids_arr, block_gvas_arr))
-        _, unique_indices = np.unique(
-            block_transfer_array,
-            axis=0,
-            return_index=True,
-        )
-        if unique_indices.size == block_ids_arr.size:
-            return block_ids_arr, block_gvas_arr
-
-        return (
-            block_ids_arr[unique_indices],
-            block_gvas_arr[unique_indices],
-        )
-
-    def _build_transfer_arrays(
-        self,
-        block_ids_arr: np.ndarray,
-        base_gvas_arr: np.ndarray,
-        layer_id: int,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        base_offset = int(self._layer_cache_entry_offsets_np[layer_id])
-        end_offset = int(self._layer_cache_entry_offsets_np[layer_id + 1])
-        layer_base_addrs = self._kv_caches_base_addr_np[base_offset:end_offset]
-        layer_block_len = self._block_len_np[base_offset:end_offset]
-        layer_block_stride = self._block_stride_np[base_offset:end_offset]
-        # Per-cache inner offsets within one layer's page: [0, len0, len0+len1, ...].
-        layer_inner_offsets = np.concatenate(
-            (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
-        )
-        rank_layer_offset = int(self._block_len_np[:base_offset].sum())
-        if base_gvas_arr.size > 0 and np.any(base_gvas_arr <= 0):
-            zero_count = int(np.sum(base_gvas_arr <= 0))
-            logger.warning(
-                "[KVPOOL] build_transfer layer=%d detected %d zero/negative base_gvas "
-                "(base_gvas_sample=%s); these blocks will be skipped in batch_copy",
-                layer_id,
-                zero_count,
-                base_gvas_arr[:5].tolist(),
-            )
-        logger.debug(
-            "[KVPOOL] build_transfer layer=%d page_size=%d caches_per_layer=%d "
-            "rank_layer_offset=%d layer_block_len=%s layer_inner_offsets=%s "
-            "base_gvas=%s",
-            layer_id,
-            self.page_size_bytes,
-            end_offset - base_offset,
-            rank_layer_offset,
-            layer_block_len.tolist(),
-            layer_inner_offsets.tolist(),
-            base_gvas_arr.tolist(),
-        )
-
-        addr_arr = layer_base_addrs[None, :] + block_ids_arr[:, None] * layer_block_stride[None, :]
-        size_arr = np.broadcast_to(layer_block_len, addr_arr.shape)
-        gvas_arr = base_gvas_arr[:, None] + rank_layer_offset + layer_inner_offsets[None, :]
-
-        return (
-            addr_arr.ravel(),
-            size_arr.ravel(),
-            gvas_arr.ravel(),
-        )
-
-    def _require_request_arrays(
-        self,
-        block_range: LayerBlockRange,
-        is_save: bool = True,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        request = block_range.request
-        group_id = self.group_id
-        block_ids_np: np.ndarray | None
-        block_gvas_np: np.ndarray | None
-        if is_save:
-            group_block_ids = request.block_ids_by_group_np
-            group_block_gvas = request.block_gvas_by_group_np
-            if (
-                group_block_ids is not None
-                and group_block_gvas is not None
-                and group_id < len(group_block_ids)
-                and group_id < len(group_block_gvas)
-            ):
-                block_ids_np = group_block_ids[group_id]
-                block_gvas_np = group_block_gvas[group_id]
-            else:
-                block_ids_np = request.block_ids_np
-                block_gvas_np = request.block_gvas_np
-        else:
-            group_block_ids = request.block_ids_by_group_np
-            group_block_gvas = request.load_block_gvas_by_group_np
-            if (
-                group_block_ids is not None
-                and group_block_gvas is not None
-                and group_id < len(group_block_ids)
-                and group_id < len(group_block_gvas)
-            ):
-                block_ids_np = group_block_ids[group_id]
-                block_gvas_np = group_block_gvas[group_id]
-            else:
-                block_ids_np = request.block_ids_np
-                block_gvas_np = request.load_block_gvas_np
-        if block_ids_np is None or block_gvas_np is None:
-            raise RuntimeError(
-                f"ReqMeta {'save' if is_save else 'load'} block metadata"
-                f" is not initialized for request {request.req_id}"
-            )
-        return block_ids_np, block_gvas_np
-
-    def build_shared(self, task: LayerTransferTask, is_save: bool = True) -> SharedBlockData | None:
-        """Pre-compute shared block data that is identical across all layers."""
-        if not task.block_ranges:
-            return None
-
-        if task.use_key_major_ranges:
-            return self._build_key_major_shared(task, is_save)
-
-        total = 0
-        for block_range in task.block_ranges:
-            total += block_range.end_block - block_range.start_block
-            if block_range.partial_block_index is not None:
-                total += 1
-
-        block_ids_arr, block_gvas_arr = self._ensure_buf(total)
-        req_ids: list[str] = []
-        is_last_chunks: list[bool | None] = []
-        all_save_keys: list[str] = []
-        all_load_keys: list[str] = []
-        collected_load_keys_request_ids: set[int] = set()
-        offset = 0
-
-        for block_range in task.block_ranges:
-            request = block_range.request
-            req_ids.append(request.req_id)
-            is_last_chunks.append(request.is_last_chunk)
-            if request.save_keys:
-                all_save_keys.extend(request.save_keys)
-            if request.load_keys and id(request) not in collected_load_keys_request_ids:
-                # Avoid collecting the same request's load_keys multiple times
-                collected_load_keys_request_ids.add(id(request))
-                all_load_keys.extend(request.load_keys)
-            block_ids_np, block_gvas_np = self._require_request_arrays(block_range, is_save)
-            gva_block_offset = request.gva_block_offset if is_save else request.load_gva_block_offset
-
-            num_blocks = block_range.end_block - block_range.start_block
-            if num_blocks > 0:
-                gva_start = block_range.start_block - gva_block_offset
-                gva_end = block_range.end_block - gva_block_offset
-                if gva_start < 0 or gva_end > len(block_gvas_np):
-                    raise RuntimeError(
-                        "ReqMeta GVA metadata does not cover requested block "
-                        f"range [{block_range.start_block}, {block_range.end_block}) "
-                        f"with offset {gva_block_offset}"
-                    )
-                end = offset + num_blocks
-                block_ids_arr[offset:end] = block_ids_np[block_range.start_block : block_range.end_block]
-                block_gvas_arr[offset:end] = block_gvas_np[gva_start:gva_end]
-                offset = end
-
-            if block_range.partial_block_index is not None:
-                partial_block_gva = None
-                partial_gva_per_group = (
-                    request.partial_save_gva_per_group if is_save else request.partial_load_gva_per_group
-                )
-                if task.group_id < len(partial_gva_per_group):
-                    partial_block_gva = partial_gva_per_group[task.group_id]
-                if partial_block_gva is None:
-                    partial_block_gva = request.last_block_gva
-                assert partial_block_gva is not None
-                block_ids_arr[offset] = block_ids_np[block_range.partial_block_index]
-                block_gvas_arr[offset] = partial_block_gva
-                offset += 1
-
-        block_ids_slice = block_ids_arr[:offset]
-        block_gvas_slice = block_gvas_arr[:offset]
-        valid_mask = block_gvas_slice > 0
-        if not np.all(valid_mask):
-            skip_count = int(np.sum(~valid_mask))
-            logger.warning(
-                "[KVPOOL] build_shared skipping %d blocks with invalid gva (gva<=0)",
-                skip_count,
-            )
-            block_ids_slice = block_ids_slice[valid_mask]
-            block_gvas_slice = block_gvas_slice[valid_mask]
-
-        block_ids_arr, block_gvas_arr = self._dedupe_transfer_blocks(block_ids_slice, block_gvas_slice)
-
-        logger.debug(
-            "[KVPOOL] build_shared req_ids=%s block_gvas_arr=%s block_ids_arr=%s",
-            req_ids,
-            block_gvas_arr.tolist(),
-            block_ids_arr.tolist(),
-        )
-        return SharedBlockData(
-            block_ids_arr=block_ids_arr,
-            block_gvas_arr=block_gvas_arr,
-            req_ids=req_ids,
-            is_last_chunks=is_last_chunks,
-            save_keys=all_save_keys,
-            load_keys=all_load_keys,
-        )
-
-    @staticmethod
-    def _request_block_keys(
-        request: ReqMeta,
-        is_save: bool,
-    ) -> tuple[list[str | None], int, str | None]:
-        if is_save:
-            return (
-                request.save_block_keys,
-                request.save_key_block_offset,
-                request.save_last_block_key,
-            )
-        return (
-            request.load_block_keys,
-            request.load_key_block_offset,
-            request.load_last_block_key,
-        )
-
-    def _request_block_ids(self, request: ReqMeta) -> list[int]:
-        if request.block_ids_by_group_np is not None and self.group_id < len(request.block_ids_by_group_np):
-            return request.block_ids_by_group_np[self.group_id].tolist()
-        if request.block_ids_np is not None:
-            return request.block_ids_np.tolist()
-        if self.group_id < len(request.block_ids_by_group):
-            return request.block_ids_by_group[self.group_id]
-        return request.block_ids
-
-    def _build_key_major_shared(
-        self,
-        task: LayerTransferTask,
-        is_save: bool,
-    ) -> SharedBlockData:
-        """Build block-key rows shared by all Mooncake layer ranges."""
-        block_ids: list[int] = []
-        block_keys: list[str] = []
-        req_ids: list[str] = []
-        is_last_chunks: list[bool | None] = []
-        all_load_keys: list[str] = []
-        seen_save_keys: set[str] = set()
-
-        for block_range in task.block_ranges:
-            request = block_range.request
-            req_ids.append(request.req_id)
-            is_last_chunks.append(request.is_last_chunk)
-            all_load_keys.extend(request.load_keys)
-            request_block_ids = self._request_block_ids(request)
-            if (
-                block_range.start_block < 0
-                or block_range.end_block < block_range.start_block
-                or block_range.end_block > len(request_block_ids)
-            ):
-                raise RuntimeError(
-                    "ReqMeta block metadata does not cover requested block range "
-                    f"[{block_range.start_block}, {block_range.end_block})"
-                )
-
-            request_keys, key_block_offset, last_block_key = self._request_block_keys(request, is_save)
-            key_start = block_range.start_block - key_block_offset
-            key_end = block_range.end_block - key_block_offset
-            if key_start < 0 or key_end > len(request_keys):
-                raise RuntimeError(
-                    f"ReqMeta {'save' if is_save else 'load'} block key metadata "
-                    f"does not cover requested range [{block_range.start_block}, "
-                    f"{block_range.end_block}) with offset {key_block_offset}"
-                )
-
-            for block_id, key in zip(
-                request_block_ids[block_range.start_block : block_range.end_block],
-                request_keys[key_start:key_end],
-                strict=True,
-            ):
-                if key is None or (is_save and key in seen_save_keys):
-                    continue
-                block_ids.append(block_id)
-                block_keys.append(key)
-                if is_save:
-                    seen_save_keys.add(key)
-
-            partial_block_index = block_range.partial_block_index
-            if partial_block_index is not None:
-                if partial_block_index < 0 or partial_block_index >= len(request_block_ids):
-                    raise RuntimeError(f"ReqMeta block metadata does not cover partial block {partial_block_index}")
-                if last_block_key is not None and (not is_save or last_block_key not in seen_save_keys):
-                    block_ids.append(request_block_ids[partial_block_index])
-                    block_keys.append(last_block_key)
-                    if is_save:
-                        seen_save_keys.add(last_block_key)
-
-        return SharedBlockData(
-            block_ids_arr=np.asarray(block_ids, dtype=np.int64),
-            block_gvas_arr=None,
-            block_keys=block_keys,
-            req_ids=req_ids,
-            is_last_chunks=is_last_chunks,
-            load_keys=all_load_keys,
-        )
-
-    def build_addrs(
-        self,
-        shared: SharedBlockData,
-        layer_id: int,
-    ) -> LayerBatchReqMeta | LayerRangeReqMeta:
-        """Compute per-layer addresses from pre-computed shared block data."""
-        if shared.block_keys is not None:
-            base_offset = int(self._layer_cache_entry_offsets_np[layer_id])
-            end_offset = int(self._layer_cache_entry_offsets_np[layer_id + 1])
-            layer_base_addrs = self._kv_caches_base_addr_np[base_offset:end_offset]
-            layer_block_len = self._block_len_np[base_offset:end_offset]
-            layer_block_stride = self._block_stride_np[base_offset:end_offset]
-            layer_inner_offsets = np.concatenate(
-                (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
-            )
-            layer_object_offset = int(self._block_len_np[:base_offset].sum())
-            offsets = (layer_object_offset + layer_inner_offsets).tolist()
-            sizes = layer_block_len.tolist()
-            all_buffers = [
-                (layer_base_addrs + block_id * layer_block_stride).tolist() for block_id in shared.block_ids_arr
-            ]
-            return LayerRangeReqMeta(
-                req_ids=shared.req_ids,
-                layer_id=layer_id,
-                block_ids=shared.block_ids_arr.tolist(),
-                keys=shared.block_keys,
-                all_buffers=all_buffers,
-                all_sizes=[sizes.copy() for _ in shared.block_ids_arr],
-                all_offsets=[offsets.copy() for _ in shared.block_ids_arr],
-                load_keys=shared.load_keys,
-            )
-
-        assert shared.block_gvas_arr is not None
-        addr_array, size_array, gvas_array = self._build_transfer_arrays(
-            shared.block_ids_arr, shared.block_gvas_arr, layer_id
-        )
-
-        return LayerBatchReqMeta(
-            req_ids=shared.req_ids,
-            layer_id=layer_id,
-            is_last_chunks=shared.is_last_chunks,
-            addr_array=addr_array,
-            size_array=size_array,
-            gvas_array=gvas_array,
-            load_keys=shared.load_keys,
-        )
-
-    def build(
-        self,
-        task: LayerTransferTask,
-        is_save: bool = True,
-    ) -> LayerBatchReqMeta | LayerRangeReqMeta | None:
-        """Full build: shared data + per-layer addresses (backward compat)."""
-        shared = self.build_shared(task, is_save)
-        if shared is None:
-            return None
-        layer_index = task.layer_id if task.use_key_major_ranges else task.layer_idx_in_group
-        return self.build_addrs(shared, layer_index)
-
-
 class KVTransferThread(threading.Thread):
     def __init__(
         self,
@@ -541,6 +145,7 @@ class KVTransferThread(threading.Thread):
         return self.block_size
 
     def add_request(self, request: Any) -> None:
+        self.raise_if_failed()
         self.request_queue.put(request)
 
     def get_and_clear_finished_requests(
@@ -1557,6 +1162,8 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         put_started_keys: set[str] | None = None,
         put_started_keys_lock: threading.Lock | None = None,
         session_tracker: MooncakeSessionTracker | None = None,
+        sync_attn_events: list[torch.npu.Event] | None = None,
+        layer_attn_recorded_events: list[threading.Event] | None = None,
     ):
         super().__init__(
             m_store,
@@ -1571,6 +1178,8 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.final_layer_id = num_layers - 1
         self.layer_save_finished_events = layer_save_finished_events
         self.sync_save_events = sync_save_events
+        self.sync_attn_events = sync_attn_events
+        self.layer_attn_recorded_events = layer_attn_recorded_events
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
         self.write_results: dict[str, int] = {}
@@ -1717,25 +1326,50 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             transfer_tasks.clear()
             self.request_queue.task_done()
 
+    def _wait_attention_done(self, physical_layer: int) -> None:
+        # slot_free also requires the compute stream to be past this layer's
+        # attention. The threading flag guards against the npu event being a
+        # no-op when synchronize() runs before record().
+        if self.layer_attn_recorded_events is None or self.sync_attn_events is None:
+            return
+        while not self.layer_attn_recorded_events[physical_layer].wait(timeout=10):
+            logger.info("Layerwise %d attention not recorded, keep waiting before slot_free", physical_layer)
+        self.sync_attn_events[physical_layer].synchronize()
+
     def _handle_request(  # type: ignore[override]
-        self, request: list[LayerTransferTask] | _LayerRevokeTask
+        self, request: list[LayerTransferTask] | _LayerRevokeTask | LayerSaveTask | LayerwisePreparation
     ):
+        if isinstance(request, LayerwisePreparation):
+            request.ensure_ready()
+            self.request_queue.task_done()
+            return
         if isinstance(request, _LayerRevokeTask):
             try:
                 self._revoke_range_keys(list(request.keys))
             finally:
                 self.request_queue.task_done()
             return
-        transfer_tasks = request
+        if isinstance(request, LayerSaveTask):
+            physical_layer = request.layer_id
+            transfer_tasks = request.transfer_tasks
+        else:
+            transfer_tasks = request
+            physical_layer = transfer_tasks[0].layer_id if transfer_tasks else 0
         # Layerwise threads only run when the worker-side
         # protocol gate is on; every store call below sits on the Backend ABC.
         if len(transfer_tasks) == 0:
+            if isinstance(request, LayerSaveTask):
+                self._wait_attention_done(physical_layer)
+                self.layer_save_finished_events[physical_layer].set()
             self.request_queue.task_done()
             return
         if transfer_tasks[0].use_key_major_ranges:
             self._handle_range_layer_tasks(transfer_tasks)
             return
         physical_layer = transfer_tasks[0].layer_id
+        preparation = transfer_tasks[0].preparation
+        if preparation is not None:
+            preparation.ensure_ready()
         has_any_save = False
         all_gvas = []
         all_addrs = []
@@ -1753,7 +1387,6 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
             if not isinstance(req_meta, LayerBatchReqMeta):
                 raise TypeError(f"Expected GVA layer metadata, got {type(req_meta).__name__}")
             for req_id in req_meta.req_ids:
-                self.dec_stored_request(req_id)
                 all_req_ids.append(req_id)
             all_save_keys.extend(shared.save_keys)
             write_finish_keys.extend(task.write_finish_keys)
@@ -1788,9 +1421,19 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
                         f"Layerwise save batch_write_finish failed: "
                         f"expected={len(finish_keys)}, results={finish_results}"
                     )
-            for req_id in all_req_ids:
-                if self.try_finish_and_delete_stored_request(req_id):
-                    self.set_finished_request(req_id)
+        self._wait_attention_done(physical_layer)
+        finished_req_ids = set().union(*(task.finished_req_ids for task in transfer_tasks))
+        for req_id in all_req_ids:
+            self.dec_stored_request(req_id)
+        last_chunk_req_ids = {
+            block_range.request.req_id
+            for task in transfer_tasks
+            for block_range in task.block_ranges
+            if block_range.request.is_last_chunk
+        }
+        for req_id in finished_req_ids & last_chunk_req_ids if preparation is not None else all_req_ids:
+            if self.try_finish_and_delete_stored_request(req_id):
+                self.set_finished_request(req_id)
         if not has_any_save:
             assert not self.layer_save_finished_events[physical_layer].is_set(), (
                 f"thread: {physical_layer} save failed "
@@ -1832,6 +1475,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         invalid_block_ids: set[int] | None = None,
         invalid_block_ids_lock: threading.Lock | None = None,
         load_abort_event: threading.Event | None = None,
+        release_load_leases: Callable[[set[str]], None] | None = None,
     ):
         super().__init__(
             m_store,
@@ -1848,6 +1492,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         self.layer_save_finished_events = layer_save_finished_events
         self.sync_save_events = sync_save_events
         self.final_layer_id = num_layers - 1
+        self.release_load_leases = release_load_leases
         self.h2d_stagger_us = h2d_stagger_us
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
@@ -2000,8 +1645,14 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             pass
 
     def _handle_request(  # type: ignore[override]
-        self, data: LayerLoadTask
+        self, data: LayerLoadTask | LayerwisePreparation
     ):
+        if isinstance(data, LayerwisePreparation):
+            data.ensure_ready()
+            self.request_queue.task_done()
+            return
+        if data.preparation is not None:
+            data.preparation.ensure_ready()
         if data.transfer_tasks and data.transfer_tasks[0].use_key_major_ranges:
             self._handle_range_layer_task(data)
             return
@@ -2108,7 +1759,10 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         if res != 0:
             raise RuntimeError(f"Layerwise {layer_id} load batch_copy failed with return code {res}")
 
-        if layer_id == self.final_layer_id and all_load_keys:
+        finished_req_ids = set().union(*(task.finished_req_ids for task, _ in task_metas))
+        if self.release_load_leases is not None:
+            self.release_load_leases(finished_req_ids)
+        elif layer_id == self.final_layer_id and all_load_keys:
             unique_load_keys = list(dict.fromkeys(all_load_keys))
             self.m_store.batch_remove_lease(unique_load_keys)
             logger.debug(
@@ -2116,8 +1770,8 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
                 len(unique_load_keys),
                 layer_id,
             )
-        if layer_id == self.final_layer_id:
-            for req_id in all_req_ids:
+        if finished_req_ids or layer_id == self.final_layer_id:
+            for req_id in finished_req_ids if self.release_load_leases is not None else all_req_ids:
                 if req_id in last_chunk_req_ids:
                     self.set_finished_request(req_id)
         assert not self.layer_load_finished_events[layer_id].is_set(), f"thread: {layer_id} load failed "

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_transfer.py
@@ -1,0 +1,807 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from vllm.logger import logger
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    ChunkedTokenDatabase,
+    LayerBatchReqMeta,
+    LayerBlockRange,
+    LayerRangeReqMeta,
+    LayerTransferTask,
+    ReqMeta,
+    SharedBlockData,
+    block_hash_to_str,
+    get_block_hashes,
+    get_partial_block_index,
+)
+
+LAYERWISE_READ_LEASE_TTL_MS = 5 * 60 * 1000
+MEMCACHE_UNMATCHED_STATE = -3101
+PARTIAL_LEASE_RETRY_COUNT = 10
+PARTIAL_LEASE_RETRY_INTERVAL_S = 0.001
+
+
+class LayerTransferArrayBuilder:
+    """Build vectorized local/GVA transfer arrays for one KV cache group."""
+
+    def __init__(
+        self,
+        token_database: ChunkedTokenDatabase,
+        num_layers: int,
+        group_id: int = 0,
+    ) -> None:
+        self._block_len_np = np.asarray(token_database.group_block_len[group_id], dtype=np.int64)
+        self._kv_caches_base_addr_np = np.asarray(
+            token_database.group_kv_caches_base_addr[group_id],
+            dtype=np.int64,
+        )
+        group_block_stride = token_database.group_block_stride.get(group_id, token_database.group_block_len[group_id])
+        self._block_stride_np = np.asarray(group_block_stride, dtype=np.int64)
+        offsets_by_group = getattr(token_database, "group_layer_cache_entry_offsets", None)
+        layer_offsets = offsets_by_group.get(group_id) if isinstance(offsets_by_group, dict) else None
+        if layer_offsets is None:
+            if num_layers <= 0 or self._block_len_np.size % num_layers:
+                raise ValueError(
+                    f"Cannot infer a uniform layerwise layout: legs={self._block_len_np.size}, layers={num_layers}"
+                )
+            caches_per_layer = self._block_len_np.size // num_layers
+            layer_offsets = np.arange(num_layers + 1, dtype=np.int64) * caches_per_layer
+        else:
+            layer_offsets = np.asarray(layer_offsets, dtype=np.int64)
+            if (
+                layer_offsets.size != num_layers + 1
+                or layer_offsets[0] != 0
+                or layer_offsets[-1] != self._block_len_np.size
+                or np.any(layer_offsets[1:] < layer_offsets[:-1])
+            ):
+                raise ValueError(
+                    f"Invalid layerwise offsets for group {group_id}: "
+                    f"offsets={layer_offsets.tolist()}, legs={self._block_len_np.size}, layers={num_layers}"
+                )
+        self._layer_offsets_np = layer_offsets
+
+        # The flat buffers are layer-major. Their byte prefix therefore gives
+        # both each layer's compact GVA offset and each leg's inner-layer offset.
+        byte_prefix = np.empty(self._block_len_np.size + 1, dtype=np.int64)
+        byte_prefix[0] = 0
+        np.cumsum(self._block_len_np, out=byte_prefix[1:])
+        self._layer_gva_offsets_np = byte_prefix[self._layer_offsets_np[:-1]]
+        leg_counts = np.diff(self._layer_offsets_np)
+        self._leg_inner_offsets_np = byte_prefix[:-1] - np.repeat(
+            self._layer_gva_offsets_np,
+            leg_counts,
+        )
+        self.page_size_bytes = int(np.diff(byte_prefix[self._layer_offsets_np]).max())
+
+    def _build_transfer_arrays(
+        self,
+        block_ids_arr: np.ndarray,
+        base_gvas_arr: np.ndarray,
+        layer_id: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        leg_start = int(self._layer_offsets_np[layer_id])
+        leg_end = int(self._layer_offsets_np[layer_id + 1])
+        layer_base_addrs = self._kv_caches_base_addr_np[leg_start:leg_end]
+        layer_block_len = self._block_len_np[leg_start:leg_end]
+        layer_block_stride = self._block_stride_np[leg_start:leg_end]
+        layer_inner_offsets = self._leg_inner_offsets_np[leg_start:leg_end]
+        rank_layer_offset = self._layer_gva_offsets_np[layer_id]
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "[KVPOOL] build_transfer layer=%d page_size=%d cache_legs=%d "
+                "rank_layer_offset=%d layer_block_len=%s layer_inner_offsets=%s base_gvas=%s",
+                layer_id,
+                self.page_size_bytes,
+                leg_end - leg_start,
+                rank_layer_offset,
+                layer_block_len.tolist(),
+                layer_inner_offsets.tolist(),
+                base_gvas_arr.tolist(),
+            )
+
+        addr_arr = layer_base_addrs[None, :] + block_ids_arr[:, None] * layer_block_stride[None, :]
+        size_arr = np.broadcast_to(layer_block_len, addr_arr.shape)
+        gvas_arr = base_gvas_arr[:, None] + rank_layer_offset + layer_inner_offsets[None, :]
+        return addr_arr.ravel(), size_arr.ravel(), gvas_arr.ravel()
+
+
+class LayerBatchBuilder(LayerTransferArrayBuilder):
+    def __init__(
+        self, token_database: ChunkedTokenDatabase, page_size_bytes: int, num_layers: int, group_id: int = 0
+    ) -> None:
+        super().__init__(token_database, num_layers, group_id)
+        self.num_layers = num_layers
+        self.group_id = group_id
+        self._layer_cache_entry_offsets_np = self._layer_offsets_np
+        self._block_ids_buf: np.ndarray | None = None
+        self._block_gvas_buf: np.ndarray | None = None
+
+    def _ensure_buf(self, capacity: int) -> tuple[np.ndarray, np.ndarray]:
+        if self._block_ids_buf is None or len(self._block_ids_buf) < capacity:
+            self._block_ids_buf = np.empty(capacity, dtype=np.int64)
+            self._block_gvas_buf = np.empty(capacity, dtype=np.int64)
+        assert self._block_ids_buf is not None and self._block_gvas_buf is not None
+        return self._block_ids_buf[:capacity], self._block_gvas_buf[:capacity]
+
+    @staticmethod
+    def _dedupe_transfer_blocks(
+        block_ids_arr: np.ndarray,
+        block_gvas_arr: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if block_ids_arr.size <= 1:
+            return block_ids_arr, block_gvas_arr
+
+        block_transfer_array = np.column_stack((block_ids_arr, block_gvas_arr))
+        _, unique_indices = np.unique(
+            block_transfer_array,
+            axis=0,
+            return_index=True,
+        )
+        if unique_indices.size == block_ids_arr.size:
+            return block_ids_arr, block_gvas_arr
+
+        return (
+            block_ids_arr[unique_indices],
+            block_gvas_arr[unique_indices],
+        )
+
+    def _require_request_arrays(
+        self,
+        block_range: LayerBlockRange,
+        is_save: bool = True,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        request = block_range.request
+        group_id = self.group_id
+        block_ids_np: np.ndarray | None
+        block_gvas_np: np.ndarray | None
+        if is_save:
+            group_block_ids = request.block_ids_by_group_np
+            group_block_gvas = request.block_gvas_by_group_np
+            if (
+                group_block_ids is not None
+                and group_block_gvas is not None
+                and group_id < len(group_block_ids)
+                and group_id < len(group_block_gvas)
+            ):
+                block_ids_np = group_block_ids[group_id]
+                block_gvas_np = group_block_gvas[group_id]
+            else:
+                block_ids_np = request.block_ids_np
+                block_gvas_np = request.block_gvas_np
+        else:
+            group_block_ids = request.block_ids_by_group_np
+            group_block_gvas = request.load_block_gvas_by_group_np
+            if (
+                group_block_ids is not None
+                and group_block_gvas is not None
+                and group_id < len(group_block_ids)
+                and group_id < len(group_block_gvas)
+            ):
+                block_ids_np = group_block_ids[group_id]
+                block_gvas_np = group_block_gvas[group_id]
+            else:
+                block_ids_np = request.block_ids_np
+                block_gvas_np = request.load_block_gvas_np
+        if block_ids_np is None or block_gvas_np is None:
+            raise RuntimeError(
+                f"ReqMeta {'save' if is_save else 'load'} block metadata"
+                f" is not initialized for request {request.req_id}"
+            )
+        return block_ids_np, block_gvas_np
+
+    def build_shared(self, task: LayerTransferTask, is_save: bool = True) -> SharedBlockData | None:
+        """Pre-compute shared block data that is identical across all layers."""
+        if not task.block_ranges:
+            return None
+
+        if task.use_key_major_ranges:
+            return self._build_key_major_shared(task, is_save)
+
+        total = 0
+        for block_range in task.block_ranges:
+            total += block_range.end_block - block_range.start_block
+            if block_range.partial_block_index is not None:
+                total += 1
+
+        block_ids_arr, block_gvas_arr = self._ensure_buf(total)
+        req_ids: list[str] = []
+        is_last_chunks: list[bool | None] = []
+        all_save_keys: list[str] = []
+        all_load_keys: list[str] = []
+        collected_load_keys_request_ids: set[int] = set()
+        offset = 0
+
+        for block_range in task.block_ranges:
+            request = block_range.request
+            req_ids.append(request.req_id)
+            is_last_chunks.append(request.is_last_chunk)
+            if request.save_keys:
+                all_save_keys.extend(request.save_keys)
+            if request.load_keys and id(request) not in collected_load_keys_request_ids:
+                # Avoid collecting the same request's load_keys multiple times
+                collected_load_keys_request_ids.add(id(request))
+                all_load_keys.extend(request.load_keys)
+            block_ids_np, block_gvas_np = self._require_request_arrays(block_range, is_save)
+            gva_block_offset = request.gva_block_offset if is_save else request.load_gva_block_offset
+
+            num_blocks = block_range.end_block - block_range.start_block
+            if num_blocks > 0:
+                gva_start = block_range.start_block - gva_block_offset
+                gva_end = block_range.end_block - gva_block_offset
+                if gva_start < 0 or gva_end > len(block_gvas_np):
+                    raise RuntimeError(
+                        "ReqMeta GVA metadata does not cover requested block "
+                        f"range [{block_range.start_block}, {block_range.end_block}) "
+                        f"with offset {gva_block_offset}"
+                    )
+                end = offset + num_blocks
+                block_ids_arr[offset:end] = block_ids_np[block_range.start_block : block_range.end_block]
+                block_gvas_arr[offset:end] = block_gvas_np[gva_start:gva_end]
+                offset = end
+
+            if block_range.partial_block_index is not None:
+                partial_block_gva = None
+                partial_gva_per_group = (
+                    request.partial_save_gva_per_group if is_save else request.partial_load_gva_per_group
+                )
+                if task.group_id < len(partial_gva_per_group):
+                    partial_block_gva = partial_gva_per_group[task.group_id]
+                if partial_block_gva is None:
+                    partial_block_gva = request.last_block_gva
+                assert partial_block_gva is not None
+                block_ids_arr[offset] = block_ids_np[block_range.partial_block_index]
+                block_gvas_arr[offset] = partial_block_gva
+                offset += 1
+
+        block_ids_slice = block_ids_arr[:offset]
+        block_gvas_slice = block_gvas_arr[:offset]
+        valid_mask = block_gvas_slice > 0
+        if not np.all(valid_mask):
+            skip_count = int(np.sum(~valid_mask))
+            logger.warning(
+                "[KVPOOL] build_shared skipping %d blocks with invalid gva (gva<=0)",
+                skip_count,
+            )
+            block_ids_slice = block_ids_slice[valid_mask]
+            block_gvas_slice = block_gvas_slice[valid_mask]
+
+        block_ids_arr, block_gvas_arr = self._dedupe_transfer_blocks(block_ids_slice, block_gvas_slice)
+
+        logger.debug(
+            "[KVPOOL] build_shared req_ids=%s block_gvas_arr=%s block_ids_arr=%s",
+            req_ids,
+            block_gvas_arr.tolist(),
+            block_ids_arr.tolist(),
+        )
+        return SharedBlockData(
+            block_ids_arr=block_ids_arr,
+            block_gvas_arr=block_gvas_arr,
+            req_ids=req_ids,
+            is_last_chunks=is_last_chunks,
+            save_keys=all_save_keys,
+            load_keys=all_load_keys,
+        )
+
+    @staticmethod
+    def _request_block_keys(
+        request: ReqMeta,
+        is_save: bool,
+    ) -> tuple[list[str | None], int, str | None]:
+        if is_save:
+            return (
+                request.save_block_keys,
+                request.save_key_block_offset,
+                request.save_last_block_key,
+            )
+        return (
+            request.load_block_keys,
+            request.load_key_block_offset,
+            request.load_last_block_key,
+        )
+
+    def _request_block_ids(self, request: ReqMeta) -> list[int]:
+        if request.block_ids_by_group_np is not None and self.group_id < len(request.block_ids_by_group_np):
+            return request.block_ids_by_group_np[self.group_id].tolist()
+        if request.block_ids_np is not None:
+            return request.block_ids_np.tolist()
+        if self.group_id < len(request.block_ids_by_group):
+            return request.block_ids_by_group[self.group_id]
+        return request.block_ids
+
+    def _build_key_major_shared(
+        self,
+        task: LayerTransferTask,
+        is_save: bool,
+    ) -> SharedBlockData:
+        """Build block-key rows shared by all Mooncake layer ranges."""
+        block_ids: list[int] = []
+        block_keys: list[str] = []
+        req_ids: list[str] = []
+        is_last_chunks: list[bool | None] = []
+        all_load_keys: list[str] = []
+        seen_save_keys: set[str] = set()
+
+        for block_range in task.block_ranges:
+            request = block_range.request
+            req_ids.append(request.req_id)
+            is_last_chunks.append(request.is_last_chunk)
+            all_load_keys.extend(request.load_keys)
+            request_block_ids = self._request_block_ids(request)
+            if (
+                block_range.start_block < 0
+                or block_range.end_block < block_range.start_block
+                or block_range.end_block > len(request_block_ids)
+            ):
+                raise RuntimeError(
+                    "ReqMeta block metadata does not cover requested block range "
+                    f"[{block_range.start_block}, {block_range.end_block})"
+                )
+
+            request_keys, key_block_offset, last_block_key = self._request_block_keys(request, is_save)
+            key_start = block_range.start_block - key_block_offset
+            key_end = block_range.end_block - key_block_offset
+            if key_start < 0 or key_end > len(request_keys):
+                raise RuntimeError(
+                    f"ReqMeta {'save' if is_save else 'load'} block key metadata "
+                    f"does not cover requested range [{block_range.start_block}, "
+                    f"{block_range.end_block}) with offset {key_block_offset}"
+                )
+
+            for block_id, key in zip(
+                request_block_ids[block_range.start_block : block_range.end_block],
+                request_keys[key_start:key_end],
+                strict=True,
+            ):
+                if key is None or (is_save and key in seen_save_keys):
+                    continue
+                block_ids.append(block_id)
+                block_keys.append(key)
+                if is_save:
+                    seen_save_keys.add(key)
+
+            partial_block_index = block_range.partial_block_index
+            if partial_block_index is not None:
+                if partial_block_index < 0 or partial_block_index >= len(request_block_ids):
+                    raise RuntimeError(f"ReqMeta block metadata does not cover partial block {partial_block_index}")
+                if last_block_key is not None and (not is_save or last_block_key not in seen_save_keys):
+                    block_ids.append(request_block_ids[partial_block_index])
+                    block_keys.append(last_block_key)
+                    if is_save:
+                        seen_save_keys.add(last_block_key)
+
+        return SharedBlockData(
+            block_ids_arr=np.asarray(block_ids, dtype=np.int64),
+            block_gvas_arr=None,
+            block_keys=block_keys,
+            req_ids=req_ids,
+            is_last_chunks=is_last_chunks,
+            load_keys=all_load_keys,
+        )
+
+    def build_addrs(
+        self,
+        shared: SharedBlockData,
+        layer_id: int,
+    ) -> LayerBatchReqMeta | LayerRangeReqMeta:
+        """Compute per-layer addresses from pre-computed shared block data."""
+        if shared.block_keys is not None:
+            base_offset = int(self._layer_cache_entry_offsets_np[layer_id])
+            end_offset = int(self._layer_cache_entry_offsets_np[layer_id + 1])
+            layer_base_addrs = self._kv_caches_base_addr_np[base_offset:end_offset]
+            layer_block_len = self._block_len_np[base_offset:end_offset]
+            layer_block_stride = self._block_stride_np[base_offset:end_offset]
+            layer_inner_offsets = np.concatenate(
+                (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
+            )
+            layer_object_offset = int(self._block_len_np[:base_offset].sum())
+            offsets = (layer_object_offset + layer_inner_offsets).tolist()
+            sizes = layer_block_len.tolist()
+            all_buffers = [
+                (layer_base_addrs + block_id * layer_block_stride).tolist() for block_id in shared.block_ids_arr
+            ]
+            return LayerRangeReqMeta(
+                req_ids=shared.req_ids,
+                layer_id=layer_id,
+                block_ids=shared.block_ids_arr.tolist(),
+                keys=shared.block_keys,
+                all_buffers=all_buffers,
+                all_sizes=[sizes.copy() for _ in shared.block_ids_arr],
+                all_offsets=[offsets.copy() for _ in shared.block_ids_arr],
+                load_keys=shared.load_keys,
+            )
+
+        assert shared.block_gvas_arr is not None
+        addr_array, size_array, gvas_array = self._build_transfer_arrays(
+            shared.block_ids_arr, shared.block_gvas_arr, layer_id
+        )
+
+        return LayerBatchReqMeta(
+            req_ids=shared.req_ids,
+            layer_id=layer_id,
+            is_last_chunks=shared.is_last_chunks,
+            addr_array=addr_array,
+            size_array=size_array,
+            gvas_array=gvas_array,
+            load_keys=shared.load_keys,
+        )
+
+    def build(
+        self,
+        task: LayerTransferTask,
+        is_save: bool = True,
+    ) -> LayerBatchReqMeta | LayerRangeReqMeta | None:
+        """Full build: shared data + per-layer addresses (backward compat)."""
+        shared = self.build_shared(task, is_save)
+        if shared is None:
+            return None
+        layer_index = task.layer_id if task.use_key_major_ranges else task.layer_idx_in_group
+        return self.build_addrs(shared, layer_index)
+
+
+@dataclass
+class GroupKeyPlan:
+    request: ReqMeta
+    group_id: int
+    block_ids: np.ndarray
+    block_indices: list[int]
+    keys: list[str]
+    partial_block_index: int | None
+    partial_key: str | None
+
+
+class LayerwiseTransferPreparer:
+    """Own GVA metadata and leases without depending on the pool worker.
+
+    Keep backend key protocols, partial-snapshot retry, and reachable-block
+    filtering from main while sharing preparation across all layer tasks.
+    """
+
+    def __init__(
+        self,
+        m_store: Backend,
+        model_name: str,
+        head_or_tp_rank: int,
+        hash_block_size: int,
+        *,
+        enabled: bool,
+        can_allocate: bool,
+        block_sizes: list[int],
+        group_block_len: dict[int, list[int]],
+        page_size_bytes: int,
+        layerwise_offload: bool,
+        protocol: Any,
+        record_invalid_blocks: Callable[[list[int]], None],
+        use_eagle: bool = False,
+        allocated_gvas: dict[str, int] | None = None,
+    ) -> None:
+        self.m_store = m_store
+        self.model_name = model_name
+        self.head_or_tp_rank = head_or_tp_rank
+        self.hash_block_size = hash_block_size
+        self.use_layerwise_transfer = enabled
+        self.enabled = enabled
+        self.can_allocate = can_allocate
+        self.grouped_block_size = block_sizes
+        self.num_kv_cache_groups = len(block_sizes)
+        self.group_block_len = group_block_len
+        self.page_size_bytes = page_size_bytes
+        self.layerwise_offload = layerwise_offload
+        self.layerwise_protocol = protocol
+        self.record_invalid_blocks = record_invalid_blocks
+        self.use_eagle = use_eagle
+        self._allocated_gvas = allocated_gvas if allocated_gvas is not None else {}
+        self.load_lease_keys_by_request: dict[str, set[str]] = {}
+        self.load_lease_refcounts: dict[str, int] = {}
+        self._lease_lock = threading.RLock()
+
+    def _make_layerwise_full_key(self, group_id: int, block_hash_hex: str) -> str:
+        """Full-block key for the layerwise transfer, built by the
+        backend's protocol module.
+
+        Single-group models use the PR #11585 format (model@hash@rank) for
+        backward compatibility. Multi-group models include group_id
+        (model@group_id@hash@rank) to distinguish groups.
+        """
+        return self.layerwise_protocol.make_full_key(
+            self.model_name,
+            group_id,
+            block_hash_hex,
+            self.head_or_tp_rank,
+            self.num_kv_cache_groups,
+        )
+
+    def _make_layerwise_partial_key(
+        self,
+        request: ReqMeta,
+        group_id: int,
+        block_index: int,
+        end_token: int,
+    ) -> str:
+        return self.layerwise_protocol.make_partial_key(
+            self.model_name,
+            request.req_id,
+            group_id,
+            block_index,
+            end_token,
+            self.head_or_tp_rank,
+        )
+
+    def _refresh_allocated_gvas(self, keys: list[str]) -> None:
+        """Drop local GVA entries whose MemCache blobs were evicted."""
+        cached_keys = list(dict.fromkeys(key for key in keys if key in self._allocated_gvas))
+        if not cached_keys:
+            return
+        exists_states = self.m_store.batch_is_exist(cached_keys)
+        if len(exists_states) != len(cached_keys):
+            raise RuntimeError(
+                "MemCache exists check returned unexpected number of states: "
+                f"expected={len(cached_keys)}, actual={len(exists_states)}"
+            )
+        for key, exists in zip(cached_keys, exists_states):
+            if exists == 0:
+                self._allocated_gvas.pop(key, None)
+            elif exists != 1:
+                raise RuntimeError(f"MemCache exists check failed for {key}: state={exists}")
+
+    def _build_key_plans(self, requests: list[ReqMeta], *, is_save: bool) -> list[GroupKeyPlan]:
+        """Resolve logical ranges once, before any backend operation."""
+        plans = []
+        for request in requests:
+            if is_save:
+                if not request.can_save:
+                    continue
+                cached_tokens = request.target_token_len
+            else:
+                if request.load_spec is None or not request.load_spec.can_load:
+                    continue
+                cached_tokens = request.load_spec.kvpool_cached_tokens
+                if not self.use_eagle and request.load_spec.kvpool_store_skip_tokens is not None:
+                    cached_tokens = request.load_spec.kvpool_store_skip_tokens
+            for group_id, block_size in enumerate(self.grouped_block_size):
+                group_ids = request.block_ids_by_group_np
+                block_ids = (
+                    group_ids[group_id] if group_ids is not None and group_id < len(group_ids) else request.block_ids_np
+                )
+                if block_ids is None:
+                    raise RuntimeError(f"Block IDs are not initialized for request {request.req_id}, group {group_id}")
+                hashes = get_block_hashes(request.block_hashes, block_size, self.hash_block_size)
+                if is_save:
+                    start = request.save_start_token // block_size
+                    end = request.save_end_token // block_size
+                    if request.load_spec is not None and request.load_spec.can_load:
+                        pool_hit = request.load_spec.kvpool_store_skip_tokens
+                        if pool_hit is None:
+                            pool_hit = request.load_spec.kvpool_cached_tokens
+                        start = max(start, pool_hit // block_size)
+                    masks = request.store_masks
+                else:
+                    assert request.load_spec is not None
+                    start = 0 if self.layerwise_offload else request.load_spec.vllm_cached_tokens // block_size
+                    end = cached_tokens // block_size
+                    masks = request.load_masks
+                mask = masks[group_id] if masks is not None and group_id < len(masks) else None
+                indices = [
+                    i
+                    for i in range(start, min(end, len(hashes), len(block_ids)))
+                    if mask is None or i >= len(mask) or mask[i]
+                ]
+                keys = [self._make_layerwise_full_key(group_id, block_hash_to_str(hashes[i])) for i in indices]
+                partial = get_partial_block_index(cached_tokens, block_size, len(hashes), self.layerwise_offload)
+                if partial is not None and (partial < start or partial >= len(block_ids)):
+                    partial = None
+                partial_key = (
+                    self._make_layerwise_partial_key(request, group_id, partial, cached_tokens)
+                    if partial is not None
+                    else None
+                )
+                plans.append(
+                    GroupKeyPlan(
+                        request, group_id, np.asarray(block_ids, dtype=np.int64), indices, keys, partial, partial_key
+                    )
+                )
+        return plans
+
+    def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
+        """Allocate all groups in one batch, preserving cached and partial keys."""
+        if not self.enabled or not self.can_allocate:
+            return
+        plans = self._build_key_plans(requests, is_save=True)
+        self._refresh_allocated_gvas([key for plan in plans for key in plan.keys])
+        sizes_by_key: dict[str, int] = {}
+        for plan in plans:
+            # Already-published prefixes must not be written again. Preserve
+            # main's eviction check before consulting the local GVA cache.
+            prefix = 0
+            for key in plan.keys:
+                if key not in self._allocated_gvas:
+                    break
+                prefix += 1
+            plan.keys = plan.keys[prefix:]
+            plan.block_indices = plan.block_indices[prefix:]
+            block_lengths = self.group_block_len.get(plan.group_id, self.group_block_len.get(0, []))
+            alloc_size = sum(block_lengths) if block_lengths else self.page_size_bytes
+            for key in [*plan.keys, *([plan.partial_key] if plan.partial_key else [])]:
+                if key in self._allocated_gvas:
+                    continue
+                if key in sizes_by_key and sizes_by_key[key] != alloc_size:
+                    raise RuntimeError(f"Conflicting allocation sizes for layerwise key {key}")
+                sizes_by_key[key] = alloc_size
+        keys = list(sizes_by_key)
+        new_gvas = (
+            self.m_store.batch_alloc(keys, list(sizes_by_key.values()), LAYERWISE_READ_LEASE_TTL_MS) if keys else []
+        )
+        if len(new_gvas) != len(keys) or any(gva <= 0 for gva in new_gvas):
+            raise RuntimeError(f"batch_alloc returned invalid GVAs: expected={len(keys)}, actual={len(new_gvas)}")
+        new_gvas_by_key = dict(zip(keys, new_gvas, strict=True))
+        seen_requests: set[str] = set()
+        copied_keys: set[str] = set()
+        for plan in plans:
+            request = plan.request
+            if request.req_id not in seen_requests:
+                request.block_gvas_by_group_np = [
+                    np.zeros(len(ids), dtype=np.int64) for ids in request.block_ids_by_group_np
+                ]
+                request.partial_save_gva_per_group = [0] * self.num_kv_cache_groups
+                request.save_keys = []
+                seen_requests.add(request.req_id)
+            gvas = request.block_gvas_by_group_np[plan.group_id]
+            for index, key in zip(plan.block_indices, plan.keys, strict=True):
+                if key not in copied_keys:
+                    gva = new_gvas_by_key[key] if key in new_gvas_by_key else self._allocated_gvas[key]
+                    gvas[index] = gva
+                    self._allocated_gvas[key] = gva
+                    copied_keys.add(key)
+                    if key in new_gvas_by_key:
+                        request.save_keys.append(key)
+            if plan.partial_key is not None and plan.partial_key not in copied_keys:
+                key = plan.partial_key
+                request.partial_save_gva_per_group[plan.group_id] = (
+                    new_gvas_by_key[key] if key in new_gvas_by_key else self._allocated_gvas[key]
+                )
+                request.save_keys.append(key)
+                copied_keys.add(key)
+                self._allocated_gvas.pop(key, None)
+            request.block_gvas_np = request.block_gvas_by_group_np[0]
+            request.gva_block_offset = 0
+
+    def _prepare_load_gvas(self, requests: list[ReqMeta]) -> None:
+        """Fetch one deduplicated batch and acquire shared request read leases."""
+        if not self.enabled:
+            return
+        plans = self._build_key_plans(requests, is_save=False)
+        keys = list(
+            dict.fromkeys(
+                key for plan in plans for key in [*plan.keys, *([plan.partial_key] if plan.partial_key else [])]
+            )
+        )
+        if not plans:
+            return
+        key_infos = self.m_store.batch_get_key_info(keys) if keys else []
+        if len(key_infos) != len(keys):
+            raise RuntimeError(
+                "Layerwise load preparation returned unexpected key infos: "
+                f"expected={len(keys)}, actual={len(key_infos)}"
+            )
+        gvas: dict[str, int] = {}
+        for key, info in zip(keys, key_infos, strict=True):
+            size = info.size()
+            addresses = info.gva_list()
+            if size and size > 0 and not addresses:
+                raise RuntimeError(f"Layerwise load preparation returned invalid GVA metadata for {key}")
+            gvas[key] = addresses[0] if size and size > 0 else 0
+        valid_keys = [key for key in keys if gvas[key] > 0]
+        partial_keys = {plan.partial_key for plan in plans if plan.partial_key is not None}
+        # Serialize acquisition/registration with final release. A finishing
+        # request must not remove a key just acquired by the next batch.
+        with self._lease_lock:
+            new_keys = [key for key in valid_keys if key not in self.load_lease_refcounts]
+            lease_results = (
+                list(self.m_store.batch_add_lease(new_keys, LAYERWISE_READ_LEASE_TTL_MS)) if new_keys else []
+            )
+            acquired = {key for key, result in zip(new_keys, lease_results) if result == 0}
+            try:
+                if len(lease_results) != len(new_keys):
+                    raise RuntimeError(
+                        "MemCache lease returned unexpected number of results: "
+                        f"expected={len(new_keys)}, actual={len(lease_results)}"
+                    )
+                for index, key in enumerate(new_keys):
+                    if key in partial_keys:
+                        for _ in range(PARTIAL_LEASE_RETRY_COUNT):
+                            if lease_results[index] != MEMCACHE_UNMATCHED_STATE:
+                                break
+                            time.sleep(PARTIAL_LEASE_RETRY_INTERVAL_S)
+                            retry = self.m_store.batch_add_lease([key], LAYERWISE_READ_LEASE_TTL_MS)
+                            if len(retry) != 1:
+                                raise RuntimeError(
+                                    f"MemCache partial lease retry returned unexpected number of results: {len(retry)}"
+                                )
+                            lease_results[index] = retry[0]
+                    if lease_results[index] == 0:
+                        acquired.add(key)
+                    else:
+                        gvas[key] = 0
+                keys_by_request: dict[str, set[str]] = {}
+                seen_requests: set[str] = set()
+                for plan in plans:
+                    request = plan.request
+                    if request.req_id not in seen_requests:
+                        request.load_block_gvas_by_group_np = [
+                            np.zeros(len(ids), dtype=np.int64) for ids in request.block_ids_by_group_np
+                        ]
+                        request.partial_load_gva_per_group = [0] * self.num_kv_cache_groups
+                        request.load_keys = []
+                        seen_requests.add(request.req_id)
+                    request_keys = keys_by_request.setdefault(request.req_id, set())
+                    positions = list(zip(plan.block_indices, plan.keys, strict=True))
+                    if plan.partial_key is not None:
+                        positions.append((plan.partial_block_index, plan.partial_key))
+                    invalid_blocks = []
+                    for block_index, key in positions:
+                        gva = gvas[key]
+                        if gva <= 0:
+                            invalid_blocks.append(int(plan.block_ids[block_index]))
+                        else:
+                            request_keys.add(key)
+                            request.load_keys.append(key)
+                        if key == plan.partial_key:
+                            request.partial_load_gva_per_group[plan.group_id] = gva
+                        else:
+                            request.load_block_gvas_by_group_np[plan.group_id][block_index] = gva
+                    if invalid_blocks:
+                        if self.num_kv_cache_groups > 1:
+                            raise RuntimeError(
+                                "Layerwise multi-group KV load failed and cannot safely "
+                                "fall back to per-block recomputation: "
+                                f"request={request.req_id}, failed_blocks={invalid_blocks}"
+                            )
+                        self.record_invalid_blocks(invalid_blocks)
+                    request.load_block_gvas_np = request.load_block_gvas_by_group_np[0]
+                    request.load_gva_block_offset = 0
+                self.register_load_leases(keys_by_request)
+            except Exception:
+                if acquired:
+                    result = self.m_store.batch_remove_lease(sorted(acquired))
+                    if result != 0:
+                        logger.error("Failed to roll back layerwise load leases: result=%s", result)
+                raise
+
+    def register_load_leases(self, keys_by_request: dict[str, set[str]]) -> None:
+        with self._lease_lock:
+            for req_id, keys in keys_by_request.items():
+                registered = self.load_lease_keys_by_request.setdefault(req_id, set())
+                for key in keys - registered:
+                    self.load_lease_refcounts[key] = self.load_lease_refcounts.get(key, 0) + 1
+                registered.update(keys)
+
+    def release_finished_load_leases(self, finished_req_ids: set[str]) -> None:
+        if not finished_req_ids or not self.enabled:
+            return
+        keys_to_release: list[str] = []
+        with self._lease_lock:
+            for req_id in finished_req_ids:
+                for key in self.load_lease_keys_by_request.pop(req_id, ()):
+                    refcount = self.load_lease_refcounts[key] - 1
+                    if refcount == 0:
+                        del self.load_lease_refcounts[key]
+                        keys_to_release.append(key)
+                    else:
+                        self.load_lease_refcounts[key] = refcount
+            if keys_to_release:
+                result = self.m_store.batch_remove_lease(keys_to_release)
+                if result != 0:
+                    logger.error(
+                        "Failed to release %d layerwise load leases for %d finished requests: res=%d",
+                        len(keys_to_release),
+                        len(finished_req_ids),
+                        result,
+                    )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -1280,7 +1281,44 @@ class LayerTransferTask:
     # maps block_range index -> list of (start, end, key_all_layers)
     cached_process_tokens: dict[int, list[tuple[int, int, list]]] | None = None
     # Mooncake uses one remote object per block/rank with per-layer ranges.
+    finished_req_ids: set[str] = field(default_factory=set)
+    uses_hbm_tail: bool = False
     use_key_major_ranges: bool = False
+    preparation: LayerwisePreparation | None = None
+
+
+@dataclass
+class LayerwisePreparation:
+    """Run one transfer-batch preparation callback exactly once."""
+
+    callback: Callable[[], None] = field(repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _ready: bool = field(default=False, init=False, repr=False)
+    _error: BaseException | None = field(default=None, init=False, repr=False)
+
+    def ensure_ready(self) -> None:
+        if self._ready:
+            if self._error is not None:
+                raise self._error
+            return
+        with self._lock:
+            if not self._ready:
+                try:
+                    self.callback()
+                except BaseException as error:
+                    self._error = error
+                finally:
+                    self._ready = True
+            if self._error is not None:
+                raise self._error
+
+
+@dataclass
+class LayerSaveTask:
+    """Layer-level save work, including control-only saves with no copies."""
+
+    layer_id: int
+    transfer_tasks: list[LayerTransferTask]
 
 
 @dataclass
@@ -1289,6 +1327,7 @@ class LayerLoadTask:
     transfer_tasks: list[LayerTransferTask]
     layer_id: int
     attention_start_gate: AttentionComputeStartGate | None = None
+    preparation: LayerwisePreparation | None = None
 
 
 @dataclass(init=False)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -45,7 +45,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     RequestTracker,
     block_hash_to_str,
     get_block_hashes,
-    get_group_block_size,
     get_group_cache_family,
     infer_cache_transfer_granularity,
     infer_group_block_sizes,
@@ -376,6 +375,12 @@ class KVPoolScheduler:
             return self._lookup_layerwise_with_coordinator(request, token_len)
         return self._lookup_layerwise_contiguous(request, token_len, num_computed_tokens)
 
+    def _layerwise_publication_states(self, keys: list[str]) -> list[int]:
+        states = self.store_scheduler.batch_is_exist(keys)
+        if len(states) != len(keys) or any(state not in (0, 1) for state in states):
+            raise RuntimeError(f"Invalid layerwise publication states: expected={len(keys)}, states={states}")
+        return states
+
     def _lookup_layerwise_with_coordinator(
         self,
         request: "Request",
@@ -407,21 +412,13 @@ class KVPoolScheduler:
             all_keys = [key for block_keys in keys_by_block for key in block_keys]
             if not all_keys:
                 return []
-            key_infos = self.store_scheduler.batch_get_key_info(all_keys)
-            if len(key_infos) != len(all_keys):
-                logger.error(
-                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
-                    len(all_keys),
-                    len(key_infos),
-                )
-                return []
-            # A block is hit only when ALL ranks' keys return valid GVA
+            states = self._layerwise_publication_states(all_keys)
             hits: list[BlockHash] = []
             offset = 0
-            for block_hash, block_keys in zip(allowed_hashes, keys_by_block):
-                block_infos = key_infos[offset : offset + len(block_keys)]
+            for block_hash, block_keys in zip(allowed_hashes, keys_by_block, strict=True):
+                block_states = states[offset : offset + len(block_keys)]
                 offset += len(block_keys)
-                if all(ki.size() and ki.size() > 0 for ki in block_infos):
+                if all(state == 1 for state in block_states):
                     hits.append(block_hash)
             return hits
 
@@ -438,66 +435,33 @@ class KVPoolScheduler:
         token_len: int,
         num_computed_tokens: int,
     ) -> int:
-        # In layerwise mode, always query from block 0 because the remote
-        # pool stores per-layer data that may not match local prefix cache.
-        num_hash_blocks = token_len // self.hash_block_size
-        block_hashes_to_check = request.block_hashes[:num_hash_blocks]
-        hits_per_group: list[int] = []
-
-        for group_id in range(len(self.grouped_block_size)):
-            effective_block_size = get_group_block_size(self.grouped_block_size, group_id)
-            group_block_hashes = get_block_hashes(block_hashes_to_check, effective_block_size, self.hash_block_size)
-            query_start_block = (
-                0 if self.use_layerwise else min(num_computed_tokens // effective_block_size, len(group_block_hashes))
-            )
-            group_block_hashes = group_block_hashes[query_start_block:]
-            # Generate all-rank keys for each block hash
-            keys_by_block = [
-                self._make_layerwise_hit_check_keys(group_id, block_hash_to_str(bh)) for bh in group_block_hashes
-            ]
-            all_keys = [key for block_keys in keys_by_block for key in block_keys]
-            if not all_keys:
+        """Check publication for every group/rank in one metadata operation."""
+        hashes = request.block_hashes[: token_len // self.hash_block_size]
+        query_keys: list[str] = []
+        plans: list[tuple[int, int, int, int]] = []
+        ranks_per_block = self.tp_size // self.put_step
+        for group_id, block_size in enumerate(self.grouped_block_size):
+            group_hashes = get_block_hashes(hashes, block_size, self.hash_block_size)
+            start = 0 if self.layerwise_offload else min(num_computed_tokens // block_size, len(group_hashes))
+            group_hashes = group_hashes[start:]
+            if not group_hashes:
                 continue
-
-            key_infos = self.store_scheduler.batch_get_key_info(all_keys)
-            if len(key_infos) != len(all_keys):
-                logger.error(
-                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
-                    len(all_keys),
-                    len(key_infos),
-                )
-                hits_per_group.append(0)
-                continue
-
-            # A block is hit only when ALL ranks' keys return valid GVA
-            num_hit_blocks = 0
-            offset = 0
-            for block_keys in keys_by_block:
-                block_infos = key_infos[offset : offset + len(block_keys)]
-                offset += len(block_keys)
-                if all(ki.size() and ki.size() > 0 for ki in block_infos):
-                    num_hit_blocks += 1
-                else:
-                    break
-
-            hits_per_group.append((query_start_block + num_hit_blocks) * effective_block_size)
-
-        if not hits_per_group:
-            logger.debug(
-                "hit_check: req=%s token_len=%d no participating groups (all skipped)",
-                request.request_id,
-                token_len,
-            )
+            plans.append((len(query_keys), len(group_hashes), start, block_size))
+            for block_hash in group_hashes:
+                query_keys.extend(self._make_layerwise_hit_check_keys(group_id, block_hash_to_str(block_hash)))
+        if not query_keys:
             return 0
-        hit_tokens = min(hits_per_group)
-        logger.debug(
-            "hit_check: req=%s token_len=%d hits_per_group=%s hit_tokens=%d",
-            request.request_id,
-            token_len,
-            hits_per_group,
-            hit_tokens,
-        )
-        return hit_tokens
+        states = self._layerwise_publication_states(query_keys)
+        hits = []
+        for offset, count, start, block_size in plans:
+            prefix = 0
+            for index in range(count):
+                begin = offset + index * ranks_per_block
+                if not all(state == 1 for state in states[begin : begin + ranks_per_block]):
+                    break
+                prefix += 1
+            hits.append((start + prefix) * block_size)
+        return min(hits)
 
     def _get_mooncake_layerwise_hit_tokens(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -28,6 +28,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import (
     get_attention_compute_start_gate,
     reset_attention_compute_start_gate,
+    reset_attention_compute_start_gates,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend import (
     backend_map,
@@ -56,6 +57,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_layerwise_kv_cache_specs,
     get_layerwise_physical_layer_index,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_transfer import LayerwiseTransferPreparer
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
@@ -64,7 +66,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     LayerBlockRange,
     LayerLoadTask,
     LayerMultiBlockReqMeta,
+    LayerSaveTask,
     LayerTransferTask,
+    LayerwisePreparation,
     ReqMeta,
     block_hash_to_str,
     get_block_hashes,
@@ -374,6 +378,7 @@ class KVPoolWorker:
         # which keys it has already allocated and reuse those GVAs instead of
         # re-allocating them on every save step.
         self._allocated_gvas: dict[str, int] = {}
+        self._layerwise_transfer_preparer: LayerwiseTransferPreparer | None = None
         self._put_started_keys: set[str] = set()
         self._put_started_keys_lock = threading.Lock()
         self._load_session_lock = threading.Lock()
@@ -448,6 +453,12 @@ class KVPoolWorker:
         self.layer_load_finished_events: list[threading.Event] | None = None
         self.layer_save_finished_events: list[threading.Event] | None = None
 
+        self._layer_load_preparation: LayerwisePreparation | None = None
+        self._early_dispatched: set[int] = set()
+        self._scatter_cursor = 0
+        self.sync_attn_events: list[torch.npu.Event] | None = None
+        self.layer_attn_recorded_events: list[threading.Event] | None = None
+        self._attention_layer_indices: dict[str, int] = {}
         self.next_layer_to_submit = 0
         self.layerwise_offload = False
         self.independent_layers: list[int] = []
@@ -530,6 +541,9 @@ class KVPoolWorker:
             self.layer_load_finished_events = [threading.Event() for i in range(self.num_layers)]
             self.layer_save_finished_events = [threading.Event() for i in range(self.num_layers)]
             self.sync_save_events = [torch.npu.Event() for i in range(self.num_layers)]
+            if self.use_layerwise_transfer:
+                self.sync_attn_events = [torch.npu.Event() for _ in range(self.num_layers)]
+                self.layer_attn_recorded_events = [threading.Event() for _ in range(self.num_layers)]
             can_save = is_kv_save_role(self.kv_role, self.consumer_is_to_put)
             if (self.use_block_key_layerwise or self.use_layerwise_transfer) and can_save:
                 ready_event_sending = threading.Event()
@@ -548,6 +562,8 @@ class KVPoolWorker:
                     self.layerwise_max_transfer_blocks,
                     self.layerwise_max_transfer_bytes,
                     group_builders=self._build_group_layer_builders(),
+                    sync_attn_events=self.sync_attn_events,
+                    layer_attn_recorded_events=self.layer_attn_recorded_events,
                     put_started_keys=self._put_started_keys,
                     put_started_keys_lock=self._put_started_keys_lock,
                     session_tracker=self._mooncake_session_tracker if self.backend_name == "mooncake" else None,
@@ -598,6 +614,11 @@ class KVPoolWorker:
                     invalid_block_ids=self._invalid_block_ids,
                     invalid_block_ids_lock=self._invalid_block_ids_lock,
                     load_abort_event=self._layer_load_aborted,
+                    release_load_leases=(
+                        self._get_layerwise_transfer_preparer().release_finished_load_leases
+                        if self.use_layerwise_transfer
+                        else None
+                    ),
                 )
             else:
                 self.kv_recv_thread = KVCacheStoreKeyLayerRecvingThread(
@@ -891,6 +912,7 @@ class KVPoolWorker:
         # Initialize store, register buffers, and start transfer threads
         # directly here (like main) — no separate init_backend handshake.
         if self.use_layerwise_transfer:
+            self._attention_layer_indices = {name: self._extract_physical_layer_index(name) for name in kv_caches}
             self.m_store.ensure_initialized()
         self.m_store.register_buffer(ptrs, lengths)
         if self.backend_name == "mooncake" and self.use_layerwise:
@@ -907,7 +929,15 @@ class KVPoolWorker:
             # newly prepared loads/saves and leave a reused buffer stale.
             self.layer_save_tasks = [[] for _ in range(self.num_layers)]
             self.layer_load_tasks = [[] for _ in range(self.num_layers)]
-            reset_attention_compute_start_gate()
+            self._early_dispatched.clear()
+            self._scatter_cursor = 0
+            if self.use_layerwise_transfer:
+                reset_attention_compute_start_gates(self.num_layers, self._attention_layer_indices)
+                if self.layer_attn_recorded_events is not None:
+                    for event in self.layer_attn_recorded_events:
+                        event.clear()
+            else:
+                reset_attention_compute_start_gate()
         logger.debug("KV pool worker start_load_kv requests=%d", len(metadata.requests))
         if len(metadata.requests) == 0:
             return
@@ -1225,7 +1255,7 @@ class KVPoolWorker:
                 if group_id < len(request.partial_load_gva_per_group)
                 else request.last_block_gva
             )
-            if partial_gva is None or partial_gva <= 0:
+            if not self.use_layerwise_transfer and (partial_gva is None or partial_gva <= 0):
                 partial_block_index = None
             if partial_block_index is not None and partial_block_index < load_start_block:
                 partial_block_index = None
@@ -1264,464 +1294,54 @@ class KVPoolWorker:
                     layer_id=layer_id,
                     block_ranges=request_block_ranges,
                     group_id=group_id,
+                    uses_hbm_tail=self.layerwise_offload and layer_id in self.independent_layers,
                     layer_idx_in_group=layer_idx_in_group,
                     use_key_major_ranges=(self.use_block_key_layerwise and self.backend_name == "mooncake"),
                 )
             )
 
-    def _make_layerwise_full_key(self, group_id: int, block_hash_hex: str) -> str:
-        """Full-block key for the layerwise transfer, built by the
-        backend's protocol module.
-
-        Single-group models use the PR #11585 format (model@hash@rank) for
-        backward compatibility. Multi-group models include group_id
-        (model@group_id@hash@rank) to distinguish groups.
-        """
-        return self.layerwise_protocol.make_full_key(
-            self.model_name,
-            group_id,
-            block_hash_hex,
-            self.head_or_tp_rank,
-            self.num_kv_cache_groups,
-        )
-
-    def _make_layerwise_partial_key(
-        self,
-        request: ReqMeta,
-        group_id: int,
-        block_index: int,
-        end_token: int,
-    ) -> str:
-        return self.layerwise_protocol.make_partial_key(
-            self.model_name,
-            request.req_id,
-            group_id,
-            block_index,
-            end_token,
-            self.head_or_tp_rank,
-        )
-
-    def _refresh_allocated_gvas(self, keys: list[str]) -> None:
-        """Drop local GVA entries whose MemCache blobs were evicted."""
-        cached_keys = list(dict.fromkeys(key for key in keys if key in self._allocated_gvas))
-        if not cached_keys:
-            return
-        exists_states = self.m_store.batch_is_exist(cached_keys)
-        if len(exists_states) != len(cached_keys):
-            raise RuntimeError(
-                "MemCache exists check returned unexpected number of states: "
-                f"expected={len(cached_keys)}, actual={len(exists_states)}"
+    def _get_layerwise_transfer_preparer(self) -> LayerwiseTransferPreparer:
+        if self._layerwise_transfer_preparer is None:
+            self._layerwise_transfer_preparer = LayerwiseTransferPreparer(
+                self.m_store,
+                self.model_name,
+                self.head_or_tp_rank,
+                self.hash_block_size,
+                enabled=self.use_layerwise_transfer,
+                can_allocate=self._is_layerwise_save_owner(),
+                block_sizes=self.grouped_block_size,
+                group_block_len=self.group_block_len,
+                page_size_bytes=self.page_size_bytes,
+                layerwise_offload=self.layerwise_offload,
+                protocol=self.layerwise_protocol,
+                record_invalid_blocks=self._record_layerwise_invalid_blocks,
+                use_eagle=self.use_eagle,
+                allocated_gvas=self._allocated_gvas,
             )
-        for key, exists in zip(cached_keys, exists_states):
-            if exists == 0:
-                self._allocated_gvas.pop(key, None)
-            elif exists != 1:
-                raise RuntimeError(f"MemCache exists check failed for {key}: state={exists}")
+        return self._layerwise_transfer_preparer
 
-    def _alloc_gvas_for_save(self, requests: list[ReqMeta]) -> None:
-        """Allocate per-group GVA on the worker side right before batch_copy.
+    def _make_layerwise_full_key(self, group_id: int, block_hash_hex: str):
+        return self._get_layerwise_transfer_preparer()._make_layerwise_full_key(group_id, block_hash_hex)
 
-        For multi-group models, iterates all KV cache groups and allocates
-        per-group GVAs. Key format: model@group_id@hash@head_or_tp_rank
-        (multi-group) or model@hash@head_or_tp_rank (single-group, backward
-        compat with PR #11585).
-        """
-        if not self.use_layerwise_transfer:
-            return
-        if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
-            return
-        if self.tp_rank % self.put_step != 0:
-            return
+    def _make_layerwise_partial_key(self, request: ReqMeta, group_id: int, block_index: int, end_token: int):
+        return self._get_layerwise_transfer_preparer()._make_layerwise_partial_key(
+            request, group_id, block_index, end_token
+        )
+
+    def _refresh_allocated_gvas(self, keys: list[str]):
+        return self._get_layerwise_transfer_preparer()._refresh_allocated_gvas(keys)
+
+    def _alloc_gvas_for_save(self, requests: list[ReqMeta]):
+        return self._get_layerwise_transfer_preparer()._alloc_gvas_for_save(requests)
+
+    def _prepare_load_gvas(self, requests: list[ReqMeta]):
         for request in requests:
-            if request.can_save is None or not request.can_save:
-                continue
-            block_hashes = request.block_hashes
-
-            all_group_gvas: list[np.ndarray] = []
-            all_group_block_ids: list[np.ndarray] = []
-            all_group_save_keys: list[str] = []
-            request.partial_save_gva_per_group = [0] * self.num_kv_cache_groups
-            for group_id in range(self.num_kv_cache_groups):
-                group_block_size = self.grouped_block_size[group_id]
-                effective_block_size = group_block_size
-                group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-                alloc_size = sum(group_block_len) if group_block_len else self.page_size_bytes
-
-                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
-                block_ids_by_group = (
-                    request.block_ids_by_group_np[group_id]
-                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
-                    else request.block_ids_np
-                )
-                if block_ids_by_group is None:
-                    raise RuntimeError(f"Block IDs are not initialized for request {request.req_id}")
-
-                save_start_block = request.save_start_token // effective_block_size
-                save_end_block = request.save_end_token // effective_block_size
-                if request.load_spec is not None and request.load_spec.can_load:
-                    pool_hit_tokens = (
-                        request.load_spec.kvpool_store_skip_tokens
-                        if request.load_spec.kvpool_store_skip_tokens is not None
-                        else request.load_spec.kvpool_cached_tokens
-                    )
-                    hit_full_blocks = pool_hit_tokens // effective_block_size
-                    save_start_block = max(save_start_block, hit_full_blocks)
-                group_store_mask = (
-                    request.store_masks[group_id]
-                    if request.store_masks is not None and group_id < len(request.store_masks)
-                    else None
-                )
-                end_limit = min(save_end_block, len(group_block_hashes))
-                candidate_blocks = [
-                    block_idx
-                    for block_idx in range(save_start_block, end_limit)
-                    if group_store_mask is None or block_idx >= len(group_store_mask) or group_store_mask[block_idx]
-                ]
-                candidate_keys = [
-                    self._make_layerwise_full_key(
-                        group_id,
-                        block_hash_to_str(group_block_hashes[block_idx]),
-                    )
-                    for block_idx in candidate_blocks
-                ]
-                self._refresh_allocated_gvas(candidate_keys)
-                # Skip blocks that are still present and readable in MemCache.
-                # Only a leading run of already-allocated blocks is skipped so
-                # the readable-blob write failure semantics stay unchanged.
-                allocated_prefix = 0
-                for block_idx in candidate_blocks:
-                    key = self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[block_idx]))
-                    if key in self._allocated_gvas:
-                        allocated_prefix += 1
-                    else:
-                        break
-                transfer_blocks = candidate_blocks[allocated_prefix:]
-
-                block_gvas: list[int] = []
-                new_keys: list[str] = []
-                new_positions: list[int] = []
-                for blk_idx in transfer_blocks:
-                    key = self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
-                    cached = self._allocated_gvas.get(key)
-                    if cached is not None:
-                        block_gvas.append(cached)
-                    else:
-                        new_keys.append(key)
-                        new_positions.append(len(block_gvas))
-                        block_gvas.append(0)
-
-                if new_keys:
-                    new_gvas = self.m_store.batch_alloc(
-                        new_keys, [alloc_size] * len(new_keys), LAYERWISE_READ_LEASE_TTL_MS
-                    )
-                    if any(gva <= 0 for gva in new_gvas):
-                        logger.error(
-                            "alloc_gvas FAIL: req=%s group=%d alloc_size=%d new_keys=%d gvas_sample=%s zero_count=%d",
-                            request.req_id,
-                            group_id,
-                            alloc_size,
-                            len(new_keys),
-                            new_gvas[:5],
-                            sum(1 for g in new_gvas if g <= 0),
-                        )
-                    for pos, key, gva in zip(new_positions, new_keys, new_gvas):
-                        if gva > 0:
-                            block_gvas[pos] = gva
-                            self._allocated_gvas[key] = gva
-                            all_group_save_keys.append(key)
-
-                partial_block_index = get_partial_block_index(
-                    request.target_token_len,
-                    effective_block_size,
-                    len(group_block_hashes),
-                    self.layerwise_offload,
-                )
-                if partial_block_index is not None and partial_block_index < len(block_ids_by_group):
-                    partial_key = self._make_layerwise_partial_key(
-                        request,
-                        group_id,
-                        partial_block_index,
-                        request.target_token_len,
-                    )
-                    partial_gva = self._allocated_gvas.get(partial_key)
-                    if partial_gva is None:
-                        allocated = self.m_store.batch_alloc(
-                            [partial_key],
-                            [alloc_size],
-                            LAYERWISE_READ_LEASE_TTL_MS,
-                        )
-                        partial_gva = allocated[0] if allocated else 0
-                        if partial_gva > 0:
-                            self._allocated_gvas[partial_key] = partial_gva
-                            all_group_save_keys.append(partial_key)
-                        else:
-                            logger.error(
-                                "alloc_gvas: partial allocation failed req=%s group=%d block=%d gva=%d",
-                                request.req_id,
-                                group_id,
-                                partial_block_index,
-                                partial_gva,
-                            )
-                    # Partial keys are request-scoped; do not retain them forever.
-                    self._allocated_gvas.pop(partial_key, None)
-                    request.partial_save_gva_per_group[group_id] = partial_gva
-
-                logger.debug(
-                    "alloc_gvas: req=%s group=%d eff_bs=%d save_blocks=[%d,%d) "
-                    "new_keys=%d cached_keys=%d masked=%s alloc_size=%d",
-                    request.req_id,
-                    group_id,
-                    effective_block_size,
-                    save_start_block,
-                    save_end_block,
-                    len(new_keys),
-                    len(block_gvas) - len(new_keys),
-                    group_store_mask is not None,
-                    alloc_size,
-                )
-
-                # Pad block_gvas to match block_ids length (fill 0 for non-transferred blocks)
-                full_gvas = [0] * len(block_ids_by_group)
-                for blk_idx, gva in zip(transfer_blocks, block_gvas):
-                    if blk_idx < len(full_gvas):
-                        full_gvas[blk_idx] = gva
-
-                all_group_gvas.append(np.asarray(full_gvas, dtype=np.int64))
-                all_group_block_ids.append(np.asarray(block_ids_by_group, dtype=np.int64))
-
-            if all_group_gvas:
-                request.save_keys = all_group_save_keys
-                request.block_gvas_by_group_np = all_group_gvas
-                request.block_ids_by_group_np = all_group_block_ids
-                request.block_gvas_np = all_group_gvas[0]
-                request.gva_block_offset = 0
-
-    def _prepare_load_gvas(self, requests: list[ReqMeta]) -> None:
-        """Fetch per-rank GVA and acquire read lease for the load path.
-
-        memcache requires batch_copy (read) to find the blob in the per-process
-        gvaBlobTracker with a valid lease. The scheduler only checks existence
-        (batch_is_exist) to decide the load range; before batch_copy(G2L) the
-        worker must, for its own per-rank keys:
-          1. batch_get_key_info to fetch the GVA (fills block_gvas_np)
-          2. batch_add_lease to register the blob locally + acquire a read lease
-        """
-        if not self.use_layerwise_transfer:
-            return
-        for request in requests:
-            if request.load_spec is None or not request.load_spec.can_load:
-                continue
-            cached_tokens = request.load_spec.kvpool_cached_tokens
-            if not getattr(self, "use_eagle", False) and request.load_spec.kvpool_store_skip_tokens is not None:
-                cached_tokens = request.load_spec.kvpool_store_skip_tokens
-            if (
-                getattr(self, "use_eagle", False)
-                and request.load_spec.kvpool_cached_tokens == request.target_token_len - 1
-            ):
-                # Full-hit path: the trailing block is recomputed and will be
-                # re-stored by the normal save path, so never skip it here.
-                logger.debug(
-                    "Reqid: %s full-hit tail recompute path, tail block will be re-stored",
-                    request.req_id,
-                )
-            block_hashes = request.block_hashes
-            request.load_masks = self._compute_reachable_load_masks(request, cached_tokens)
-
-            all_group_load_gvas: list[np.ndarray] = []
-            all_group_load_keys: list[str] = []
-            request.partial_load_gva_per_group = [0] * self.num_kv_cache_groups
-            for group_id in range(self.num_kv_cache_groups):
-                group_block_size = self.grouped_block_size[group_id]
-                effective_block_size = group_block_size
-
-                group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
-                load_start_block = (
-                    0 if self.layerwise_offload else request.load_spec.vllm_cached_tokens // effective_block_size
-                )
-                cached_full_blocks = cached_tokens // effective_block_size
-                full_blocks = min(cached_full_blocks, len(group_block_hashes))
-
-                block_ids_by_group = (
-                    request.block_ids_by_group_np[group_id]
-                    if (request.block_ids_by_group_np is not None and group_id < len(request.block_ids_by_group_np))
-                    else request.block_ids_np
-                )
-                if block_ids_by_group is None:
-                    all_group_load_gvas.append(np.zeros(0, dtype=np.int64))
-                    continue
-                full_len = len(block_ids_by_group)
-
-                partial_block_index = get_partial_block_index(
-                    cached_tokens,
-                    effective_block_size,
-                    len(group_block_hashes),
-                    self.layerwise_offload,
-                )
-                if partial_block_index is not None and (
-                    partial_block_index < load_start_block or partial_block_index >= full_len
-                ):
-                    partial_block_index = None
-
-                if load_start_block >= full_blocks and partial_block_index is None:
-                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
-                    continue
-
-                group_load_mask = (
-                    request.load_masks[group_id]
-                    if request.load_masks is not None and group_id < len(request.load_masks)
-                    else None
-                )
-                block_indices = [
-                    block_idx
-                    for block_idx in range(load_start_block, full_blocks)
-                    if group_load_mask is None or block_idx >= len(group_load_mask) or group_load_mask[block_idx]
-                ]
-                keys = [
-                    self._make_layerwise_full_key(group_id, block_hash_to_str(group_block_hashes[block_idx]))
-                    for block_idx in block_indices
-                ]
-                has_partial_key = False
-                if partial_block_index is not None:
-                    keys.append(
-                        self._make_layerwise_partial_key(
-                            request,
-                            group_id,
-                            partial_block_index,
-                            cached_tokens,
-                        )
-                    )
-                    block_indices.append(partial_block_index)
-                    has_partial_key = True
-                if not keys:
-                    all_group_load_gvas.append(np.zeros(full_len, dtype=np.int64))
-                    continue
-
-                key_infos = self.m_store.batch_get_key_info(keys)
-                gvas = []
-                valid_gva_indices = []
-                invalid_block_ids: list[int] = []
-                for ki, key, block_idx in zip(key_infos, keys, block_indices):
-                    sizes = ki.size()
-                    gva = ki.gva_list()[0] if sizes and sizes > 0 else 0
-                    gvas.append(gva)
-                    if gva > 0:
-                        valid_gva_indices.append(len(gvas) - 1)
-                    else:
-                        if block_idx < len(block_ids_by_group):
-                            invalid_block_ids.append(int(block_ids_by_group[block_idx]))
-                        logger.warning(
-                            "load_gvas: req=%s group=%d got invalid gva=%d (size=%d), block_id=%s load failed",
-                            request.req_id,
-                            group_id,
-                            gva,
-                            sizes if sizes else 0,
-                            int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else "N/A",
-                        )
-
-                # Only call batch_add_lease for keys with valid size
-                valid_keys = [keys[index] for index in valid_gva_indices]
-                if valid_keys:
-                    lease_results = self.m_store.batch_add_lease(valid_keys, LAYERWISE_READ_LEASE_TTL_MS)
-                    if len(lease_results) != len(valid_keys):
-                        raise RuntimeError(
-                            "MemCache lease returned unexpected number of results: "
-                            f"expected={len(valid_keys)}, actual={len(lease_results)}"
-                        )
-                    leased_keys = []
-                    for gva_index, lease_res in zip(valid_gva_indices, lease_results):
-                        block_idx = block_indices[gva_index]
-                        if lease_res == MEMCACHE_UNMATCHED_STATE and block_idx == partial_block_index:
-                            partial_key = keys[gva_index]
-                            for retry in range(1, PARTIAL_LEASE_RETRY_COUNT + 1):
-                                time.sleep(PARTIAL_LEASE_RETRY_INTERVAL_S)
-                                retry_results = self.m_store.batch_add_lease(
-                                    [partial_key],
-                                    LAYERWISE_READ_LEASE_TTL_MS,
-                                )
-                                if len(retry_results) != 1:
-                                    raise RuntimeError(
-                                        "MemCache partial lease retry returned "
-                                        f"unexpected number of results: {len(retry_results)}"
-                                    )
-                                lease_res = retry_results[0]
-                                if lease_res != MEMCACHE_UNMATCHED_STATE:
-                                    break
-                        block_id = int(block_ids_by_group[block_idx]) if block_idx < len(block_ids_by_group) else None
-                        if lease_res == 0:
-                            leased_keys.append(keys[gva_index])
-                        else:
-                            gvas[gva_index] = 0
-                            if block_id is not None:
-                                invalid_block_ids.append(block_id)
-                            logger.warning(
-                                "load_gvas: req=%s group=%d lease failed result=%d, block_id=%s load failed",
-                                request.req_id,
-                                group_id,
-                                lease_res,
-                                block_id,
-                            )
-                else:
-                    lease_results = []
-                    leased_keys = []
-
-                # Report invalid blocks to scheduler for recompute.
-                # Single-group models can safely report individual block IDs.
-                # Multi-group (hybrid) models must not report partial group
-                # failures, as the scheduler cannot handle inconsistent KV
-                # cache state across groups (see PR #9701 for rationale).
-                if invalid_block_ids:
-                    if self.num_kv_cache_groups == 1:
-                        with self._invalid_block_ids_lock:
-                            self._invalid_block_ids.update(invalid_block_ids)
-                    else:
-                        leased_keys_to_release = list(
-                            dict.fromkeys(
-                                [
-                                    *all_group_load_keys,
-                                    *leased_keys,
-                                ]
-                            )
-                        )
-                        if leased_keys_to_release:
-                            self.m_store.batch_remove_lease(leased_keys_to_release)
-                        raise RuntimeError(
-                            "Layerwise multi-group KV load failed and cannot "
-                            "safely fall back to per-block recomputation: "
-                            f"request={request.req_id}, "
-                            f"failed_blocks={invalid_block_ids}"
-                        )
-                all_group_load_keys.extend(leased_keys)
-
-                logger.debug(
-                    "load_gvas: req=%s group=%d eff_bs=%d load_blocks=[%d,%d) keys=%d valid_gvas=%d lease_fail=%d",
-                    request.req_id,
-                    group_id,
-                    effective_block_size,
-                    load_start_block,
-                    full_blocks,
-                    len(keys),
-                    sum(1 for g in gvas if g > 0),
-                    sum(1 for r in lease_results if r != 0),
-                )
-
-                # Pad to match block_ids_by_group length, filling only the
-                # positions whose keys were actually queried (the trailing
-                # partial key is excluded from the per-position fill).
-                full_gvas = [0] * full_len
-                full_key_count = len(block_indices) - (1 if has_partial_key else 0)
-                for gva_index in range(full_key_count):
-                    block_idx = block_indices[gva_index]
-                    if block_idx < len(full_gvas):
-                        full_gvas[block_idx] = gvas[gva_index]
-                all_group_load_gvas.append(np.asarray(full_gvas, dtype=np.int64))
-                if has_partial_key and gvas:
-                    request.partial_load_gva_per_group[group_id] = gvas[-1]
-
-            if all_group_load_gvas:
-                request.load_keys = all_group_load_keys
-                request.load_block_gvas_by_group_np = all_group_load_gvas
-                request.load_block_gvas_np = all_group_load_gvas[0]
-                request.load_gva_block_offset = 0
+            if request.load_spec is not None and request.load_spec.can_load:
+                cached_tokens = request.load_spec.kvpool_cached_tokens
+                if not self.use_eagle and request.load_spec.kvpool_store_skip_tokens is not None:
+                    cached_tokens = request.load_spec.kvpool_store_skip_tokens
+                request.load_masks = self._compute_reachable_load_masks(request, cached_tokens)
+        return self._get_layerwise_transfer_preparer()._prepare_load_gvas(requests)
 
     def _record_layerwise_invalid_blocks(self, block_ids: list[int]) -> None:
         if not block_ids:
@@ -2050,30 +1670,16 @@ class KVPoolWorker:
                         task.cached_process_tokens = cached
 
     def _build_shared_load_data(self) -> None:
-        """Build shared block data once and attach to all layer load tasks.
-
-        In multi-group mode, shared data is built per-group because each
-        group has different block_ranges (different effective_block_size).
-        """
+        """Share each group's full-prefix and HBM-tail arrays independently."""
         if not isinstance(self.kv_recv_thread, KVCacheStoreLayerRecvingThread):
             return
-        for group_id in range(self.num_kv_cache_groups):
-            first_task = None
-            for layer_id in range(self.num_layers):
-                for task in self.layer_load_tasks[layer_id]:
-                    if task.group_id == group_id:
-                        first_task = task
-                        break
-                if first_task:
-                    break
-            if first_task is None:
-                continue
-            shared = self.kv_recv_thread.build_shared_data(first_task)
-            if shared is not None:
-                for layer_id in range(self.num_layers):
-                    for task in self.layer_load_tasks[layer_id]:
-                        if task.group_id == group_id:
-                            task.shared_block_data = shared
+        shared_by_group = {}
+        for tasks in self.layer_load_tasks:
+            for task in tasks:
+                key = (task.group_id, task.uses_hbm_tail)
+                if key not in shared_by_group:
+                    shared_by_group[key] = self.kv_recv_thread.build_shared_data(task)
+                task.shared_block_data = shared_by_group[key]
 
     def _compute_reachable_store_masks(
         self,
@@ -2117,48 +1723,121 @@ class KVPoolWorker:
         except AssertionError:
             return None
 
+    @staticmethod
+    def _mark_last_layer_tasks(layer_tasks: list[list[LayerTransferTask]]) -> None:
+        last_tasks: dict[str, LayerTransferTask] = {}
+        for tasks in layer_tasks:
+            for task in tasks:
+                task.finished_req_ids.clear()
+                for block_range in task.block_ranges:
+                    last_tasks[block_range.request.req_id] = task
+        for req_id, task in last_tasks.items():
+            task.finished_req_ids.add(req_id)
+
     def process_layer_data(self, requests: list[ReqMeta]) -> None:
         if not requests:
+            self._layer_load_preparation = None
             return
-        # Keep this method safe for direct callers as well as start_load_kv().
-        # Worker threads may still own the lists from the preceding step.
+        # Each asynchronous batch owns its lists until all layer tasks finish.
         self.layer_save_tasks = [[] for _ in range(self.num_layers)]
         self.layer_load_tasks = [[] for _ in range(self.num_layers)]
         if self.backend_name == "mooncake" and self.use_block_key_layerwise:
             self._prepare_mooncake_layerwise_sessions(requests)
         for request in requests:
+            if request.block_ids_by_group_np is None:
+                request.block_ids_by_group_np = [np.asarray(ids, dtype=np.int64) for ids in request.block_ids_by_group]
             request.store_masks = self._compute_reachable_store_masks(request)
         for physical_layer in range(self.num_layers):
             group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
             for group_id, layer_idx_in_group in group_layers:
                 self._process_save_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
-        # Protect the previous partial before allocating the next snapshot.
-        self._prepare_load_gvas(requests)
-        self._alloc_gvas_for_save(requests)
-        self._build_shared_save_data()
+        # Preserve current key-major session preparation. GVA preparation is
+        # submitted once and shared by receive and send threads below.
+        if not self.use_layerwise_transfer:
+            self._prepare_load_gvas(requests)
+            self._alloc_gvas_for_save(requests)
+            self._build_shared_save_data()
+        else:
+            for request in requests:
+                if request.load_spec is not None and request.load_spec.can_load:
+                    cached_tokens = request.load_spec.kvpool_cached_tokens
+                    if not self.use_eagle and request.load_spec.kvpool_store_skip_tokens is not None:
+                        cached_tokens = request.load_spec.kvpool_store_skip_tokens
+                    request.load_masks = self._compute_reachable_load_masks(request, cached_tokens)
         for physical_layer in range(self.num_layers):
             group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
             for group_id, layer_idx_in_group in group_layers:
                 self._process_load_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
-        self._build_shared_load_data()
+        if not self.use_layerwise_transfer:
+            self._build_shared_load_data()
+            self._layer_load_preparation = None
+            return
+        preparer = self._get_layerwise_transfer_preparer()
+
+        def prepare_load() -> None:
+            preparer._prepare_load_gvas(requests)
+            self._build_shared_load_data()
+            self._mark_last_layer_tasks(self.layer_load_tasks)
+
+        load_preparation = LayerwisePreparation(prepare_load)
+        self._layer_load_preparation = load_preparation
+
+        def prepare_save() -> None:
+            # Protect the previous partial snapshot before allocating the next.
+            load_preparation.ensure_ready()
+            preparer._alloc_gvas_for_save(requests)
+            self._build_shared_save_data()
+            self._mark_last_layer_tasks(self.layer_save_tasks)
+
+        save_preparation = LayerwisePreparation(prepare_save)
+        for tasks in self.layer_save_tasks:
+            for task in tasks:
+                task.preparation = save_preparation
+        if any(self.layer_load_tasks):
+            assert self.kv_recv_thread is not None
+            self.kv_recv_thread.add_request(load_preparation)
+        if any(self.layer_save_tasks):
+            assert self.kv_send_thread is not None
+            self.kv_send_thread.add_request(save_preparation)
 
     def _submit_ready_layer_loads(self) -> None:
         assert self.kv_recv_thread is not None
         recv_thread = self.kv_recv_thread
 
         def submit_layer_load(layer_id: int) -> bool:
-            reuse_source = self.prefetch_layer_map.get(layer_id)
-            if not self.layer_load_tasks[layer_id] and reuse_source is None:
+            reuse_mate = self.prefetch_layer_map.get(layer_id)
+            has_load = bool(self.layer_load_tasks[layer_id])
+            if not has_load and reuse_mate is None:
                 return False
             attention_start_gate = None
-            if self.layer_load_tasks[layer_id] and layer_id != self.current_layer:
+            if has_load and layer_id != self.current_layer and not self.use_layerwise_transfer:
                 attention_start_gate = get_attention_compute_start_gate()
+            elif has_load and layer_id != self.current_layer:
+                if reuse_mate is None:
+                    # No reuse dependency: the slot is empty, so release the H2D
+                    # copy at the current layer's attention boundary to start the
+                    # transfer as early as possible (e.g. first occupants L1..L3
+                    # all ride the L0 gate).
+                    attention_start_gate = get_attention_compute_start_gate(self.current_layer)
+                else:
+                    # Reused slot: release the H2D copy at the layer right after the
+                    # reuse source. slot_free(reuse_mate) is guaranteed ready by then
+                    # (the source layer finished attention before its next layer
+                    # starts), and the layers between here and layer_id mask the
+                    # transfer. Binding layer_id's own gate would serialize the copy
+                    # against layer_id's attention and leave no overlap.
+                    if reuse_mate + 1 < layer_id:
+                        # An adjacent target cannot wait on its own attention gate.
+                        # TODO: Map multi-layer MTP names to physical gate indices;
+                        # a single MTP layer reused across steps is unaffected.
+                        attention_start_gate = get_attention_compute_start_gate(reuse_mate + 1)
             recv_thread.add_request(
                 LayerLoadTask(  # type: ignore[arg-type]
-                    wait_for_save_layer=reuse_source,
+                    wait_for_save_layer=reuse_mate,
                     transfer_tasks=self.layer_load_tasks[layer_id],
                     layer_id=layer_id,
                     attention_start_gate=attention_start_gate,
+                    preparation=self._layer_load_preparation,
                 )
             )
             return True
@@ -2178,7 +1857,8 @@ class KVPoolWorker:
         assert self.kv_recv_thread is not None
         try:
             self.kv_recv_thread.raise_if_failed()
-            reset_attention_compute_start_gate()
+            if not self.use_layerwise_transfer:
+                reset_attention_compute_start_gate()
             self._submit_ready_layer_loads()
             should_wait = (
                 bool(self.layer_load_tasks[self.current_layer]) or self.current_layer in self.prefetch_layer_map
@@ -2212,6 +1892,52 @@ class KVPoolWorker:
             self._invalid_block_ids.clear()
         return invalid_blocks
 
+    def on_kv_cache_written(self, layer_name: str = "") -> None:
+        """Dispatch a layer's save as soon as its KV is scattered (pre-attention).
+
+        Records the scatter-complete event and queues the L2G save immediately,
+        rather than waiting for save_kv_layer at layer end. Idempotent; the
+        layer-end callback dispatches any layer whose attention path skipped
+        this hook.
+        """
+        if not self.use_layerwise_transfer or self.kv_send_thread is None:
+            return
+        if self.current_layer >= self.num_layers:
+            return
+        if layer_name:
+            idx = self._extract_physical_layer_index(layer_name)
+        else:
+            idx = self._scatter_cursor
+        self._scatter_cursor = idx + 1
+        if idx >= self.num_layers:  # Layer is outside the registered cache layout.
+            return
+        if idx in self._early_dispatched:
+            return
+        self._dispatch_layer_save(idx)
+
+    def _dispatch_layer_save(self, layer_idx: int) -> None:
+        """Queue copy or control-only work for one physical layer."""
+        assert self.sync_save_events is not None
+        assert self.kv_send_thread is not None
+        send_thread = self.kv_send_thread
+        send_thread.raise_if_failed()
+        self.sync_save_events[layer_idx].record()
+        transfer_tasks = self.layer_save_tasks[layer_idx]
+        for task in transfer_tasks:
+            for block_range in task.block_ranges:
+                send_thread.add_stored_request(block_range.request.req_id)
+        if self.use_layerwise_transfer:
+            send_thread.add_request(LayerSaveTask(layer_id=layer_idx, transfer_tasks=transfer_tasks))
+        elif transfer_tasks:
+            send_thread.add_request(transfer_tasks)  # type: ignore[arg-type]
+        else:
+            # The key-based path has no shared-slot reuse or asynchronous PD
+            # completion to gate, so preserve its synchronous empty-layer
+            # completion behavior.
+            assert self.layer_save_finished_events is not None
+            self.layer_save_finished_events[layer_idx].set()
+        self._early_dispatched.add(layer_idx)
+
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
         if self.current_layer >= self.num_layers:
             return
@@ -2220,19 +1946,23 @@ class KVPoolWorker:
         assert self.kv_send_thread is not None
         send_thread = self.kv_send_thread
         send_thread.raise_if_failed()
-        self.sync_save_events[self.current_layer].record()
-        if self.layer_save_tasks[self.current_layer]:
-            for task in self.layer_save_tasks[self.current_layer]:
-                for block_range in task.block_ranges:
-                    send_thread.add_stored_request(block_range.request.req_id)
-            send_thread.add_request(self.layer_save_tasks[self.current_layer])  # type: ignore[arg-type]
-        else:
-            self.layer_save_finished_events[self.current_layer].set()
+        if self.current_layer not in self._early_dispatched:
+            self._dispatch_layer_save(self.current_layer)
+        # Attention for this layer is done (post o_proj); the slot's readers
+        # include the compute stream, so slot reuse must wait for it.
+        if self.use_layerwise_transfer:
+            assert self.sync_attn_events is not None
+            assert self.layer_attn_recorded_events is not None
+            self.sync_attn_events[self.current_layer].record()
+            self.layer_attn_recorded_events[self.current_layer].set()
         if self.current_layer == self.num_layers - 1:
             while not self.layer_save_finished_events[self.num_layers - 1].wait(timeout=10):
                 send_thread.raise_if_failed()
                 logger.info("Layerwise %d save not done, keep waiting", self.current_layer)
             send_thread.raise_if_failed()
+            # A reused buffer's load task owns its save gate and clears it
+            # after observing the signal. Clearing that gate here can race
+            # with the asynchronous receive thread and lose the wake-up.
             reuse_source_layers = set(self.prefetch_layer_map.values())
             for layer_id in range(self.num_layers):
                 if layer_id in reuse_source_layers:


### PR DESCRIPTION
### What this PR does / why we need it?

Rebases and adapts #12854 to current `main`. The buffer-reuse and MTP/sparse C8 prerequisites (#12852 and #12853), partial-block offload, and several lifecycle fixes have already landed, so this PR carries the remaining transfer preparation and scheduling changes forward.

- Move GVA allocation, metadata lookup, shared read-lease ownership, and vectorized address construction into dedicated layerwise transfer components.
- Batch and deduplicate load/save metadata across requests and KV cache groups, validate backend results, and roll back acquired leases when preparation fails.
- Prepare each batch once, protecting the previous partial snapshot before allocating its successor. Keep full-prefix reloads separate from the HBM tail used by independent layers.
- Dispatch saves after KV scatter and release reused slots only after the copy and attention complete. Keep main's target-layer PD slot-release callback, Mooncake range-session protocol, reachable-block masks, and backend-owned key formats.
- Bind prefetch gates to physical layers, including registered MTP names; avoid waiting on an adjacent reused layer's own attention. Complete requests on their last actual transfer and preserve fatal-transfer handling.
- Keep scheduler lookups limited to publication state; fetch GVAs in the worker that performs the transfer.

### Does this PR introduce _any_ user-facing change?

No new configuration options or public APIs. Existing layerwise layouts, partial prefill/decode snapshots, and `consumer_is_to_put` saves remain supported.

### How was this patch tested?

- `bash format.sh ci`: passed all repository checks.
- CPU/mock KV Pool regression tests: **394 passed**, including the new allocation batching, malformed metadata, lease rollback/reference counting, preparation ordering, per-layer gates, and slot-lifecycle cases. Run in a Python environment without vLLM/NPU dependencies:

  ```bash
  PYTHONPATH=. python -m pytest --noconftest tests/ut/distributed/ascend_store \
    --ignore=tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py \
    --ignore=tests/ut/distributed/ascend_store/test_coordinator.py -q
  ```

- Changed Python files parsed successfully; `git diff --check` passed.
- Full pytest, coordinator/layout integration, and Ascend end-to-end/performance validation remain pending CI. The local macOS vLLM checkout is incompatible with the current repository-wide test imports; CPU/mock results do not validate NPU execution.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
