### PR TITLE
[Feature][KV Transfer] Support blockwise Mooncake DSA transfers for sparse KV offload

### DIFF
--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2536,6 +2536,180 @@ int64_t compute_lru_resident_addrs(const at::Tensor& miss_count, const at::Tenso
 
 namespace {
 
+void check_current_kv_index_tensor(const at::Tensor& tensor, const torch::ScalarType dtype, const char* name) {
+  TORCH_CHECK(tensor.device().is_cpu(), name, " must be a CPU tensor");
+  TORCH_CHECK(tensor.scalar_type() == dtype, name, " has an invalid dtype");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+struct CurrentKvIndexCopyPayload {
+  at::Tensor slot_mapping;
+  at::Tensor src_idx_buffer;
+  at::Tensor dst_idx_buffer;
+  at::Tensor count_buffer;
+  int64_t num_actual_tokens;
+  int64_t max_num_tokens;
+  int64_t num_host_slots;
+  bool delete_after_run;
+};
+
+std::unique_ptr<CurrentKvIndexCopyPayload> make_current_kv_index_copy_payload(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  check_current_kv_index_tensor(slot_mapping, torch::kInt64, "slot_mapping");
+  check_current_kv_index_tensor(src_idx_buffer, torch::kInt64, "src_idx_buffer");
+  check_current_kv_index_tensor(dst_idx_buffer, torch::kInt64, "dst_idx_buffer");
+  check_current_kv_index_tensor(count_buffer, torch::kInt32, "count_buffer");
+  TORCH_CHECK(num_actual_tokens >= 0, "num_actual_tokens must not be negative");
+  TORCH_CHECK(max_num_tokens > 0, "max_num_tokens must be positive");
+  TORCH_CHECK(max_num_tokens <= std::numeric_limits<int32_t>::max(), "max_num_tokens exceeds int32 capacity");
+  TORCH_CHECK(num_actual_tokens <= max_num_tokens, "num_actual_tokens exceeds max_num_tokens");
+  TORCH_CHECK(num_host_slots > 0, "num_host_slots must be positive");
+  TORCH_CHECK(slot_mapping.numel() >= num_actual_tokens, "slot_mapping is smaller than num_actual_tokens");
+  TORCH_CHECK(src_idx_buffer.numel() >= max_num_tokens, "src_idx_buffer is too small");
+  TORCH_CHECK(dst_idx_buffer.numel() >= max_num_tokens, "dst_idx_buffer is too small");
+  TORCH_CHECK(count_buffer.numel() >= 1, "count_buffer is empty");
+
+  return std::make_unique<CurrentKvIndexCopyPayload>(CurrentKvIndexCopyPayload{
+      slot_mapping, src_idx_buffer, dst_idx_buffer, count_buffer, num_actual_tokens, max_num_tokens, num_host_slots,
+      false});
+}
+
+void build_current_kv_index_copy_descriptors(CurrentKvIndexCopyPayload* payload) noexcept {
+  if (payload == nullptr) {
+    return;
+  }
+  const auto* slots = payload->slot_mapping.data_ptr<int64_t>();
+  auto* src_idx = payload->src_idx_buffer.data_ptr<int64_t>();
+  auto* dst_idx = payload->dst_idx_buffer.data_ptr<int64_t>();
+  auto* count = payload->count_buffer.data_ptr<int32_t>();
+  int32_t num_copies = 0;
+
+  for (int64_t token_idx = 0; token_idx < payload->num_actual_tokens; ++token_idx) {
+    const int64_t slot = slots[token_idx];
+    if (slot < 0 || slot >= payload->num_host_slots) {
+      continue;
+    }
+    src_idx[num_copies] = token_idx;
+    dst_idx[num_copies] = slot;
+    ++num_copies;
+  }
+
+  if (num_copies > 0) {
+    const int64_t last_src = src_idx[num_copies - 1];
+    const int64_t last_dst = dst_idx[num_copies - 1];
+    for (int64_t i = num_copies; i < payload->max_num_tokens; ++i) {
+      src_idx[i] = last_src;
+      dst_idx[i] = last_dst;
+    }
+  } else {
+    std::fill_n(src_idx, payload->max_num_tokens, 0);
+    std::fill_n(dst_idx, payload->max_num_tokens, 0);
+  }
+  count[0] = num_copies;
+}
+
+int64_t compute_current_kv_index_copy_descriptors(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  auto payload = make_current_kv_index_copy_payload(slot_mapping, num_actual_tokens, max_num_tokens, num_host_slots,
+                                                    src_idx_buffer, dst_idx_buffer, count_buffer);
+  build_current_kv_index_copy_descriptors(payload.get());
+  return count_buffer.data_ptr<int32_t>()[0];
+}
+
+struct CurrentKvIndexCopyGraphPayloadRegistry {
+  aclmdlRI model_ri;
+  std::vector<std::unique_ptr<CurrentKvIndexCopyPayload>> payloads;
+};
+
+std::mutex& current_kv_index_copy_graph_registry_mutex() {
+  static auto* mutex = new std::mutex();
+  return *mutex;
+}
+
+std::unordered_map<aclmdlRI, std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry>>&
+current_kv_index_copy_graph_registries() {
+  static auto* registries =
+      new std::unordered_map<aclmdlRI, std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry>>();
+  return *registries;
+}
+
+void delete_current_kv_index_copy_graph_payloads(void* args) noexcept {
+  auto* registry = static_cast<CurrentKvIndexCopyGraphPayloadRegistry*>(args);
+  std::unique_ptr<CurrentKvIndexCopyGraphPayloadRegistry> owned_registry;
+  {
+    std::lock_guard<std::mutex> lock(current_kv_index_copy_graph_registry_mutex());
+    auto& registries = current_kv_index_copy_graph_registries();
+    const auto it = registries.find(registry->model_ri);
+    if (it != registries.end() && it->second.get() == registry) {
+      owned_registry = std::move(it->second);
+      registries.erase(it);
+    }
+  }
+}
+
+CurrentKvIndexCopyPayload* retain_current_kv_index_copy_graph_payload(
+    aclmdlRI model_ri, std::unique_ptr<CurrentKvIndexCopyPayload> payload) {
+  auto* raw_payload = payload.get();
+  std::lock_guard<std::mutex> lock(current_kv_index_copy_graph_registry_mutex());
+  auto& registries = current_kv_index_copy_graph_registries();
+  auto it = registries.find(model_ri);
+  if (it == registries.end()) {
+    auto registry = std::make_unique<CurrentKvIndexCopyGraphPayloadRegistry>();
+    registry->model_ri = model_ri;
+    auto* raw_registry = registry.get();
+    it = registries.emplace(model_ri, std::move(registry)).first;
+    const aclError register_ret =
+        aclmdlRIDestroyRegisterCallback(model_ri, delete_current_kv_index_copy_graph_payloads, raw_registry);
+    if (register_ret != ACL_SUCCESS) {
+      registries.erase(it);
+    }
+    TORCH_CHECK(register_ret == ACL_SUCCESS,
+                "failed to bind current KV index_copy payload registry to graph lifetime, error code: ",
+                register_ret);
+  }
+  it->second->payloads.push_back(std::move(payload));
+  return raw_payload;
+}
+
+void current_kv_index_copy_descriptor_callback(void* args) noexcept {
+  auto* payload = static_cast<CurrentKvIndexCopyPayload*>(args);
+  build_current_kv_index_copy_descriptors(payload);
+  if (payload->delete_after_run) {
+    delete payload;
+  }
+}
+
+void enqueue_current_kv_index_copy_descriptors(
+    const at::Tensor& slot_mapping, int64_t num_actual_tokens, int64_t max_num_tokens, int64_t num_host_slots,
+    const at::Tensor& src_idx_buffer, const at::Tensor& dst_idx_buffer, const at::Tensor& count_buffer) {
+  auto payload = make_current_kv_index_copy_payload(slot_mapping, num_actual_tokens, max_num_tokens, num_host_slots,
+                                                    src_idx_buffer, dst_idx_buffer, count_buffer);
+  const auto stream = c10_npu::getCurrentNPUStream().stream();
+  aclmdlRICaptureStatus capture_status = ACL_MODEL_RI_CAPTURE_STATUS_NONE;
+  aclmdlRI model_ri = nullptr;
+  const aclError capture_ret = aclmdlRICaptureGetInfo(stream, &capture_status, &model_ri);
+  TORCH_CHECK(capture_ret == ACL_SUCCESS,
+              "aclmdlRICaptureGetInfo for current KV index_copy descriptors failed, error code: ", capture_ret);
+  TORCH_CHECK(capture_status != ACL_MODEL_RI_CAPTURE_STATUS_INVALIDATED,
+              "current KV index_copy descriptors cannot enqueue on an invalidated graph capture");
+  const bool graph_lifetime = capture_status == ACL_MODEL_RI_CAPTURE_STATUS_ACTIVE;
+  TORCH_CHECK(!graph_lifetime || model_ri != nullptr, "active graph capture returned a null model runtime instance");
+
+  payload->delete_after_run = !graph_lifetime;
+  auto* raw_payload = payload.get();
+  if (graph_lifetime) {
+    raw_payload = retain_current_kv_index_copy_graph_payload(model_ri, std::move(payload));
+  }
+  const aclError ret = aclrtLaunchHostFunc(stream, current_kv_index_copy_descriptor_callback, raw_payload);
+  if (ret == ACL_SUCCESS && !graph_lifetime) {
+    payload.release();
+  }
+  TORCH_CHECK(ret == ACL_SUCCESS, "aclrtLaunchHostFunc for current KV index_copy descriptors failed, error code: ",
+              ret);
+}
+
 struct LruResidentCompactWithPlanPayload {
   uintptr_t req_ids_ptr;
   uintptr_t last_req_ids_ptr;
@@ -2960,6 +3134,18 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
                  auto options = torch::TensorOptions().dtype(torch::kInt16).device(torch::kCPU);
                  return at::from_blob(reinterpret_cast<void*>(ptr_val), shape, options);
              });
+
+    ops.def("sparse_kv_compute_current_kv_index_copy_descriptors(Tensor slot_mapping, int num_actual_tokens, "
+            "int max_num_tokens, int num_host_slots, Tensor(a!) src_idx_buffer, Tensor(b!) dst_idx_buffer, "
+            "Tensor(c!) count_buffer) -> int");
+    ops.impl("sparse_kv_compute_current_kv_index_copy_descriptors", torch::kCPU,
+             &vllm_ascend::compute_current_kv_index_copy_descriptors);
+
+    ops.def("sparse_kv_enqueue_current_kv_index_copy_descriptors(Tensor slot_mapping, int num_actual_tokens, "
+            "int max_num_tokens, int num_host_slots, Tensor(a!) src_idx_buffer, Tensor(b!) dst_idx_buffer, "
+            "Tensor(c!) count_buffer) -> ()");
+    ops.impl("sparse_kv_enqueue_current_kv_index_copy_descriptors", torch::kCPU,
+             &vllm_ascend::enqueue_current_kv_index_copy_descriptors);
 #endif
 
     ops.def("device_print(str msg) -> ()");

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,9 @@ disable_error_code = annotation-unchecked
 [mypy-torch_npu.*]
 ignore_missing_imports = True
 
+[mypy-mooncake.*]
+ignore_missing_imports = True
+
 [mypy-npugraph_ex.*]
 ignore_missing_imports = True
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
@@ -29,6 +29,8 @@ def _load_sparse_kv_ops():
         "sparse_kv_compute_lru_resident_addrs",
         "sparse_kv_restore_bfloat16_tensor",
         "sparse_kv_restore_int16_tensor",
+        "sparse_kv_compute_current_kv_index_copy_descriptors",
+        "sparse_kv_enqueue_current_kv_index_copy_descriptors",
     }
     missing = [name for name in required if not hasattr(torch.ops._C_ascend, name)]
     if missing:
@@ -144,6 +146,79 @@ def test_sparse_kv_restore_tensor_views(sparse_kv_ops):
     assert int16_view.data_ptr() == int16.data_ptr()
     assert bf16_view.dtype == torch.bfloat16
     assert int16_view.dtype == torch.int16
+
+
+def test_current_kv_index_copy_descriptors_pad_last_valid(sparse_kv_ops):
+    slot_mapping = torch.tensor([7, -1, 3, 99], dtype=torch.int64)
+    max_num_tokens = 6
+    src_idx = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+    dst_idx = torch.full((max_num_tokens,), -1, dtype=torch.int64)
+    count = torch.zeros(1, dtype=torch.int32)
+
+    result = sparse_kv_ops.sparse_kv_compute_current_kv_index_copy_descriptors(
+        slot_mapping,
+        4,
+        max_num_tokens,
+        16,
+        src_idx,
+        dst_idx,
+        count,
+    )
+
+    assert result == 2
+    assert count.tolist() == [2]
+    assert src_idx.tolist() == [0, 2, 2, 2, 2, 2]
+    assert dst_idx.tolist() == [7, 3, 3, 3, 3, 3]
+
+
+def test_current_kv_index_copy_descriptors_survive_graph_replays(
+    sparse_kv_ops,
+):
+    if not torch_npu.npu.is_available():
+        pytest.skip("Ascend NPU is unavailable")
+
+    max_num_tokens = 4
+    slot_mapping = torch.zeros(max_num_tokens, dtype=torch.int64)
+    src_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
+    dst_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
+    count = torch.zeros(1, dtype=torch.int32)
+    side_stream_marker = torch.zeros(1, device="npu")
+    graph = torch.npu.NPUGraph()
+    current_stream = torch_npu.npu.current_stream()
+    save_stream = torch_npu.npu.Stream()
+    try:
+        with torch.npu.graph(graph):
+            sparse_kv_ops.sparse_kv_enqueue_current_kv_index_copy_descriptors(
+                slot_mapping,
+                max_num_tokens,
+                max_num_tokens,
+                16,
+                src_idx,
+                dst_idx,
+                count,
+            )
+            descriptors_ready = current_stream.record_event()
+            with torch_npu.npu.stream(save_stream):
+                save_stream.wait_event(descriptors_ready)
+            current_stream.wait_stream(save_stream)
+        torch_npu.npu.synchronize()
+
+        slot_mapping.copy_(torch.tensor([7, -1, 3, 99]))
+        graph.replay()
+        torch_npu.npu.synchronize()
+        assert count.tolist() == [2]
+        assert src_idx.tolist() == [0, 2, 2, 2]
+        assert dst_idx.tolist() == [7, 3, 3, 3]
+
+        slot_mapping.copy_(torch.tensor([5, 4, 3, 2]))
+        graph.replay()
+        torch_npu.npu.synchronize()
+        assert count.tolist() == [4]
+        assert src_idx.tolist() == [0, 1, 2, 3]
+        assert dst_idx.tolist() == [5, 4, 3, 2]
+    finally:
+        graph.reset()
+        torch_npu.npu.synchronize()
 
 
 def test_sparse_kv_compute_lru_resident_addrs(sparse_kv_ops):

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_sparse_kv_offload.py
@@ -182,7 +182,7 @@ def test_current_kv_index_copy_descriptors_survive_graph_replays(
     src_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
     dst_idx = torch.zeros(max_num_tokens, dtype=torch.int64)
     count = torch.zeros(1, dtype=torch.int32)
-    side_stream_marker = torch.zeros(1, device="npu")
+    _side_stream_marker = torch.zeros(1, device="npu")
     graph = torch.npu.NPUGraph()
     current_stream = torch_npu.npu.current_stream()
     save_stream = torch_npu.npu.Stream()

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -231,6 +231,7 @@ def test_fused_overlap_external_plan_passes_raw_topk_and_full_selection_state():
         _get_offload_layer_id=lambda _: 0,
         get_fused_overlap_cpu_kv_inputs=lambda _: (full_kv_cpu, full_rope_cpu),
         allocate_fused_overlap_membership_map=allocate_membership,
+        is_fused_membership_storage=lambda tensor: tensor.dtype == torch.int16,
         prepare_fused_overlap_external_plan=prepare_plan,
         inject_current_kv_into_selection=inject_current,
         wait_for_current_kv_writeback=wait_for_writeback,

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -936,6 +936,21 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(mock_logger_info.call_count, 2)
 
     @patch(
+        "vllm_ascend.cpu_binding.envs.VLLM_ASCEND_SKIP_MIGRATEPAGES",
+        True,
+    )
+    @patch("vllm_ascend.cpu_binding.execute_command")
+    def test_bind_memory_skips_when_configured(
+        self,
+        mock_execute_command,
+    ):
+        cpu_alloc = make_cpu_alloc()
+
+        cpu_alloc.bind_memory("999", 0)
+
+        mock_execute_command.assert_not_called()
+
+    @patch(
         "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
     )
     @patch("vllm_ascend.cpu_binding.logger.info")

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -1,0 +1,231 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
+    mooncake_host_pool as host_pool_module,
+)
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
+    HostPoolTopology,
+    MooncakeHostPool,
+)
+
+
+class TestMooncakeHostPool(unittest.TestCase):
+
+    def _allocate_region_for_mode(self, *, host_register: bool) -> HostMemoryRegion:
+        raw = MagicMock()
+        raw.reshape.return_value = raw
+        raw.data_ptr.return_value = 0x1000
+        aligned = MagicMock()
+        aligned.device = SimpleNamespace(type="npu")
+        raw.narrow.return_value = aligned
+        segment = MagicMock()
+        segment.tensors.return_value = [raw]
+
+        with (
+            patch.object(
+                host_pool_module,
+                "_select_shared_segment_mode",
+                return_value=(host_register, host_register),
+            ),
+            patch(
+                "mooncake.shared_segment.create_shared_segment",
+                return_value=segment,
+            ),
+        ):
+            return host_pool_module.allocate_mooncake_host_region(
+                size_bytes=32,
+                alignment=16,
+                topology=HostPoolTopology(tp_rank=0, tp_size=1),
+            )
+
+    def test_allocates_aligned_views_from_one_region(self):
+        raw = torch.empty(256, dtype=torch.int8)
+        pool = MooncakeHostPool(
+            HostMemoryRegion(raw),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+
+        first, second = pool.allocate_tensors([17, 23], alignment=32)
+
+        self.assertEqual(first.numel(), 17)
+        self.assertEqual(second.numel(), 23)
+        self.assertEqual(first.data_ptr() % 32, 0)
+        self.assertEqual(second.data_ptr() % 32, 0)
+        self.assertGreaterEqual(second.data_ptr(), first.data_ptr() + first.numel())
+        self.assertEqual(first.untyped_storage().data_ptr(), raw.untyped_storage().data_ptr())
+        self.assertEqual(second.untyped_storage().data_ptr(), raw.untyped_storage().data_ptr())
+
+    def test_exhausted_pool_is_rejected(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(32, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+
+        with self.assertRaisesRegex(MemoryError, "exhausted"):
+            pool.allocate_tensors([64], alignment=16)
+
+    def test_only_owner_registers_and_unregisters_region(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(
+                torch.empty(64, dtype=torch.int8),
+                register_location="npu:0",
+            ),
+            HostPoolTopology(tp_rank=0, tp_size=2, owner_rank=0),
+        )
+        engine = MagicMock()
+        engine.register_memory.return_value = 0
+        engine.unregister_memory.return_value = 0
+
+        pool.register(engine)
+        pool.register(engine)
+        pool.unregister()
+
+        engine.register_memory.assert_called_once_with(
+            pool.data_ptr,
+            pool.nbytes,
+            location="npu:0",
+        )
+        engine.unregister_memory.assert_called_once_with(pool.data_ptr)
+
+    def test_register_without_location_uses_two_argument_api(self):
+        class TwoArgumentEngine:
+            def __init__(self):
+                self.calls = []
+
+            def register_memory(self, ptr, size):
+                self.calls.append(("register", ptr, size))
+                return 0
+
+            def unregister_memory(self, ptr):
+                self.calls.append(("unregister", ptr))
+                return 0
+
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+        engine = TwoArgumentEngine()
+
+        pool.register(engine)
+        pool.unregister()
+
+        self.assertEqual(
+            engine.calls,
+            [
+                ("register", pool.data_ptr, pool.nbytes),
+                ("unregister", pool.data_ptr),
+            ],
+        )
+
+
+    def test_non_owner_cannot_register_region(self):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
+            HostPoolTopology(tp_rank=1, tp_size=2, owner_rank=0),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "only the owner rank"):
+            pool.register(MagicMock())
+
+    def test_region_preserves_requested_capacity_after_alignment(self):
+        requested_size = 32
+        alignment = 16
+        raw = MagicMock()
+        raw.reshape.return_value = raw
+        raw.data_ptr.return_value = 0x1001
+        aligned = MagicMock()
+        aligned.device = SimpleNamespace(type="npu")
+        aligned.numel.return_value = requested_size
+        raw.narrow.return_value = aligned
+        segment = MagicMock()
+        segment.tensors.return_value = [raw]
+
+        with (
+            patch.object(
+                host_pool_module,
+                "_select_shared_segment_mode",
+                return_value=(False, False),
+            ),
+            patch(
+                "mooncake.shared_segment.create_shared_segment",
+                return_value=segment,
+            ) as create_segment,
+        ):
+            region = host_pool_module.allocate_mooncake_host_region(
+                size_bytes=requested_size,
+                alignment=alignment,
+                topology=HostPoolTopology(
+                    tp_rank=0,
+                    tp_size=1,
+                    device_id=7,
+                ),
+            )
+
+        block = create_segment.call_args.kwargs["blocks"]["pool"]
+        self.assertEqual(block["shape"], (requested_size + alignment - 1,))
+        raw.narrow.assert_called_once_with(0, alignment - 1, requested_size)
+        self.assertIs(region.tensor, aligned)
+        self.assertEqual(region.tensor.numel(), requested_size)
+        self.assertEqual(region.register_location, "npu:7")
+
+    def test_host_register_sets_migratepages_guard(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(host_pool_module.os.environ, {}, clear=False):
+            host_pool_module.os.environ.pop(key, None)
+
+            self._allocate_region_for_mode(host_register=True)
+
+            self.assertEqual(host_pool_module.os.environ[key], "1")
+
+    def test_host_register_preserves_explicit_migratepages_setting(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(
+            host_pool_module.os.environ,
+            {key: "0"},
+            clear=False,
+        ):
+            self._allocate_region_for_mode(host_register=True)
+
+            self.assertEqual(host_pool_module.os.environ[key], "0")
+
+    def test_non_host_register_mode_does_not_set_migratepages_guard(self):
+        key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+        with patch.dict(host_pool_module.os.environ, {}, clear=False):
+            host_pool_module.os.environ.pop(key, None)
+
+            self._allocate_region_for_mode(host_register=False)
+
+            self.assertNotIn(key, host_pool_module.os.environ)
+    def test_failed_construction_releases_region(self):
+        release = MagicMock()
+        region = HostMemoryRegion(
+            torch.empty(8, dtype=torch.float32),
+            handle="segment",
+            release_callback=release,
+        )
+
+        with (
+            patch.object(
+                host_pool_module,
+                "allocate_mooncake_host_region",
+                return_value=region,
+            ),
+            self.assertRaisesRegex(TypeError, "int8 byte tensor"),
+        ):
+            MooncakeHostPool.allocate(
+                size_bytes=8,
+                alignment=8,
+                topology=HostPoolTopology(tp_rank=0, tp_size=1),
+            )
+
+        release.assert_called_once_with("segment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -76,68 +76,6 @@ class TestMooncakeHostPool(unittest.TestCase):
         with self.assertRaisesRegex(MemoryError, "exhausted"):
             pool.allocate_tensors([64], alignment=16)
 
-    def test_only_owner_registers_and_unregisters_region(self):
-        pool = MooncakeHostPool(
-            HostMemoryRegion(
-                torch.empty(64, dtype=torch.int8),
-                register_location="npu:0",
-            ),
-            HostPoolTopology(tp_rank=0, tp_size=2, owner_rank=0),
-        )
-        engine = MagicMock()
-        engine.register_memory.return_value = 0
-        engine.unregister_memory.return_value = 0
-
-        pool.register(engine)
-        pool.register(engine)
-        pool.unregister()
-
-        engine.register_memory.assert_called_once_with(
-            pool.data_ptr,
-            pool.nbytes,
-            location="npu:0",
-        )
-        engine.unregister_memory.assert_called_once_with(pool.data_ptr)
-
-    def test_register_without_location_uses_two_argument_api(self):
-        class TwoArgumentEngine:
-            def __init__(self):
-                self.calls = []
-
-            def register_memory(self, ptr, size):
-                self.calls.append(("register", ptr, size))
-                return 0
-
-            def unregister_memory(self, ptr):
-                self.calls.append(("unregister", ptr))
-                return 0
-
-        pool = MooncakeHostPool(
-            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
-            HostPoolTopology(tp_rank=0, tp_size=1),
-        )
-        engine = TwoArgumentEngine()
-
-        pool.register(engine)
-        pool.unregister()
-
-        self.assertEqual(
-            engine.calls,
-            [
-                ("register", pool.data_ptr, pool.nbytes),
-                ("unregister", pool.data_ptr),
-            ],
-        )
-
-    def test_non_owner_cannot_register_region(self):
-        pool = MooncakeHostPool(
-            HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
-            HostPoolTopology(tp_rank=1, tp_size=2, owner_rank=0),
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "only the owner rank"):
-            pool.register(MagicMock())
-
     def test_region_preserves_requested_capacity_after_alignment(self):
         requested_size = 32
         alignment = 16
@@ -177,7 +115,6 @@ class TestMooncakeHostPool(unittest.TestCase):
         raw.narrow.assert_called_once_with(0, alignment - 1, requested_size)
         self.assertIs(region.tensor, aligned)
         self.assertEqual(region.tensor.numel(), requested_size)
-        self.assertEqual(region.register_location, "npu:7")
 
     def test_host_register_sets_migratepages_guard(self):
         key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
@@ -207,6 +144,19 @@ class TestMooncakeHostPool(unittest.TestCase):
             self._allocate_region_for_mode(host_register=False)
 
             self.assertNotIn(key, host_pool_module.os.environ)
+
+    def test_no_supported_mode_raises(self):
+        with (
+            patch(
+                "mooncake.shared_segment.shared_segment_supported",
+                return_value=False,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "cannot expose an NPU-addressable",
+            ),
+        ):
+            host_pool_module._select_shared_segment_mode()
 
     def test_failed_construction_releases_region(self):
         release = MagicMock()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -1,5 +1,8 @@
+import sys
+import types
 import unittest
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -7,16 +10,19 @@ import torch
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
     mooncake_host_pool as host_pool_module,
 )
-
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
     HostMemoryRegion,
     HostPoolTopology,
     MooncakeHostPool,
 )
 
+_shared_segment_stub: Any = types.ModuleType("mooncake.shared_segment")
+_shared_segment_stub.create_shared_segment = MagicMock()
+_shared_segment_stub.shared_segment_supported = MagicMock(return_value=True)
+sys.modules.setdefault("mooncake.shared_segment", _shared_segment_stub)
+
 
 class TestMooncakeHostPool(unittest.TestCase):
-
     def _allocate_region_for_mode(self, *, host_register: bool) -> HostMemoryRegion:
         raw = MagicMock()
         raw.reshape.return_value = raw
@@ -123,7 +129,6 @@ class TestMooncakeHostPool(unittest.TestCase):
             ],
         )
 
-
     def test_non_owner_cannot_register_region(self):
         pool = MooncakeHostPool(
             HostMemoryRegion(torch.empty(64, dtype=torch.int8)),
@@ -202,6 +207,7 @@ class TestMooncakeHostPool(unittest.TestCase):
             self._allocate_region_for_mode(host_register=False)
 
             self.assertNotIn(key, host_pool_module.os.environ)
+
     def test_failed_construction_releases_region(self):
         release = MagicMock()
         region = HostMemoryRegion(

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py
@@ -115,6 +115,7 @@ class TestMooncakeHostPool(unittest.TestCase):
         raw.narrow.assert_called_once_with(0, alignment - 1, requested_size)
         self.assertIs(region.tensor, aligned)
         self.assertEqual(region.tensor.numel(), requested_size)
+        self.assertEqual(region.segment_offset, alignment - 1)
 
     def test_host_register_sets_migratepages_guard(self):
         key = "VLLM_ASCEND_SKIP_MIGRATEPAGES"
@@ -157,7 +158,6 @@ class TestMooncakeHostPool(unittest.TestCase):
             ),
         ):
             host_pool_module._select_shared_segment_mode()
-
     def test_failed_construction_releases_region(self):
         release = MagicMock()
         region = HostMemoryRegion(
@@ -185,3 +185,25 @@ class TestMooncakeHostPool(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_layout_uses_segment_offsets_and_rejects_overlaps():
+    pools, descriptions = [], []
+    for rank in range(2):
+        pool = MooncakeHostPool(
+            HostMemoryRegion(torch.empty(256, dtype=torch.int8), segment_offset=8),
+            HostPoolTopology(tp_rank=rank, tp_size=2),
+        )
+        k, v = [t.view(torch.bfloat16).reshape(4, 2, 1, 2) for t in pool.allocate_tensors([32, 32], 16)]
+        views = [("layer", "k", k), ("layer", "v", v)]
+        descriptions.append(pool.describe_local_views(views, 4))
+        pools.append(pool)
+        assert k.reshape(4, 2, 2).contiguous().data_ptr() == k.data_ptr()
+    assert pools[0].data_ptr != pools[1].data_ptr
+    assert descriptions[0] == descriptions[1]
+    pools[1].region.segment_offset = 0
+    assert pools[1].describe_local_views(views, 4) != descriptions[0]
+    with unittest.TestCase().assertRaisesRegex(ValueError, "overlapping"):
+        pools[1].describe_local_views([("layer", "k", k), ("layer", "v", k)], 4)
+    with unittest.TestCase().assertRaisesRegex(ValueError, "outside"):
+        pools[0].describe_local_views(views, 4)

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -326,10 +326,14 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                     ),
                     patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
                 ):
-                    SparseKVOffloadManager(
+                    manager = SparseKVOffloadManager(
                         vllm_config,
                         kv_cache_config,
                         offload_config,
+                    )
+                    manager.prepare_host_kv_allocation(
+                        device_id=7,
+                        dp_rank=0,
                     )
 
                 initialized_config = offload_backend.initialize.call_args.args[0]
@@ -344,6 +348,52 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                 self.assertEqual(initialized_config.world_size, 2)
                 self.assertEqual(initialized_config.rank_id, rank)
                 tp_group.barrier.assert_called_once_with()
+
+    def test_layer_allocation_uses_backend_callback_on_non_owner_rank(self):
+        host_k = MagicMock()
+        host_v = MagicMock()
+        allocate_host = MagicMock(return_value=[host_k, host_v])
+
+        result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+            k_tensor_size=128,
+            v_tensor_size=64,
+            alignment=32,
+            tp_rank=1,
+            keep_device_kv_cache=False,
+            npu_kv_cache_allocate_func=MagicMock(),
+            host_kv_cache_allocate_func=allocate_host,
+        )
+
+        self.assertIs(result[2], host_k)
+        self.assertIs(result[3], host_v)
+        allocate_host.assert_called_once_with([128, 64], 32)
+
+    def test_manager_close_releases_host_allocator_once(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        allocator = MagicMock()
+        manager._host_kv_allocator = allocator
+
+        manager.close()
+        manager.close()
+
+        allocator.close.assert_called_once_with()
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_manager_close_retains_host_allocator_when_close_fails(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        allocator = MagicMock()
+        allocator.close.side_effect = [RuntimeError("close failed"), None]
+        manager._host_kv_allocator = allocator
+
+        with self.assertRaisesRegex(RuntimeError, "close failed"):
+            manager.close()
+
+        self.assertIs(manager._host_kv_allocator, allocator)
+
+        manager.close()
+
+        self.assertIsNone(manager._host_kv_allocator)
+        self.assertEqual(allocator.close.call_count, 2)
 
     def test_manager_rejects_pool_larger_than_dram_limit(self):
         vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -1,11 +1,18 @@
+import contextlib
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import torch
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
     sparse_kv_offload_manager as manager_module,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
+    HostPoolTopology,
+    MooncakeHostPool,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     SparseKVOffloadManager,
@@ -54,6 +61,38 @@ def _make_memory_plan_inputs(max_num_seqs=2):
     vllm_config = SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs))
     alignment_reserve = 2 * manager_module._CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
     return specs, vllm_config, alignment_reserve
+
+
+def _make_manager_init_inputs(dram_size_per_dp_gb=1):
+    spec = _FakeKVCacheSpec(
+        page_size_bytes=1024,
+        max_blocks_per_request=100,
+        store_on_host=True,
+    )
+    kv_cache_config = SimpleNamespace(
+        num_blocks=200,
+        kv_cache_groups=[SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)],
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            get_num_layers=MagicMock(return_value=1),
+            max_model_len=128,
+        ),
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=1,
+            max_num_batched_tokens=1,
+        ),
+        speculative_config=None,
+    )
+    offload_config = SimpleNamespace(
+        topk_buffer_size=1,
+        topk=1,
+        use_fused_overlap=False,
+        host_backend="memfabric",
+        dram_size_per_dp_GB=dram_size_per_dp_gb,
+    )
+    return vllm_config, kv_cache_config, offload_config
 
 
 class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
@@ -245,38 +284,8 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "host-resident"):
             get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config)
 
-    def _make_manager_init_inputs(self, dram_size_per_dp_gb=1):
-        spec = _FakeKVCacheSpec(
-            page_size_bytes=1024,
-            max_blocks_per_request=100,
-            store_on_host=True,
-        )
-        kv_cache_config = SimpleNamespace(
-            num_blocks=200,
-            kv_cache_groups=[SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)],
-        )
-        vllm_config = SimpleNamespace(
-            model_config=SimpleNamespace(
-                get_num_layers=MagicMock(return_value=1),
-                max_model_len=128,
-            ),
-            parallel_config=SimpleNamespace(),
-            scheduler_config=SimpleNamespace(
-                max_num_seqs=1,
-                max_num_batched_tokens=1,
-            ),
-            speculative_config=None,
-        )
-        offload_config = SimpleNamespace(
-            topk_buffer_size=1,
-            topk=1,
-            use_fused_overlap=False,
-            dram_size_per_dp_GB=dram_size_per_dp_gb,
-        )
-        return vllm_config, kv_cache_config, offload_config
-
     def test_manager_initializes_offload_with_planned_pool_size(self):
-        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         planned_pool_size = 4096
         for rank, expected_alloc_size in ((0, planned_pool_size), (1, 0)):
             with self.subTest(rank=rank):
@@ -368,6 +377,72 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertIs(result[3], host_v)
         allocate_host.assert_called_once_with([128, 64], 32)
 
+    def test_manager_prepares_mooncake_host_pool(self):
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
+        offload_config.host_backend = "mooncake"
+        planned_pool_size = 4096
+        allocator = MagicMock()
+        tp_group = SimpleNamespace(barrier=MagicMock())
+
+        with (
+            patch.object(manager_module, "get_tensor_model_parallel_rank", return_value=1),
+            patch.object(manager_module, "get_tensor_model_parallel_world_size", return_value=2),
+            patch.object(manager_module, "get_tp_group", return_value=tp_group),
+            patch.object(
+                manager_module,
+                "get_sparse_kv_offload_cpu_pool_size_bytes",
+                return_value=planned_pool_size,
+            ),
+            patch.object(
+                manager_module.MooncakeHostPool,
+                "allocate",
+                return_value=allocator,
+            ) as allocate_pool,
+            patch.object(manager_module.torch, "zeros", return_value=MagicMock()),
+            patch.object(manager_module.torch, "empty", return_value=MagicMock()),
+            patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
+        ):
+            manager = SparseKVOffloadManager(vllm_config, kv_cache_config, offload_config)
+            manager.prepare_host_kv_allocation(device_id=7, dp_rank=3)
+
+        self.assertIs(manager._host_kv_allocator, allocator)
+        self.assertTrue(manager._host_allocation_prepared)
+        allocate_pool.assert_called_once()
+        call = allocate_pool.call_args
+        self.assertEqual(call.kwargs["size_bytes"], planned_pool_size)
+        self.assertEqual(call.kwargs["alignment"], manager_module._CPU_CACHE_ALIGNMENT)
+        topology = call.kwargs["topology"]
+        self.assertEqual(topology.tp_rank, 1)
+        self.assertEqual(topology.tp_size, 2)
+        self.assertEqual(topology.owner_rank, 0)
+        self.assertEqual(topology.device_id, 7)
+        self.assertEqual(topology.dp_rank, 3)
+        self.assertIs(topology.tp_group, tp_group)
+        tp_group.barrier.assert_not_called()
+
+    def test_failed_mooncake_prepare_remains_retryable(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "mooncake"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        with (
+            patch.object(
+                manager_module.MooncakeHostPool,
+                "allocate",
+                side_effect=RuntimeError("allocation failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "allocation failed"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        self.assertFalse(manager._host_allocation_prepared)
+        self.assertIsNone(manager._host_kv_allocator)
+
     def test_manager_close_releases_host_allocator_once(self):
         manager = object.__new__(SparseKVOffloadManager)
         allocator = MagicMock()
@@ -396,7 +471,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertEqual(allocator.close.call_count, 2)
 
     def test_manager_rejects_pool_larger_than_dram_limit(self):
-        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         offload_backend = SimpleNamespace(
             OffloadConfig=MagicMock(),
             Scene=SimpleNamespace(SHARED="shared"),
@@ -438,6 +513,348 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
 
         offload_backend.OffloadConfig.assert_not_called()
         offload_backend.initialize.assert_not_called()
+
+
+class TestMemFabricHostKVAllocator(unittest.TestCase):
+    def test_owner_rank_delegates_to_empty_aligned_helper(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=0)
+        k, v = MagicMock(), MagicMock()
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors", return_value=[k, v]) as helper:
+            tensors = allocator.allocate_tensors([128, 64], alignment=32)
+        helper.assert_called_once_with([128, 64], 32)
+        self.assertEqual(tensors, [k, v])
+
+    def test_non_owner_rank_returns_none_views_without_allocation(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=1)
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors") as helper:
+            tensors = allocator.allocate_tensors([128, 64], alignment=32)
+        helper.assert_not_called()
+        self.assertEqual(tensors, [None, None])
+
+    def test_close_is_noop_and_idempotent(self):
+        allocator = manager_module.MemFabricHostKVAllocator(tp_rank=0)
+        allocator.close()
+        allocator.close()  # 不抛异常即可；MemFabric 池由 offload 运行时托管
+
+
+class TestHostBackendSelection(unittest.TestCase):
+    def test_manager_prepares_memfabric_host_allocator(self):
+        vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
+        planned_pool_size = 4096
+        tp_group = SimpleNamespace(barrier=MagicMock())
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=0),
+        )
+
+        with (
+            patch.object(manager_module, "get_tensor_model_parallel_rank", return_value=0),
+            patch.object(manager_module, "get_tensor_model_parallel_world_size", return_value=2),
+            patch.object(manager_module, "get_tp_group", return_value=tp_group),
+            patch.object(
+                manager_module,
+                "get_sparse_kv_offload_cpu_pool_size_bytes",
+                return_value=planned_pool_size,
+            ),
+            patch.object(manager_module, "offload", offload_backend, create=True),
+            patch.object(manager_module.torch, "zeros", return_value=MagicMock()),
+            patch.object(manager_module.torch, "empty", return_value=MagicMock()),
+            patch.object(manager_module, "_sparse_kv_ops", return_value=MagicMock()),
+        ):
+            manager = SparseKVOffloadManager(vllm_config, kv_cache_config, offload_config)
+            manager.prepare_host_kv_allocation(device_id=7, dp_rank=0)
+
+        self.assertIsInstance(manager._host_kv_allocator, manager_module.MemFabricHostKVAllocator)
+        self.assertTrue(manager._host_allocation_prepared)
+        tp_group.barrier.assert_called_once_with()
+
+    def test_failed_memfabric_prepare_remains_retryable(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "memfabric"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=1),  # 触发 assert
+        )
+        with (
+            patch.object(manager_module, "offload", offload_backend, create=True),
+            self.assertRaisesRegex(AssertionError, "offload.initialize failed"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        self.assertFalse(manager._host_allocation_prepared)
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_prepare_is_idempotent_across_backends(self):
+        # mooncake
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "mooncake"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+        with patch.object(manager_module.MooncakeHostPool, "allocate", return_value=MagicMock()) as allocate_pool:
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+        allocate_pool.assert_called_once()
+
+        # memfabric
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "memfabric"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+        offload_backend = SimpleNamespace(
+            OffloadConfig=lambda: SimpleNamespace(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=0),
+        )
+        with patch.object(manager_module, "offload", offload_backend, create=True):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+        offload_backend.initialize.assert_called_once()
+
+    def test_prepare_rejects_unknown_host_backend(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = "rdma"
+        manager._host_allocation_prepared = False
+        manager._host_kv_allocator = None
+        manager.host_pool_size_bytes = 4096
+        manager.tp_rank = 0
+        manager.tp_size = 1
+        manager.tp_group = MagicMock()
+
+        with (
+            patch.object(manager_module.MooncakeHostPool, "allocate") as allocate_pool,
+            patch.object(manager_module, "offload", MagicMock(), create=True) as offload_backend,
+            self.assertRaisesRegex(ValueError, "Unsupported sparse KV offload Host backend"),
+        ):
+            manager.prepare_host_kv_allocation(device_id=0, dp_rank=0)
+
+        allocate_pool.assert_not_called()
+        offload_backend.initialize.assert_not_called()
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_allocate_host_kv_tensors_raises_before_prepare(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = None
+
+        with self.assertRaisesRegex(RuntimeError, "prepare_host_kv_allocation must run"):
+            manager.allocate_host_kv_tensors([128, 64], 32)
+
+    def test_allocate_host_kv_tensors_delegates_to_allocator(self):
+        mooncake = MagicMock()
+        mooncake.allocate_tensors.return_value = [MagicMock()]
+        cases = [
+            ("mooncake", mooncake),
+            ("memfabric_rank0", manager_module.MemFabricHostKVAllocator(0)),
+            ("memfabric_rank1", manager_module.MemFabricHostKVAllocator(1)),
+        ]
+        for name, allocator in cases:
+            with self.subTest(name=name):
+                manager = object.__new__(SparseKVOffloadManager)
+                manager._host_kv_allocator = allocator
+                with patch.object(
+                    manager_module,
+                    "empty_aligned_int8_cpu_tensors",
+                    return_value=[MagicMock(), MagicMock()],
+                ) as helper:
+                    tensors = manager.allocate_host_kv_tensors([128, 64], 32)
+                if name == "mooncake":
+                    self.assertIs(tensors, mooncake.allocate_tensors.return_value)
+                    helper.assert_not_called()
+                elif name == "memfabric_rank0":
+                    self.assertIs(tensors, helper.return_value)
+                else:
+                    self.assertEqual(tensors, [None, None])
+                    helper.assert_not_called()
+
+    def test_close_releases_mooncake_region_via_manager(self):
+        release_callback = MagicMock()
+        pool = MooncakeHostPool(
+            HostMemoryRegion(
+                torch.empty(64, dtype=torch.int8),
+                handle="segment",
+                release_callback=release_callback,
+            ),
+            HostPoolTopology(tp_rank=0, tp_size=1),
+        )
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = pool
+
+        manager.close()
+
+        release_callback.assert_called_once_with("segment")
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_close_memfabric_allocator_is_noop(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        manager._host_kv_allocator = manager_module.MemFabricHostKVAllocator(0)
+
+        manager.close()
+
+        self.assertIsNone(manager._host_kv_allocator)
+
+    def test_layer_allocation_none_cpu_on_memfabric_non_owner(self):
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors") as helper:
+            result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+                k_tensor_size=128,
+                v_tensor_size=64,
+                alignment=32,
+                tp_rank=1,
+                keep_device_kv_cache=False,
+                npu_kv_cache_allocate_func=MagicMock(),
+                host_kv_cache_allocate_func=manager_module.MemFabricHostKVAllocator(1).allocate_tensors,
+            )
+        helper.assert_not_called()
+        self.assertIsNone(result[2])
+        self.assertIsNone(result[3])
+
+    def test_layer_allocation_cpu_on_memfabric_owner(self):
+        k_cpu, v_cpu = MagicMock(), MagicMock()
+        with patch.object(manager_module, "empty_aligned_int8_cpu_tensors", return_value=[k_cpu, v_cpu]) as helper:
+            result = manager_module.allocate_kv_cache_tensors_for_sparse_kv_offload(
+                k_tensor_size=128,
+                v_tensor_size=64,
+                alignment=32,
+                tp_rank=0,
+                keep_device_kv_cache=False,
+                npu_kv_cache_allocate_func=MagicMock(),
+                host_kv_cache_allocate_func=manager_module.MemFabricHostKVAllocator(0).allocate_tensors,
+            )
+        helper.assert_called_once_with([128, 64], 32)
+        self.assertIs(result[2], k_cpu)
+        self.assertIs(result[3], v_cpu)
+
+    def test_both_allocators_satisfy_hostkvallocator_contract(self):
+        for cls in (
+            manager_module.MooncakeHostPool,
+            manager_module.MemFabricHostKVAllocator,
+        ):
+            with self.subTest(cls=cls):
+                self.assertTrue(hasattr(cls, "allocate_tensors"))
+                self.assertTrue(hasattr(cls, "close"))
+
+
+def _shape_aware_tensor_fake(*args, **kwargs):
+    """最小 torch.Tensor 替身：切片/视图/形状断言全部自洽。"""
+    fake = MagicMock()
+    shape = args[0] if args else kwargs.get("shape", [])
+    if isinstance(shape, int):  # torch.arange(n, ...) 场景
+        shape = [shape]
+    fake.shape = torch.Size(shape)
+    fake._itemsize = getattr(kwargs.get("dtype", torch.int8), "itemsize", 1)
+
+    def _view(*view_args):
+        # .view(dtype): 按元素大小换算第一维；.view(shape...): 直接复用自身。
+        dtype = view_args[0] if view_args else None
+        itemsize = getattr(dtype, "itemsize", 0)
+        if not itemsize:
+            return fake
+        new_shape = list(fake.shape)
+        if new_shape:
+            new_shape[0] = new_shape[0] * fake._itemsize // itemsize
+        return _shape_aware_tensor_fake(new_shape, dtype=dtype)
+
+    def _getitem(key):
+        if not isinstance(key, slice):
+            return fake
+        start = key.start or 0
+        stop = key.stop if key.stop is not None else (fake.shape[0] if fake.shape else 0)
+        new_shape = list(fake.shape)
+        if new_shape:
+            new_shape[0] = stop - start
+        return _shape_aware_tensor_fake(new_shape, dtype=fake.dtype)
+
+    fake.view.side_effect = _view
+    fake.__getitem__.side_effect = _getitem
+    fake.repeat.return_value = fake
+    fake.pin_memory.return_value = fake
+    fake.copy_.return_value = fake
+    fake.item.return_value = 0xFEED
+    fake.data_ptr.return_value = 0x1000
+    fake.numel.return_value = 4096
+    fake.element_size.return_value = 1
+    fake.size.side_effect = lambda dim: fake.shape[dim]
+    fake.dtype = kwargs.get("dtype", torch.int8)
+    fake.device = kwargs.get("device", "cpu")
+    return fake
+
+
+class TestRegisterKvCachesBackendBranch(unittest.TestCase):
+    @staticmethod
+    def _make_register_caches_manager(host_backend, k_cpu, v_cpu):
+        topk = _shape_aware_tensor_fake([1, 1])  # size(-2)==1, size(-1)==1
+        topk.dtype = torch.bfloat16
+        topk.device = "npu"
+        kv_caches = {"host.0": (MagicMock(), MagicMock(), k_cpu, v_cpu, topk, topk)}
+        manager = object.__new__(SparseKVOffloadManager)
+        manager.host_backend = host_backend
+        manager._host_kv_allocator = None  # 分支只看配置，与 allocator 实例无关
+        manager._register_offload_layers = MagicMock()
+        manager.offload_layer_names = ["host.0"]
+        manager.num_layers = 1
+        manager.tp_size = 2
+        manager.kv_cache_config = SimpleNamespace(num_blocks=8)
+        manager.block_size = 128
+        manager.topk_buffer_size = 256
+        manager.topk = 8
+        manager.max_num_tokens = 4
+        manager.max_num_topk_rows = 4
+        manager.max_model_len = 1024
+        manager.use_fused_overlap = False
+        manager.tp_rank = 1
+        manager.tp_group = MagicMock()
+        return manager, kv_caches
+
+    @staticmethod
+    def _patch_torch_factories() -> contextlib.ExitStack:
+        stack = contextlib.ExitStack()
+        for factory in ("zeros", "empty", "full", "arange"):
+            stack.enter_context(
+                patch.object(
+                    manager_module.torch,
+                    factory,
+                    side_effect=_shape_aware_tensor_fake,
+                )
+            )
+        return stack
+
+    def test_register_kv_caches_uses_local_views_with_mooncake_backend(self):
+        k_cpu = _shape_aware_tensor_fake([64])
+        v_cpu = _shape_aware_tensor_fake([64])
+        manager, kv_caches = self._make_register_caches_manager("mooncake", k_cpu, v_cpu)
+
+        with self._patch_torch_factories():
+            manager.register_kv_caches(kv_caches)
+
+        manager.tp_group.broadcast.assert_not_called()
+        self.assertEqual(len(manager.k_caches_cpu), 1)
+        self.assertEqual(manager.gvas_k_bases, [k_cpu.data_ptr()])
+        self.assertEqual(manager.gvas_v_bases, [v_cpu.data_ptr()])
+
+    def test_register_kv_caches_broadcasts_with_memfabric_backend(self):
+        manager, kv_caches = self._make_register_caches_manager("memfabric", None, None)
+
+        with self._patch_torch_factories():
+            manager.register_kv_caches(kv_caches)
+
+        self.assertEqual(manager.tp_group.broadcast.call_count, 5)
+        self.assertEqual(manager.k_caches_cpu, [])
+        self.assertEqual(len(manager.gvas_k_bases), 1)
 
 
 if __name__ == "__main__":

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -470,6 +470,38 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertIsNone(manager._host_kv_allocator)
         self.assertEqual(allocator.close.call_count, 2)
 
+    def test_manager_close_retries_membership_region_release(self):
+        manager = object.__new__(SparseKVOffloadManager)
+        region = MagicMock()
+        region.release.side_effect = [
+            RuntimeError("release failed"),
+            None,
+        ]
+        membership = MagicMock()
+        planner = MagicMock()
+        device_staging = MagicMock()
+        manager.fused_overlap_membership_region = region
+        manager.fused_overlap_membership_map = membership
+        manager.fused_overlap_planner_membership_map = planner
+        manager.fused_overlap_membership_plan_device_staging = device_staging
+        manager._host_kv_allocator = None
+
+        with self.assertRaisesRegex(RuntimeError, "release failed"):
+            manager.close()
+
+        self.assertIs(manager.fused_overlap_membership_region, region)
+        self.assertIs(manager.fused_overlap_membership_map, membership)
+
+        manager.close()
+
+        self.assertIsNone(manager.fused_overlap_membership_region)
+        self.assertIsNone(manager.fused_overlap_membership_map)
+        self.assertIsNone(manager.fused_overlap_planner_membership_map)
+        self.assertIsNone(
+            manager.fused_overlap_membership_plan_device_staging
+        )
+        self.assertEqual(region.release.call_count, 2)
+
     def test_manager_rejects_pool_larger_than_dram_limit(self):
         vllm_config, kv_cache_config, offload_config = _make_manager_init_inputs()
         offload_backend = SimpleNamespace(

--- a/tests/ut/distributed/kv_transfer/test_mooncake_transfer_engine.py
+++ b/tests/ut/distributed/kv_transfer/test_mooncake_transfer_engine.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import (  # noqa: E402
+    GlobalTE,
+)
+
+
+def _manager_with_engine(engine: object) -> GlobalTE:
+    manager = GlobalTE()
+    manager.transfer_engine = engine
+    return manager
+
+
+def test_register_buffer_uses_two_arguments_without_locations():
+    engine = MagicMock()
+    engine.register_memory.return_value = 0
+    manager = _manager_with_engine(engine)
+
+    manager.register_buffer([100, 200], [10, 20])
+
+    assert engine.register_memory.call_args_list == [call(100, 10), call(200, 20)]
+
+
+def test_register_buffer_uses_three_arguments_with_locations(monkeypatch):
+    engine = MagicMock()
+    engine.register_memory.return_value = 0
+    manager = _manager_with_engine(engine)
+    monkeypatch.setattr(
+        "vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine.get_version",
+        lambda _: "0.3.12",
+    )
+
+    manager.register_buffer([100, 200], [10, 20], ["*", "npu:0"])
+
+    assert engine.register_memory.call_args_list == [call(100, 10, "*"), call(200, 20, "npu:0")]
+
+
+@pytest.mark.parametrize("mooncake_version", ["0.3.11", "0.3.11.post1"])
+def test_register_buffer_rejects_locations_on_old_mooncake(mooncake_version, monkeypatch):
+    engine = MagicMock()
+    manager = _manager_with_engine(engine)
+    monkeypatch.setattr(
+        "vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine.get_version",
+        lambda _: mooncake_version,
+    )
+
+    with pytest.raises(RuntimeError, match="does not support register_memory locations"):
+        manager.register_buffer([100], [10], ["npu:0"])
+
+    engine.register_memory.assert_not_called()
+
+
+def test_register_buffer_only_registers_once():
+    engine = MagicMock()
+    engine.register_memory.return_value = 0
+    manager = _manager_with_engine(engine)
+
+    manager.register_buffer([100], [10])
+    manager.register_buffer([200], [20])
+
+    engine.register_memory.assert_called_once_with(100, 10)
+
+
+def test_register_buffer_raises_when_registration_fails():
+    engine = MagicMock()
+    engine.register_memory.return_value = 7
+    manager = _manager_with_engine(engine)
+
+    with pytest.raises(RuntimeError, match="Mooncake memory registration failed"):
+        manager.register_buffer([100], [10])
+
+    assert not manager.is_register_buffer
+
+
+def test_unregister_buffer_reverses_registration_and_allows_reregistration():
+    engine = MagicMock()
+    engine.register_memory.return_value = 0
+    engine.unregister_memory.return_value = 0
+    manager = _manager_with_engine(engine)
+
+    manager.register_buffer([100, 200], [10, 20])
+    manager.unregister_buffer()
+    manager.unregister_buffer()
+
+    assert engine.unregister_memory.call_args_list == [call(200), call(100)]
+    assert manager._registered_regions == []
+    assert not manager.is_register_buffer
+
+    manager.register_buffer([300], [30])
+    assert engine.register_memory.call_args_list[-1] == call(300, 30)
+
+
+def test_unregister_buffer_retains_failed_regions_for_retry():
+    engine = MagicMock()
+    engine.register_memory.return_value = 0
+    engine.unregister_memory.side_effect = [9, 0, 0]
+    manager = _manager_with_engine(engine)
+    manager.register_buffer([100, 200], [10, 20])
+
+    with pytest.raises(RuntimeError, match="ptr=200: ret_value=9"):
+        manager.unregister_buffer()
+
+    assert manager._registered_regions == [(200, 20, "*")]
+    assert manager.is_register_buffer
+
+    manager.unregister_buffer()
+    assert engine.unregister_memory.call_args_list == [call(200), call(100), call(200)]
+    assert not manager.is_register_buffer

--- a/tests/ut/distributed/kv_transfer/test_mooncake_transfer_engine.py
+++ b/tests/ut/distributed/kv_transfer/test_mooncake_transfer_engine.py
@@ -15,44 +15,23 @@ def _manager_with_engine(engine: object) -> GlobalTE:
     return manager
 
 
-def test_register_buffer_uses_two_arguments_without_locations():
+def test_register_buffer_uses_wildcard_location_by_default():
     engine = MagicMock()
     engine.register_memory.return_value = 0
     manager = _manager_with_engine(engine)
 
     manager.register_buffer([100, 200], [10, 20])
 
-    assert engine.register_memory.call_args_list == [call(100, 10), call(200, 20)]
+    assert engine.register_memory.call_args_list == [call(100, 10, "*"), call(200, 20, "*")]
 
 
-def test_register_buffer_uses_three_arguments_with_locations(monkeypatch):
+def test_register_buffer_uses_explicit_locations():
     engine = MagicMock()
     engine.register_memory.return_value = 0
     manager = _manager_with_engine(engine)
-    monkeypatch.setattr(
-        "vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine.get_version",
-        lambda _: "0.3.12",
-    )
-
     manager.register_buffer([100, 200], [10, 20], ["*", "npu:0"])
 
     assert engine.register_memory.call_args_list == [call(100, 10, "*"), call(200, 20, "npu:0")]
-
-
-@pytest.mark.parametrize("mooncake_version", ["0.3.11", "0.3.11.post1"])
-def test_register_buffer_rejects_locations_on_old_mooncake(mooncake_version, monkeypatch):
-    engine = MagicMock()
-    manager = _manager_with_engine(engine)
-    monkeypatch.setattr(
-        "vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine.get_version",
-        lambda _: mooncake_version,
-    )
-
-    with pytest.raises(RuntimeError, match="does not support register_memory locations"):
-        manager.register_buffer([100], [10], ["npu:0"])
-
-    engine.register_memory.assert_not_called()
-
 
 def test_register_buffer_only_registers_once():
     engine = MagicMock()
@@ -62,7 +41,7 @@ def test_register_buffer_only_registers_once():
     manager.register_buffer([100], [10])
     manager.register_buffer([200], [20])
 
-    engine.register_memory.assert_called_once_with(100, 10)
+    engine.register_memory.assert_called_once_with(100, 10, "*")
 
 
 def test_register_buffer_raises_when_registration_fails():
@@ -91,7 +70,7 @@ def test_unregister_buffer_reverses_registration_and_allows_reregistration():
     assert not manager.is_register_buffer
 
     manager.register_buffer([300], [30])
-    assert engine.register_memory.call_args_list[-1] == call(300, 30)
+    assert engine.register_memory.call_args_list[-1] == call(300, 30, "*")
 
 
 def test_unregister_buffer_retains_failed_regions_for_retry():

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -292,6 +292,9 @@ class TestKVCacheSendingThread(unittest.TestCase):
 
         sock.close()
         context.term()
+        thread.stop()
+        thread.join(timeout=3)
+        self.assertFalse(thread.is_alive())
 
     def test_reformat_kv_cache_hybrid_linear_uses_cache_block_size(self):
         block_size = 4

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -3438,6 +3438,12 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
                                 remote_multi_nodes_meta_mapping={},
                             )
 
+                            if case["prefill_pp_size"] > 1:
+                                # This synthetic PCP+PP case bypasses startup validation.
+                                # It must not pass merely because stage 0's block counts match.
+                                with self.assertRaisesRegex(AssertionError, "KV source coverage incomplete"):
+                                    worker._get_kv_split_metadata("req_pd", meta)
+                                continue
                             ports, local_ids, remote_ids = worker._get_kv_split_metadata("req_pd", meta)
                             group_pulls = worker._get_group_pulls_metadata(
                                 "req_pd",

--- a/tests/ut/kv_offload/test_mooncake_dsa_metadata.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_metadata.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p import (
+    mooncake_dsa_metadata as dsa,
+)
+
+
+def _endpoint(rank: int = 0) -> dsa.RemoteEndpoint:
+    return dsa.RemoteEndpoint(
+        remote_host=f"10.0.0.{rank + 1}",
+        remote_port=9000 + rank,
+        remote_engine_id=f"prefill-{rank}",
+    )
+
+
+def _source() -> dsa.RemoteSource:
+    return dsa.RemoteSource(
+        remote_request_id="prefill-request",
+        endpoints_by_prefill_rank=(_endpoint(0), _endpoint(1)),
+        indexer_block_ids=(2, 3),
+        main_block_ids=(4, 5),
+    )
+
+
+def _request(request_id: str = "decode-request") -> dsa.DsaStepRequest:
+    return dsa.DsaStepRequest(
+        request_id=request_id,
+        source=_source(),
+        main_host_block_ids=(10, 11),
+        indexer_hbm_block_ids=(20, 21),
+    )
+
+
+def test_remote_endpoint_validates_port() -> None:
+    with pytest.raises(ValueError, match="1..65535"):
+        dsa.RemoteEndpoint("127.0.0.1", 0, "engine")
+
+
+def test_remote_source_normalizes_block_ids() -> None:
+    source = dsa.RemoteSource(
+        "prefill-request",
+        [_endpoint()],
+        [1, 2],
+        [3, 4],
+    )
+    assert source.endpoints_by_prefill_rank == (_endpoint(),)
+    assert source.indexer_block_ids == (1, 2)
+    assert source.main_block_ids == (3, 4)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("indexer_block_ids", "main_block_ids"),
+)
+def test_remote_source_rejects_empty_block_ids(field: str) -> None:
+    kwargs = {
+        "remote_request_id": "prefill-request",
+        "endpoints_by_prefill_rank": (_endpoint(),),
+        "indexer_block_ids": (1,),
+        "main_block_ids": (2,),
+    }
+    kwargs[field] = ()
+    with pytest.raises(ValueError, match="must not be empty"):
+        dsa.RemoteSource(**kwargs)
+
+
+def test_step_request_owns_only_one_shot_destinations() -> None:
+    request = _request()
+    assert request.main_host_block_ids == (10, 11)
+    assert request.indexer_hbm_block_ids == (20, 21)
+    assert not hasattr(request, "lifecycle")
+    assert not hasattr(request, "main_reservation_id")
+
+
+def test_connector_metadata_sorts_requests() -> None:
+    metadata = dsa.DsaConnectorMetadata(
+        (_request("request-b"), _request("request-a"))
+    )
+    assert tuple(item.request_id for item in metadata.requests) == (
+        "request-a",
+        "request-b",
+    )
+
+
+def test_connector_metadata_rejects_conflicting_request() -> None:
+    first = _request()
+    second = dsa.DsaStepRequest(
+        request_id=first.request_id,
+        source=first.source,
+        main_host_block_ids=(12,),
+        indexer_hbm_block_ids=(22,),
+    )
+    with pytest.raises(ValueError, match="conflicting"):
+        dsa.DsaConnectorMetadata((first, second))
+
+
+def test_transfer_failure_requires_phase() -> None:
+    with pytest.raises(ValueError, match="requires a failure phase"):
+        dsa.DsaLocalResult(
+            request_id="request",
+            tp_rank=0,
+            kind=dsa.DsaLocalResultKind.TRANSFER_FAILED,
+        )
+
+
+def test_worker_metadata_aggregates_tp_results() -> None:
+    left = dsa.DsaWorkerResultMetadata(
+        (
+            dsa.DsaLocalResult(
+                "request",
+                0,
+                dsa.DsaLocalResultKind.RECEIVE_COMPLETE,
+            ),
+        )
+    )
+    right = dsa.DsaWorkerResultMetadata(
+        (
+            dsa.DsaLocalResult(
+                "request",
+                1,
+                dsa.DsaLocalResultKind.RECEIVE_COMPLETE,
+            ),
+        )
+    )
+    merged = left.aggregate(right)
+    assert tuple(result.tp_rank for result in merged.results) == (0, 1)
+
+
+def test_worker_metadata_rejects_conflicting_result() -> None:
+    success = dsa.DsaWorkerResultMetadata(
+        (
+            dsa.DsaLocalResult(
+                "request",
+                0,
+                dsa.DsaLocalResultKind.RECEIVE_COMPLETE,
+            ),
+        )
+    )
+    failure = dsa.DsaWorkerResultMetadata(
+        (
+            dsa.DsaLocalResult(
+                "request",
+                0,
+                dsa.DsaLocalResultKind.TRANSFER_FAILED,
+                dsa.DsaTransferPhase.INDEXER_D2D,
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="conflicting"):
+        success.aggregate(failure)

--- a/tests/ut/kv_offload/test_mooncake_dsa_metadata.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_metadata.py
@@ -54,7 +54,7 @@ def test_remote_source_normalizes_block_ids() -> None:
     "field",
     ("indexer_block_ids", "main_block_ids"),
 )
-def test_remote_source_rejects_empty_block_ids(field: str) -> None:
+def test_remote_source_preserves_empty_block_ids(field: str) -> None:
     kwargs = {
         "remote_request_id": "prefill-request",
         "endpoints_by_prefill_rank": (_endpoint(),),
@@ -62,8 +62,7 @@ def test_remote_source_rejects_empty_block_ids(field: str) -> None:
         "main_block_ids": (2,),
     }
     kwargs[field] = ()
-    with pytest.raises(ValueError, match="must not be empty"):
-        dsa.RemoteSource(**kwargs)
+    assert getattr(dsa.RemoteSource(**kwargs), field) == ()
 
 
 def test_step_request_owns_only_one_shot_destinations() -> None:
@@ -75,9 +74,7 @@ def test_step_request_owns_only_one_shot_destinations() -> None:
 
 
 def test_connector_metadata_sorts_requests() -> None:
-    metadata = dsa.DsaConnectorMetadata(
-        (_request("request-b"), _request("request-a"))
-    )
+    metadata = dsa.DsaConnectorMetadata((_request("request-b"), _request("request-a")))
     assert tuple(item.request_id for item in metadata.requests) == (
         "request-a",
         "request-b",

--- a/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
+    _MooncakeDsaDecodeScheduler,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_metadata import (
+    DsaLocalResult,
+    DsaLocalResultKind,
+    DsaTransferPhase,
+    DsaWorkerResultMetadata,
+)
+
+
+def _scheduler():
+    scheduler = object.__new__(_MooncakeDsaDecodeScheduler)
+    scheduler._main_block_size = 2
+    scheduler.main_group_idx = 1
+    scheduler.indexer_group_idx = 0
+    scheduler._dsa_requests = {}
+    scheduler._dsa_prefill_tp_size = 2
+    scheduler._expected_tp_ranks = frozenset((0, 1))
+    return scheduler
+
+
+def _request():
+    return SimpleNamespace(
+        request_id="request",
+        prompt_token_ids=[1, 2, 3, 4],
+        num_computed_tokens=0,
+        kv_transfer_params={
+            "do_remote_prefill": True,
+            "remote_request_id": "remote",
+            "remote_block_ids": ((10, 11), (20, 21)),
+            "remote_host": "127.0.0.1",
+            "remote_port": 5000,
+            "remote_engine_id": "prefill",
+            "remote_multi_nodes_meta_mapping": {},
+        },
+    )
+
+
+def test_dsa_scheduler_emits_once_and_waits_for_all_tp_results():
+    scheduler = _scheduler()
+    request = _request()
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (4, True)
+    blocks = SimpleNamespace(
+        get_block_ids=lambda: ([30, 31], [40, 41])
+    )
+    scheduler.update_state_after_alloc(request, blocks, 4)
+
+    metadata = scheduler.build_connector_meta(None)
+    assert len(metadata.requests) == 1
+    assert scheduler.build_connector_meta(None).requests == ()
+    command = metadata.requests[0]
+    assert command.source.indexer_block_ids == (10, 11)
+    assert command.source.main_block_ids == (20, 21)
+    assert command.indexer_hbm_block_ids == (30, 31)
+    assert command.main_host_block_ids == (40, 41)
+
+    output = SimpleNamespace(
+        kv_connector_worker_meta=DsaWorkerResultMetadata(
+            (
+                DsaLocalResult(
+                    "request",
+                    0,
+                    DsaLocalResultKind.RECEIVE_COMPLETE,
+                ),
+            )
+        ),
+        finished_recving=set(),
+    )
+    scheduler.update_connector_output(output)
+    assert output.finished_recving == set()
+
+    output.kv_connector_worker_meta = DsaWorkerResultMetadata(
+        (
+            DsaLocalResult(
+                "request",
+                1,
+                DsaLocalResultKind.RECEIVE_COMPLETE,
+            ),
+        )
+    )
+    scheduler.update_connector_output(output)
+    assert output.finished_recving == {"request"}
+    assert "request" not in scheduler._dsa_requests
+
+
+def test_dsa_scheduler_failure_requests_local_recompute():
+    scheduler = _scheduler()
+    request = _request()
+    scheduler.get_num_new_matched_tokens(request, 0)
+    scheduler.update_state_after_alloc(
+        request,
+        SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41])),
+        4,
+    )
+    output = SimpleNamespace(
+        kv_connector_worker_meta=DsaWorkerResultMetadata(
+            (
+                DsaLocalResult(
+                    "request",
+                    0,
+                    DsaLocalResultKind.TRANSFER_FAILED,
+                    DsaTransferPhase.INDEXER_D2D,
+                ),
+                DsaLocalResult(
+                    "request",
+                    1,
+                    DsaLocalResultKind.RECEIVE_COMPLETE,
+                ),
+            )
+        ),
+        finished_recving=set(),
+    )
+    scheduler.update_connector_output(output)
+    assert request.num_computed_tokens == 0
+    assert output.finished_recving == {"request"}

--- a/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
@@ -26,6 +26,18 @@ def _scheduler():
     return scheduler
 
 
+def _blocks(group0, group1, unhashed_group0=None):
+    if unhashed_group0 is None:
+        unhashed_group0 = group0
+    return SimpleNamespace(
+        get_block_ids=lambda: (group0, group1),
+        get_unhashed_block_ids_all_groups=lambda: (
+            unhashed_group0,
+            group1,
+        ),
+    )
+
+
 def _request():
     return SimpleNamespace(
         request_id="request",
@@ -46,36 +58,46 @@ def _request():
 
 
 @pytest.mark.parametrize("group0_block_size,prefix_tokens", [(2, 2), (1, 2)])
-def test_failure_reporting_asserts_before_emitting_cached_prefix(group0_block_size, prefix_tokens):
+def test_failure_reporting_excludes_untouched_cached_prefix(
+    group0_block_size, prefix_tokens
+):
     scheduler = _scheduler()
     scheduler.block_size[0] = group0_block_size
     request = _request()
     external_tokens, _ = scheduler.get_num_new_matched_tokens(request, prefix_tokens)
     group0_ids = list(range(30, 30 + 4 // group0_block_size))
-    blocks = SimpleNamespace(get_block_ids=lambda: (group0_ids, [40, 41]))
-    with pytest.raises(AssertionError, match="failure-reporting range includes untouched prefix") as error:
-        scheduler.update_state_after_alloc(request, blocks, external_tokens)
-    assert "request=request" in str(error.value)
-    assert "read_tokens=[2, 4)" in str(error.value)
-    assert f"untouched_prefix_block_ids={group0_ids[: prefix_tokens // group0_block_size]}" in str(error.value)
-    assert scheduler.build_connector_meta(None).requests == ()
+    blocks = _blocks(
+        group0_ids,
+        [40, 41],
+        group0_ids[prefix_tokens // group0_block_size :],
+    )
+    scheduler.update_state_after_alloc(request, blocks, external_tokens)
+    (command,) = scheduler.build_connector_meta(None).requests
+    first_transferred_block = prefix_tokens // group0_block_size
+    assert command.invalid_block_ids == tuple(group0_ids[first_transferred_block:])
 
 
 @pytest.mark.parametrize(
-    "group0_block_size,prefix_tokens,external_tokens", [(2, 0, 4), (2, 1, 3), (4, 2, 2), (2, 4, 0)]
+    "group0_block_size,prefix_tokens,external_tokens,expected_invalid_ids",
+    [
+        (2, 0, 4, (30, 31)),
+        (2, 1, 3, (30, 31)),
+        (4, 2, 2, (30,)),
+        (2, 4, 0, ()),
+    ],
 )
-def test_failure_reporting_allows_overlapping_block_and_notification_only(
-    group0_block_size, prefix_tokens, external_tokens
+def test_failure_reporting_includes_overlapping_block_and_handles_notification_only(
+    group0_block_size, prefix_tokens, external_tokens, expected_invalid_ids
 ):
     scheduler = _scheduler()
     scheduler.block_size[0] = group0_block_size
     request = _request()
     scheduler.get_num_new_matched_tokens(request, prefix_tokens)
     group0_ids = list(range(30, 30 + 4 // group0_block_size))
-    blocks = SimpleNamespace(get_block_ids=lambda: (group0_ids, [40, 41]))
+    blocks = _blocks(group0_ids, [40, 41], expected_invalid_ids)
     scheduler.update_state_after_alloc(request, blocks, external_tokens)
     (command,) = scheduler.build_connector_meta(None).requests
-    assert command.invalid_block_ids == tuple(group0_ids)
+    assert command.invalid_block_ids == expected_invalid_ids
     assert command.notify_only == (external_tokens == 0)
 
 
@@ -83,7 +105,7 @@ def test_dsa_scheduler_emits_once_and_waits_for_all_tp_results():
     scheduler = _scheduler()
     request = _request()
     assert scheduler.get_num_new_matched_tokens(request, 0) == (4, True)
-    blocks = SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41]))
+    blocks = _blocks([30, 31], [40, 41])
     scheduler.update_state_after_alloc(request, blocks, 4)
 
     metadata = scheduler.build_connector_meta(None)
@@ -130,7 +152,7 @@ def test_dsa_scheduler_failure_never_requests_local_recompute():
     scheduler.get_num_new_matched_tokens(request, 0)
     scheduler.update_state_after_alloc(
         request,
-        SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41])),
+        _blocks([30, 31], [40, 41]),
         4,
     )
     output = SimpleNamespace(
@@ -161,7 +183,7 @@ def test_empty_external_receive_only_notifies_prefill():
     scheduler = _scheduler()
     request = _request()
     assert scheduler.get_num_new_matched_tokens(request, 4) == (0, False)
-    scheduler.update_state_after_alloc(request, SimpleNamespace(get_block_ids=lambda: ([], [])), 0)
+    scheduler.update_state_after_alloc(request, _blocks([], []), 0)
     (command,) = scheduler.build_connector_meta(None).requests
     assert command.notify_only
     assert command.main_host_block_ids == ()
@@ -181,7 +203,7 @@ def test_cancel_keeps_delayed_free_until_rank_results():
     scheduler = _scheduler()
     request = _request()
     scheduler.get_num_new_matched_tokens(request, 0)
-    scheduler.update_state_after_alloc(request, SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41])), 4)
+    scheduler.update_state_after_alloc(request, _blocks([30, 31], [40, 41]), 4)
     scheduler.build_connector_meta(None)
     assert scheduler.request_finished(request, ()) == (True, None)
     assert scheduler.build_connector_meta(None).cancelled_requests == ("request",)

--- a/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_scheduler.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from types import SimpleNamespace
 
+import pytest
+
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
     _MooncakeDsaDecodeScheduler,
 )
@@ -15,6 +17,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_metadata import (
 def _scheduler():
     scheduler = object.__new__(_MooncakeDsaDecodeScheduler)
     scheduler._main_block_size = 2
+    scheduler.block_size = [2, 2]
     scheduler.main_group_idx = 1
     scheduler.indexer_group_idx = 0
     scheduler._dsa_requests = {}
@@ -31,6 +34,8 @@ def _request():
         kv_transfer_params={
             "do_remote_prefill": True,
             "remote_request_id": "remote",
+            "dsa_main_group_id": 1,
+            "dsa_indexer_group_id": 0,
             "remote_block_ids": ((10, 11), (20, 21)),
             "remote_host": "127.0.0.1",
             "remote_port": 5000,
@@ -40,13 +45,45 @@ def _request():
     )
 
 
+@pytest.mark.parametrize("group0_block_size,prefix_tokens", [(2, 2), (1, 2)])
+def test_failure_reporting_asserts_before_emitting_cached_prefix(group0_block_size, prefix_tokens):
+    scheduler = _scheduler()
+    scheduler.block_size[0] = group0_block_size
+    request = _request()
+    external_tokens, _ = scheduler.get_num_new_matched_tokens(request, prefix_tokens)
+    group0_ids = list(range(30, 30 + 4 // group0_block_size))
+    blocks = SimpleNamespace(get_block_ids=lambda: (group0_ids, [40, 41]))
+    with pytest.raises(AssertionError, match="failure-reporting range includes untouched prefix") as error:
+        scheduler.update_state_after_alloc(request, blocks, external_tokens)
+    assert "request=request" in str(error.value)
+    assert "read_tokens=[2, 4)" in str(error.value)
+    assert f"untouched_prefix_block_ids={group0_ids[: prefix_tokens // group0_block_size]}" in str(error.value)
+    assert scheduler.build_connector_meta(None).requests == ()
+
+
+@pytest.mark.parametrize(
+    "group0_block_size,prefix_tokens,external_tokens", [(2, 0, 4), (2, 1, 3), (4, 2, 2), (2, 4, 0)]
+)
+def test_failure_reporting_allows_overlapping_block_and_notification_only(
+    group0_block_size, prefix_tokens, external_tokens
+):
+    scheduler = _scheduler()
+    scheduler.block_size[0] = group0_block_size
+    request = _request()
+    scheduler.get_num_new_matched_tokens(request, prefix_tokens)
+    group0_ids = list(range(30, 30 + 4 // group0_block_size))
+    blocks = SimpleNamespace(get_block_ids=lambda: (group0_ids, [40, 41]))
+    scheduler.update_state_after_alloc(request, blocks, external_tokens)
+    (command,) = scheduler.build_connector_meta(None).requests
+    assert command.invalid_block_ids == tuple(group0_ids)
+    assert command.notify_only == (external_tokens == 0)
+
+
 def test_dsa_scheduler_emits_once_and_waits_for_all_tp_results():
     scheduler = _scheduler()
     request = _request()
     assert scheduler.get_num_new_matched_tokens(request, 0) == (4, True)
-    blocks = SimpleNamespace(
-        get_block_ids=lambda: ([30, 31], [40, 41])
-    )
+    blocks = SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41]))
     scheduler.update_state_after_alloc(request, blocks, 4)
 
     metadata = scheduler.build_connector_meta(None)
@@ -87,7 +124,7 @@ def test_dsa_scheduler_emits_once_and_waits_for_all_tp_results():
     assert "request" not in scheduler._dsa_requests
 
 
-def test_dsa_scheduler_failure_requests_local_recompute():
+def test_dsa_scheduler_failure_never_requests_local_recompute():
     scheduler = _scheduler()
     request = _request()
     scheduler.get_num_new_matched_tokens(request, 0)
@@ -114,6 +151,48 @@ def test_dsa_scheduler_failure_requests_local_recompute():
         ),
         finished_recving=set(),
     )
+    request.num_computed_tokens = 3
     scheduler.update_connector_output(output)
-    assert request.num_computed_tokens == 0
+    assert request.num_computed_tokens == 3
     assert output.finished_recving == {"request"}
+
+
+def test_empty_external_receive_only_notifies_prefill():
+    scheduler = _scheduler()
+    request = _request()
+    assert scheduler.get_num_new_matched_tokens(request, 4) == (0, False)
+    scheduler.update_state_after_alloc(request, SimpleNamespace(get_block_ids=lambda: ([], [])), 0)
+    (command,) = scheduler.build_connector_meta(None).requests
+    assert command.notify_only
+    assert command.main_host_block_ids == ()
+    assert "request" not in scheduler._dsa_requests
+
+
+def test_rejection_before_allocation_retains_notification():
+    scheduler = _scheduler()
+    request = _request()
+    assert scheduler.request_finished(request, ()) == (False, None)
+    (command,) = scheduler.build_connector_meta(None).requests
+    assert command.notify_only
+    assert not request.kv_transfer_params["do_remote_prefill"]
+
+
+def test_cancel_keeps_delayed_free_until_rank_results():
+    scheduler = _scheduler()
+    request = _request()
+    scheduler.get_num_new_matched_tokens(request, 0)
+    scheduler.update_state_after_alloc(request, SimpleNamespace(get_block_ids=lambda: ([30, 31], [40, 41])), 4)
+    scheduler.build_connector_meta(None)
+    assert scheduler.request_finished(request, ()) == (True, None)
+    assert scheduler.build_connector_meta(None).cancelled_requests == ("request",)
+    assert "request" in scheduler._dsa_requests
+
+
+def test_source_group_order_is_independent_of_local_groups():
+    scheduler = _scheduler()
+    request = _request()
+    request.kv_transfer_params.update(dsa_main_group_id=0, dsa_indexer_group_id=1)
+    scheduler.get_num_new_matched_tokens(request, 0)
+    source = scheduler._dsa_requests["request"].source
+    assert source.main_block_ids == (10, 11)
+    assert source.indexer_block_ids == (20, 21)

--- a/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p import (
+    mooncake_connector,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
+    KVCacheRecvingThread,
+    MooncakeConnectorWorker,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_metadata import (
+    DsaLocalResultKind,
+    DsaStepRequest,
+    DsaTransferPhase,
+    RemoteEndpoint,
+    RemoteSource,
+)
+
+
+@pytest.mark.parametrize("main_owner", [True, False])
+def test_blockwise_receive_writes_shared_main_only_on_owner(main_owner):
+    thread = object.__new__(KVCacheRecvingThread)
+    thread.tp_rank = 0
+    thread._dsa_main_owner = main_owner
+    thread._dsa_indexer_local_layout = [[(0, 100, 8, 8, 1)]]
+    thread._dsa_main_local_layout = [[(0, 200, 8, 8, 1)]] if main_owner else [[]]
+    thread.remote_metadata_lock = MagicMock()
+    thread.kv_caches_base_addr = {"prefill": {5000: [[1000]]}}
+    thread.remote_metadata_hosts = {"prefill": {5000: "10.0.0.1"}}
+    thread.remote_block_stride_per_addr = {"prefill": {5000: [[8]]}}
+    thread.remote_block_size_scale = {"prefill": {5000: [[1]]}}
+    thread.remote_block_len_per_addr = {"prefill": {5000: [[8]]}}
+    thread.remote_te_port = {"prefill": {5000: 6000}}
+    thread._get_remote_metadata = MagicMock()
+    thread._send_done_recv_signal = MagicMock()
+    thread._log_dsa_transfer_phase_diag = MagicMock()
+
+    calls = []
+    thread.engine = SimpleNamespace(
+        batch_transfer_sync_read=lambda session, *lists: calls.append(
+            (session, lists)
+        )
+        or 0
+    )
+    thread._build_dsa_transfer_lists = MagicMock(
+        side_effect=[([1], [11], [8]), ([2], [12], [8])]
+        if main_owner
+        else [([1], [11], [8])]
+    )
+
+    endpoint = RemoteEndpoint("10.0.0.1", 5000, "prefill")
+    command = DsaStepRequest(
+        request_id="req",
+        source=RemoteSource("remote-req", (endpoint,), (1,), (2,)),
+        main_host_block_ids=(12,),
+        indexer_hbm_block_ids=(11,),
+    )
+    results = []
+
+    thread._execute_dsa_receive(command, endpoint, results.append)
+
+    assert len(calls) == (2 if main_owner else 1)
+    assert results[0].kind is DsaLocalResultKind.RECEIVE_COMPLETE
+    thread._send_done_recv_signal.assert_called_once()
+
+
+def _dsa_receive_fixture():
+    thread = object.__new__(KVCacheRecvingThread)
+    thread.tp_rank = 0
+    thread._dsa_main_owner = True
+    thread._dsa_indexer_local_layout = [[(0, 100, 8, 8, 1)]]
+    thread._dsa_main_local_layout = [[(0, 200, 8, 8, 1)]]
+    thread.remote_metadata_lock = MagicMock()
+    thread.kv_caches_base_addr = {"prefill": {5000: [[1000]]}}
+    thread.remote_metadata_hosts = {"prefill": {5000: "10.0.0.1"}}
+    thread.remote_block_stride_per_addr = {"prefill": {5000: [[8]]}}
+    thread.remote_block_size_scale = {"prefill": {5000: [[1]]}}
+    thread.remote_block_len_per_addr = {"prefill": {5000: [[8]]}}
+    thread.remote_te_port = {"prefill": {5000: 6000}}
+    thread._get_remote_metadata = MagicMock()
+    thread._send_done_recv_signal = MagicMock()
+    thread._build_dsa_transfer_lists = MagicMock(
+        return_value=([1], [11], [8])
+    )
+    endpoint = RemoteEndpoint("10.0.0.1", 5000, "prefill")
+    command = DsaStepRequest(
+        request_id="req",
+        source=RemoteSource("remote-req", (endpoint,), (1,), (2,)),
+        main_host_block_ids=(12,),
+        indexer_hbm_block_ids=(11,),
+    )
+    return thread, command, endpoint
+
+
+def test_blockwise_receive_exception_returns_terminal_failure():
+    thread, command, endpoint = _dsa_receive_fixture()
+    thread.engine = SimpleNamespace(
+        batch_transfer_sync_read=MagicMock(
+            side_effect=RuntimeError("transfer failed")
+        )
+    )
+    results = []
+
+    thread._execute_dsa_receive(command, endpoint, results.append)
+
+    assert len(results) == 1
+    assert results[0].kind is DsaLocalResultKind.TRANSFER_FAILED
+    assert results[0].failure_phase is DsaTransferPhase.INDEXER_D2D
+    thread._send_done_recv_signal.assert_called_once()
+
+
+def test_done_signal_exception_does_not_override_receive_success():
+    thread, command, endpoint = _dsa_receive_fixture()
+    thread.engine = SimpleNamespace(
+        batch_transfer_sync_read=MagicMock(return_value=0)
+    )
+    thread._send_done_recv_signal.side_effect = ValueError(
+        "done signal failed"
+    )
+    results = []
+
+    thread._execute_dsa_receive(command, endpoint, results.append)
+
+    assert len(results) == 1
+    assert results[0].kind is DsaLocalResultKind.RECEIVE_COMPLETE
+    assert results[0].failure_phase is None
+
+
+@pytest.mark.parametrize("main_owner", [True, False])
+def test_local_layout_uses_shared_pool_only_on_owner(
+    main_owner, monkeypatch
+):
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker.num_blocks = 4
+    worker.kv_caches_base_addr = [[], []]
+    worker.engine = MagicMock()
+    host_k = torch.empty((4, 1, 2), dtype=torch.bfloat16)
+    host_v = torch.empty((4, 1, 2), dtype=torch.bfloat16)
+    pool = SimpleNamespace(
+        is_owner=main_owner,
+        register=MagicMock(),
+    )
+    manager = SimpleNamespace(
+        offload_layer_names=["model.layers.0.self_attn.attn"],
+        get_mooncake_host_pool=lambda: pool,
+        get_fused_overlap_cpu_kv_inputs=lambda _name: (
+            host_k,
+            host_v,
+        ),
+    )
+    monkeypatch.setattr(
+        mooncake_connector,
+        "get_sparse_kv_offload_manager",
+        lambda: manager,
+    )
+    indexer = torch.empty((8, 1, 2), dtype=torch.int8)
+    kv_caches = {"model.layers.0.indexer.k_cache": (indexer,)}
+    layer_name_to_idx = {
+        "model.layers.0.self_attn.attn": 0,
+        "model.layers.0.indexer.k_cache": 1,
+    }
+
+    indexer_layout, main_layout, is_owner = (
+        worker._build_dsa_local_layouts(
+            kv_caches, layer_name_to_idx
+        )
+    )
+
+    assert len(indexer_layout[1]) == 1
+    assert indexer_layout[1][0][0] == 0
+    assert is_owner is main_owner
+    if main_owner:
+        assert [entry[0] for entry in main_layout[0]] == [0, 1]
+        pool.register.assert_called_once_with(worker.engine)
+    else:
+        assert not any(main_layout)
+        pool.register.assert_not_called()

--- a/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
@@ -1,181 +1,393 @@
 # SPDX-License-Identifier: Apache-2.0
+import queue
+import threading
+from collections import defaultdict
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
-from vllm_ascend.distributed.kv_transfer.kv_p2p import (
-    mooncake_connector,
-)
+from vllm_ascend.distributed.kv_transfer.kv_p2p import mooncake_connector
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (
     KVCacheRecvingThread,
+    KVCacheTaskTracker,
     MooncakeConnectorWorker,
 )
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_metadata import (
     DsaLocalResultKind,
     DsaStepRequest,
-    DsaTransferPhase,
     RemoteEndpoint,
     RemoteSource,
 )
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_transfer import DsaCacheLayout
+
+MAIN = "model.layers.0.self_attn.attn"
+INDEXER = "model.layers.0.indexer.attn.index_cache"
 
 
-@pytest.mark.parametrize("main_owner", [True, False])
-def test_blockwise_receive_writes_shared_main_only_on_owner(main_owner):
+def make_worker(rank=0, ptp=8, dcp=8, dtp=4):
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker.tp_rank, worker.tp_size = rank, dtp
+    worker._prefill_tp_size, worker._decode_tp_size = ptp, dtp
+    worker._prefill_pp_size = 1
+    worker.use_mla = worker.use_sparse = True
+    worker.pcp_size = worker.dcp_size = 1
+    worker.num_key_value_heads = 1
+    worker.tp_num_need_pulls = 1
+    worker.side_channel_port = 6000
+    worker.handshake_port = 6000 + rank
+    worker.engine_id = "decode"
+    worker._dsa_decode = True
+    worker._dsa_active_commands = {}
+    worker._dsa_cancel_events = {}
+    worker._dsa_results = queue.SimpleQueue()
+    worker.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(is_deepseek_mla=True),
+        parallel_config=SimpleNamespace(tensor_parallel_size=dtp),
+        kv_transfer_config=SimpleNamespace(kv_port=5000),
+    )
     thread = object.__new__(KVCacheRecvingThread)
-    thread.tp_rank = 0
-    thread._dsa_main_owner = main_owner
-    thread._dsa_indexer_local_layout = [[(0, 100, 8, 8, 1)]]
-    thread._dsa_main_local_layout = [[(0, 200, 8, 8, 1)]] if main_owner else [[]]
-    thread.remote_metadata_lock = MagicMock()
-    thread.kv_caches_base_addr = {"prefill": {5000: [[1000]]}}
-    thread.remote_metadata_hosts = {"prefill": {5000: "10.0.0.1"}}
-    thread.remote_block_stride_per_addr = {"prefill": {5000: [[8]]}}
-    thread.remote_block_size_scale = {"prefill": {5000: [[1]]}}
-    thread.remote_block_len_per_addr = {"prefill": {5000: [[8]]}}
-    thread.remote_te_port = {"prefill": {5000: 6000}}
-    thread._get_remote_metadata = MagicMock()
+    worker.kv_recv_thread = thread
+    thread.tp_rank = rank
+    thread.vllm_config = worker.vllm_config
+    thread._prefill_pp_size = 1
+    thread.pp_layer_indices = {0: (0, 1)}
+    thread.num_draft_layers = 0
+    thread.index_cache_plane_base = 1
+    thread._dsa_transformer_layers = {MAIN: 0, INDEXER: 0}
+    thread.request_queue = queue.Queue()
+    thread.request_task_counts = defaultdict(int)
+    thread.finished_request_markers = set()
+    thread.request_task_counts_lock = threading.Lock()
+    thread.failed_recv_requests = set()
+    thread.dsa_failure_phases = {}
+    thread.failed_recv_requests_lock = threading.Lock()
+    thread.invalid_block_ids = set()
+    thread.remote_metadata_lock = threading.Lock()
+    groups = {0: ({"layer_names": [MAIN]}, [0]), 1: ({"layer_names": [INDEXER]}, [1])}
+    thread.kv_group2layeridx = groups
+    thread.remote_metadata_hosts = {"prefill": {5000 + p: "127.0.0.1" for p in range(ptp)}}
+    thread.remote_kv_group2layeridx = {"prefill": {5000 + p: groups for p in range(ptp)}}
+    thread.kv_caches_base_addr = {"prefill": {5000 + p: [[10000, 20000], [30000]] for p in range(ptp)}}
+    thread.remote_block_stride_per_addr = {"prefill": {5000 + p: [[8, 8], [8]] for p in range(ptp)}}
+    thread.remote_block_size_scale = {"prefill": {5000 + p: [[1, 1], [dcp]] for p in range(ptp)}}
+    thread.remote_block_len_per_addr = {"prefill": {5000 + p: [[8, 8], [8]] for p in range(ptp)}}
+    thread.remote_cache_dtypes = {"prefill": {5000 + p: [["bf16", "bf16"], ["bf16"]] for p in range(ptp)}}
+    thread.remote_num_blocks = {"prefill": {5000 + p: 128 for p in range(ptp)}}
+    thread.remote_te_port = {"prefill": {5000 + p: 7000 + p for p in range(ptp)}}
+    thread._dsa_main_local_layout = [DsaCacheLayout(MAIN, i, 1000 + i * 1000, 8, 8, 1, 4, "bf16") for i in range(2)]
+    thread._dsa_indexer_local_layout = [DsaCacheLayout(INDEXER, 0, 3000, 8, 8, 1, 4, "bf16")]
+    thread.engine = SimpleNamespace(batch_transfer_sync_read=MagicMock(return_value=0))
     thread._send_done_recv_signal = MagicMock()
-    thread._log_dsa_transfer_phase_diag = MagicMock()
-
-    calls = []
-    thread.engine = SimpleNamespace(
-        batch_transfer_sync_read=lambda session, *lists: calls.append(
-            (session, lists)
-        )
-        or 0
-    )
-    thread._build_dsa_transfer_lists = MagicMock(
-        side_effect=[([1], [11], [8]), ([2], [12], [8])]
-        if main_owner
-        else [([1], [11], [8])]
-    )
-
-    endpoint = RemoteEndpoint("10.0.0.1", 5000, "prefill")
+    endpoints = tuple(RemoteEndpoint("127.0.0.1", 5000 + p, "prefill") for p in range(ptp))
     command = DsaStepRequest(
-        request_id="req",
-        source=RemoteSource("remote-req", (endpoint,), (1,), (2,)),
-        main_host_block_ids=(12,),
-        indexer_hbm_block_ids=(11,),
+        "request",
+        RemoteSource(
+            "remote",
+            endpoints,
+            (9, 7),
+            (9, 7),
+            remote_ptp_size=ptp,
+            remote_dcp_size=dcp,
+            remote_block_size=4,
+            num_external_tokens=ptp * 4,
+        ),
+        tuple(range(20, 20 + ptp)),
+        tuple(range(40, 40 + ptp)),
+        invalid_block_ids=(81, 83),
     )
-    results = []
-
-    thread._execute_dsa_receive(command, endpoint, results.append)
-
-    assert len(calls) == (2 if main_owner else 1)
-    assert results[0].kind is DsaLocalResultKind.RECEIVE_COMPLETE
-    thread._send_done_recv_signal.assert_called_once()
+    return worker, thread, command
 
 
-def _dsa_receive_fixture():
-    thread = object.__new__(KVCacheRecvingThread)
-    thread.tp_rank = 0
-    thread._dsa_main_owner = True
-    thread._dsa_indexer_local_layout = [[(0, 100, 8, 8, 1)]]
-    thread._dsa_main_local_layout = [[(0, 200, 8, 8, 1)]]
-    thread.remote_metadata_lock = MagicMock()
-    thread.kv_caches_base_addr = {"prefill": {5000: [[1000]]}}
-    thread.remote_metadata_hosts = {"prefill": {5000: "10.0.0.1"}}
-    thread.remote_block_stride_per_addr = {"prefill": {5000: [[8]]}}
-    thread.remote_block_size_scale = {"prefill": {5000: [[1]]}}
-    thread.remote_block_len_per_addr = {"prefill": {5000: [[8]]}}
-    thread.remote_te_port = {"prefill": {5000: 6000}}
-    thread._get_remote_metadata = MagicMock()
-    thread._send_done_recv_signal = MagicMock()
-    thread._build_dsa_transfer_lists = MagicMock(
-        return_value=([1], [11], [8])
-    )
-    endpoint = RemoteEndpoint("10.0.0.1", 5000, "prefill")
-    command = DsaStepRequest(
-        request_id="req",
-        source=RemoteSource("remote-req", (endpoint,), (1,), (2,)),
-        main_host_block_ids=(12,),
-        indexer_hbm_block_ids=(11,),
-    )
-    return thread, command, endpoint
+def submit(worker, command):
+    worker._dispatch_dsa_commands((command,))
+    tasks = []
+    while not worker.kv_recv_thread.request_queue.empty():
+        task = worker.kv_recv_thread.request_queue.get_nowait()
+        worker.kv_recv_thread._mark_request_task_submitted(task)
+        tasks.append(task)
+    return tasks
 
 
-def test_blockwise_receive_exception_returns_terminal_failure():
-    thread, command, endpoint = _dsa_receive_fixture()
-    thread.engine = SimpleNamespace(
-        batch_transfer_sync_read=MagicMock(
-            side_effect=RuntimeError("transfer failed")
-        )
-    )
-    results = []
+@pytest.mark.parametrize("ptp,dcp,dtp", [(8, 8, 4), (16, 16, 8), (4, 1, 4), (8, 1, 4)])
+def test_real_endpoint_handlers_cover_main_once_and_full_indexer_per_rank(ptp, dcp, dtp):
+    writes = []
+    done_counts = defaultdict(int)
+    expected_counts = {}
+    for rank in range(dtp):
+        worker, thread, command = make_worker(rank, ptp, dcp, dtp)
+        if dcp == 1:
+            command = replace(
+                command,
+                source=replace(command.source, main_block_ids=tuple(range(ptp)), indexer_block_ids=tuple(range(ptp))),
+            )
+        tasks = submit(worker, command)
+        for task in reversed(tasks):
+            thread._handle_dsa_request(task)
+        (result,) = worker.build_connector_worker_meta().results
+        assert result.kind is DsaLocalResultKind.RECEIVE_COMPLETE
+        assert worker.build_connector_worker_meta() is None
+        indexer_bytes = 0
+        for call in thread.engine.batch_transfer_sync_read.call_args_list:
+            _, dsts, _, sizes = call.args
+            for dst, size in zip(dsts, sizes):
+                if dst >= 3000:
+                    indexer_bytes += size
+                else:
+                    writes.extend(range(dst, dst + size))
+        assert indexer_bytes == ptp * 8
+        for call in thread._send_done_recv_signal.call_args_list:
+            _, _, port, counts = call.args
+            if counts[port]["num"]:
+                done_counts[port] += 1
+                expected_counts[port] = counts[port]["num"]
+    assert len(writes) == len(set(writes)) == ptp * 8 * 2
+    assert dict(done_counts) == expected_counts
 
-    thread._execute_dsa_receive(command, endpoint, results.append)
 
-    assert len(results) == 1
-    assert results[0].kind is DsaLocalResultKind.TRANSFER_FAILED
-    assert results[0].failure_phase is DsaTransferPhase.INDEXER_D2D
-    thread._send_done_recv_signal.assert_called_once()
-
-
-def test_done_signal_exception_does_not_override_receive_success():
-    thread, command, endpoint = _dsa_receive_fixture()
-    thread.engine = SimpleNamespace(
-        batch_transfer_sync_read=MagicMock(return_value=0)
-    )
-    thread._send_done_recv_signal.side_effect = ValueError(
-        "done signal failed"
-    )
-    results = []
-
-    thread._execute_dsa_receive(command, endpoint, results.append)
-
-    assert len(results) == 1
-    assert results[0].kind is DsaLocalResultKind.RECEIVE_COMPLETE
-    assert results[0].failure_phase is None
+def test_failure_and_last_task_first_wait_for_all_pending_and_report_group_zero_ids():
+    worker, thread, command = make_worker()
+    tasks = submit(worker, command)
+    thread.engine.batch_transfer_sync_read.return_value = -1
+    thread._handle_dsa_request(tasks[-1])
+    assert worker.build_connector_worker_meta() is None
+    for task in tasks[:-1]:
+        thread._handle_dsa_request(task)
+    (result,) = worker.build_connector_worker_meta().results
+    assert result.kind is DsaLocalResultKind.TRANSFER_FAILED
+    assert thread.get_and_clear_invalid_block_ids() == {81, 83}
+    assert thread._send_done_recv_signal.call_count == len(tasks)
 
 
-@pytest.mark.parametrize("main_owner", [True, False])
-def test_local_layout_uses_shared_pool_only_on_owner(
-    main_owner, monkeypatch
-):
+def test_cancel_skips_reads_but_preserves_all_notifications_and_terminal_result():
+    worker, thread, command = make_worker()
+    tasks = submit(worker, command)
+    tasks[0]["cancelled"].set()
+    for task in tasks:
+        thread._handle_dsa_request(task)
+    thread.engine.batch_transfer_sync_read.assert_not_called()
+    assert thread._send_done_recv_signal.call_count == len(tasks)
+    assert len(worker.build_connector_worker_meta().results) == 1
+
+
+def test_notification_only_does_not_report_a_new_receive():
+    worker, thread, command = make_worker()
+    command = replace(command, notify_only=True, main_host_block_ids=(), indexer_hbm_block_ids=())
+    tasks = submit(worker, command)
+    for task in tasks:
+        thread._handle_dsa_request(task)
+    thread.engine.batch_transfer_sync_read.assert_not_called()
+    assert thread._send_done_recv_signal.call_count == len(tasks)
+    assert worker.build_connector_worker_meta() is None
+
+
+def test_submission_gap_does_not_finish_before_last_marker():
+    worker, thread, command = make_worker()
+    worker._dispatch_dsa_commands((command,))
+    while not thread.request_queue.empty():
+        task = thread.request_queue.get_nowait()
+        thread._mark_request_task_submitted(task)
+        thread._handle_dsa_request(task)
+        if not task["all_task_done"]:
+            assert worker.build_connector_worker_meta() is None
+    assert worker.build_connector_worker_meta() is not None
+
+
+def test_duplicate_and_late_done_do_not_release_early_or_recreate_state():
+    tracker = KVCacheTaskTracker()
+    tracker.add_req_to_process("r")
+    tracker.record_participant_done("r", "engine-A:port:0", 2)
+    tracker.record_participant_done("r", "engine-A:port:0", 2)
+    assert tracker.get_and_clear_finished_requests() == set()
+    tracker.record_participant_done("r", "engine-B:port:0", 2)
+    assert tracker.get_and_clear_finished_requests() == {"r"}
+    tracker.record_participant_done("r", "engine-A:port:0", 2)
+    assert not tracker.received_participants
+    assert tracker.get_and_clear_finished_requests() == set()
+
+
+@pytest.mark.parametrize("owner", [True, False])
+def test_all_ranks_register_and_use_local_main_views(owner, monkeypatch):
     worker = object.__new__(MooncakeConnectorWorker)
     worker.num_blocks = 4
-    worker.kv_caches_base_addr = [[], []]
     worker.engine = MagicMock()
-    host_k = torch.empty((4, 1, 2), dtype=torch.bfloat16)
-    host_v = torch.empty((4, 1, 2), dtype=torch.bfloat16)
-    pool = SimpleNamespace(
-        is_owner=main_owner,
-        register=MagicMock(),
-    )
+    worker._get_layer_spec = lambda name: SimpleNamespace(block_size=4)
+    host_k = torch.empty((4, 4, 1), dtype=torch.bfloat16)
+    host_v = torch.empty_like(host_k)
+    pool = SimpleNamespace(is_owner=owner, register_local_writer=MagicMock())
     manager = SimpleNamespace(
-        offload_layer_names=["model.layers.0.self_attn.attn"],
-        get_mooncake_host_pool=lambda: pool,
-        get_fused_overlap_cpu_kv_inputs=lambda _name: (
-            host_k,
-            host_v,
-        ),
+        get_mooncake_host_pool=lambda: pool, get_local_host_kv_views=lambda name: (host_k, host_v)
     )
-    monkeypatch.setattr(
-        mooncake_connector,
-        "get_sparse_kv_offload_manager",
-        lambda: manager,
+    monkeypatch.setattr(mooncake_connector, "get_sparse_kv_offload_manager", lambda: manager)
+    indexer = torch.empty_like(host_k)
+    indexer_layout, main_layout = worker._build_dsa_local_layouts(
+        {MAIN: (None,) * 6, INDEXER: (indexer,)}, {MAIN: 0, INDEXER: 1}
     )
-    indexer = torch.empty((8, 1, 2), dtype=torch.int8)
-    kv_caches = {"model.layers.0.indexer.k_cache": (indexer,)}
-    layer_name_to_idx = {
-        "model.layers.0.self_attn.attn": 0,
-        "model.layers.0.indexer.k_cache": 1,
+    assert main_layout[0].base == host_k.data_ptr()
+    assert main_layout[1].base == host_v.data_ptr()
+    assert indexer_layout[0].base == indexer.data_ptr()
+    pool.register_local_writer.assert_called_once_with(worker.engine)
+
+
+def test_cancel_inflight_read_waits_for_sync_return_before_terminal_callback():
+    worker, thread, command = make_worker()
+    tasks = submit(worker, command)
+    entered, release = threading.Event(), threading.Event()
+
+    def read(*args):
+        entered.set()
+        assert release.wait(5)
+        return 0
+
+    thread.engine.batch_transfer_sync_read.side_effect = read
+    running = threading.Thread(target=thread._handle_dsa_request, args=(tasks[0],))
+    running.start()
+    assert entered.wait(5)
+    tasks[0]["cancelled"].set()
+    for task in tasks[1:]:
+        thread._handle_dsa_request(task)
+    assert worker.build_connector_worker_meta() is None
+    assert "request" in worker._dsa_active_commands
+    release.set()
+    running.join(5)
+    assert not running.is_alive()
+    assert worker.build_connector_worker_meta() is not None
+    thread.engine.batch_transfer_sync_read.assert_called_once()
+
+
+def test_missing_remote_component_reports_failure_without_any_read():
+    worker, thread, command = make_worker()
+    tasks = submit(worker, command)
+    thread.remote_cache_dtypes["prefill"][5000] = [["bf16"], ["bf16"]]
+    for task in tasks:
+        thread._handle_dsa_request(task)
+    (result,) = worker.build_connector_worker_meta().results
+    assert result.kind is DsaLocalResultKind.TRANSFER_FAILED
+    thread.engine.batch_transfer_sync_read.assert_not_called()
+    assert thread.get_and_clear_invalid_block_ids() == {81, 83}
+
+
+def test_expiry_removes_participant_state(monkeypatch):
+    tracker = KVCacheTaskTracker()
+    tracker.add_req_to_process("r")
+    tracker.add_delayed_request("r", 0)
+    tracker.record_participant_done("r", "engine:port:0", 2)
+    monkeypatch.setattr(mooncake_connector.time, "time", lambda: 10**12)
+    assert tracker.get_and_clear_finished_requests() == {"r"}
+    assert not tracker.received_participants
+    tracker.record_participant_done("r", "engine:port:1", 2)
+    assert tracker.get_and_clear_finished_requests() == set()
+
+
+def test_changed_expected_count_is_rejected():
+    tracker = KVCacheTaskTracker()
+    tracker.add_req_to_process("r")
+    tracker.record_participant_done("r", "a", 2)
+    with pytest.raises(ValueError, match="count changed"):
+        tracker.record_participant_done("r", "b", 1)
+    assert tracker.get_and_clear_finished_requests() == set()
+
+
+def test_cross_host_endpoint_translation_preserves_source_counts():
+    worker, _, command = make_worker()
+    endpoints = tuple(RemoteEndpoint(f"192.0.2.{p + 1}", 8000 + p, f"engine{p}") for p in range(8))
+    command = replace(command, source=replace(command.source, endpoints_by_prefill_rank=endpoints))
+    tasks = submit(worker, command)
+    assert [t["dsa_remote_endpoint"] for t in tasks] == list(endpoints)
+    assert [t["expected"] for t in tasks] == [4] * 8
+    assert [t["cp_rank"] for t in tasks] == list(range(8))
+
+
+def test_prefill_pp_keeps_indexer_task_in_every_stage():
+    worker, _, command = make_worker(ptp=4, dcp=1, dtp=4)
+    worker._prefill_pp_size = 2
+    endpoints = tuple(RemoteEndpoint("127.0.0.1", 5000 + p, "prefill") for p in range(8))
+    command = replace(command, source=replace(command.source, remote_pp_size=2, endpoints_by_prefill_rank=endpoints))
+    plan = worker._plan_dsa_endpoints(command)
+    readers = [task for task in plan if task[4] > 0]
+    assert [(rank, pp, indexer) for rank, _, pp, indexer, _, _ in readers] == [(0, 0, True), (4, 1, True)]
+
+
+@pytest.mark.parametrize("dsa", [False, True])
+def test_dcp_pp_missing_source_stage_is_reported_before_transfer(dsa):
+    worker, thread, command = make_worker(ptp=8, dcp=8, dtp=4)
+    worker._prefill_pp_size = 2
+    endpoints = tuple(RemoteEndpoint("127.0.0.1", 5000 + p, "prefill") for p in range(16))
+    command = replace(command, source=replace(command.source, remote_pp_size=2, endpoints_by_prefill_rank=endpoints))
+    with pytest.raises(AssertionError, match="Mooncake KV source coverage incomplete") as error:
+        if dsa:
+            worker._dispatch_dsa_commands((command,))
+        else:
+            worker._is_hma_required = False
+            worker.pcp_rank = worker.dcp_rank = 0
+            worker.block_size = 4
+            worker.block_size_scale = [[1]]
+            worker.kv_group2layeridx = {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])}
+            worker.local_remote_block_port_mapping = {}
+            worker.remote_port_send_num = {}
+            meta = SimpleNamespace(
+                remote_pcp_size=1,
+                remote_dcp_size=8,
+                remote_ptp_size=8,
+                remote_port=5000,
+                remote_host="localhost",
+                remote_engine_id="prefill",
+                remote_request_id="remote",
+                remote_multi_nodes_meta_mapping={},
+                remote_block_size=4,
+                num_external_tokens=32,
+                num_computed_tokens=0,
+                num_prompt_blocks=8,
+                local_block_ids=(list(range(8)),),
+                remote_block_ids=([9],),
+            )
+            worker._get_kv_split_metadata("remote", meta)
+    message = str(error.value)
+    assert "request=remote" in message
+    assert f"missing_(pp_rank,cp_rank)={[(1, rank) for rank in range(8)]}" in message
+    assert "selected_ports=[5000, 5001, 5002, 5003, 5004, 5005, 5006, 5007]" in message
+    assert thread.request_queue.empty()
+    thread.engine.batch_transfer_sync_read.assert_not_called()
+
+
+def test_dsa_main_and_indexer_have_distinct_metadata_indices():
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker._dsa_pd_offload = True
+    worker.total_layers = 4
+    worker.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=SimpleNamespace(model_type="deepseek_v3"))
+    )
+    names = [MAIN, "model.layers.0.self_attn.indexer.k_cache", "model.mtp.layers.0.attn"]
+    worker.kv_cache_config = SimpleNamespace(kv_cache_groups=[SimpleNamespace(layer_names=names)])
+    worker._get_layer_spec = lambda name: SimpleNamespace(num_kv_heads=1)
+    worker._get_spec_total_num_kv_heads = lambda spec, index: 1
+    groups = worker._build_kv_group2layeridx()
+    mapping = mooncake_connector.build_layer_name_to_metadata_idx(groups)
+    assert len(set(mapping.values())) == len(names)
+    assert set(mapping) == set(names)
+
+
+def test_remote_group_and_layer_order_does_not_change_component_addresses():
+    worker, thread, command = make_worker()
+    tasks = submit(worker, command)
+    port = tasks[0]["remote_handshake_port"]
+    # Remote metadata order differs from Decode, as do its transfer group IDs.
+    thread.remote_kv_group2layeridx["prefill"][port] = {
+        7: ({"layer_names": [INDEXER]}, [0]),
+        9: ({"layer_names": [MAIN]}, [1]),
     }
-
-    indexer_layout, main_layout, is_owner = (
-        worker._build_dsa_local_layouts(
-            kv_caches, layer_name_to_idx
-        )
-    )
-
-    assert len(indexer_layout[1]) == 1
-    assert indexer_layout[1][0][0] == 0
-    assert is_owner is main_owner
-    if main_owner:
-        assert [entry[0] for entry in main_layout[0]] == [0, 1]
-        pool.register.assert_called_once_with(worker.engine)
-    else:
-        assert not any(main_layout)
-        pool.register.assert_not_called()
+    for table in (
+        thread.kv_caches_base_addr,
+        thread.remote_block_stride_per_addr,
+        thread.remote_block_size_scale,
+        thread.remote_block_len_per_addr,
+        thread.remote_cache_dtypes,
+    ):
+        table["prefill"][port] = list(reversed(table["prefill"][port]))
+    thread._execute_dsa_receive(tasks[0])
+    assert thread.engine.batch_transfer_sync_read.call_count == 2
+    indexer_call, main_call = thread.engine.batch_transfer_sync_read.call_args_list
+    assert all(src >= 30000 for src in indexer_call.args[2])
+    assert all(10000 <= src < 30000 for src in main_call.args[2])

--- a/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
@@ -21,7 +21,10 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_metadata import (
     RemoteEndpoint,
     RemoteSource,
 )
-from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_transfer import DsaCacheLayout
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_transfer import (
+    MAX_REGISTER_MEMORY_BYTES,
+    DsaCacheLayout,
+)
 
 MAIN = "model.layers.0.self_attn.attn"
 INDEXER = "model.layers.0.indexer.attn.index_cache"
@@ -210,27 +213,168 @@ def test_duplicate_and_late_done_do_not_release_early_or_recreate_state():
     assert tracker.get_and_clear_finished_requests() == set()
 
 
-@pytest.mark.parametrize("owner", [True, False])
-def test_all_ranks_register_and_use_local_main_views(owner, monkeypatch):
+@pytest.mark.parametrize("rank", [0, 1])
+def test_all_ranks_build_layouts_from_local_main_views_without_registration(rank, monkeypatch):
     worker = object.__new__(MooncakeConnectorWorker)
+    worker.tp_rank = rank
     worker.num_blocks = 4
     worker.engine = MagicMock()
     worker._get_layer_spec = lambda name: SimpleNamespace(block_size=4)
     host_k = torch.empty((4, 4, 1), dtype=torch.bfloat16)
     host_v = torch.empty_like(host_k)
-    pool = SimpleNamespace(is_owner=owner, register_local_writer=MagicMock())
-    manager = SimpleNamespace(
-        get_mooncake_host_pool=lambda: pool, get_local_host_kv_views=lambda name: (host_k, host_v)
-    )
+    manager = SimpleNamespace(get_local_host_kv_views=lambda name: (host_k, host_v))
     monkeypatch.setattr(mooncake_connector, "get_sparse_kv_offload_manager", lambda: manager)
     indexer = torch.empty_like(host_k)
-    indexer_layout, main_layout = worker._build_dsa_local_layouts(
-        {MAIN: (None,) * 6, INDEXER: (indexer,)}, {MAIN: 0, INDEXER: 1}
-    )
+    indexer_layout, main_layout = worker._build_dsa_local_layouts({MAIN: (None,) * 6, INDEXER: (indexer,)})
     assert main_layout[0].base == host_k.data_ptr()
     assert main_layout[1].base == host_v.data_ptr()
     assert indexer_layout[0].base == indexer.data_ptr()
-    pool.register_local_writer.assert_called_once_with(worker.engine)
+
+
+def test_dsa_register_regions_include_host_and_hbm_locations_once(monkeypatch):
+    worker = object.__new__(MooncakeConnectorWorker)
+    host_storage = torch.empty(256, dtype=torch.int8)
+    host_k = host_storage[:64].view(torch.bfloat16).view(4, 8)
+    host_v = host_storage[64:128].view(torch.bfloat16).view(4, 8)
+    indexer = torch.empty((4, 8), dtype=torch.bfloat16)
+    pool = SimpleNamespace(
+        data_ptr=host_storage.data_ptr(),
+        nbytes=host_storage.nbytes,
+        topology=SimpleNamespace(device_id=3),
+    )
+    manager = SimpleNamespace(get_mooncake_host_pool=lambda: pool)
+    monkeypatch.setattr(mooncake_connector, "get_sparse_kv_offload_manager", lambda: manager)
+    indexer_layouts = [DsaCacheLayout(INDEXER, 0, indexer.data_ptr(), 16, 16, 1, 4, "bf16", 4)]
+    main_layouts = [
+        DsaCacheLayout(MAIN, 0, host_k.data_ptr(), 16, 16, 1, 4, "bf16", 4),
+        DsaCacheLayout(MAIN, 1, host_v.data_ptr(), 16, 16, 1, 4, "bf16", 4),
+    ]
+    regions, locations = worker._dsa_consumer_register_regions(
+        {INDEXER: (indexer,)},
+        (indexer_layouts, main_layouts),
+    )
+    assert regions.ptrs == [host_k.data_ptr(), indexer.data_ptr()]
+    assert regions.lengths == [host_v.data_ptr() + host_v.nbytes - host_k.data_ptr(), indexer.nbytes]
+    assert locations == ["npu:3", "*"]
+
+
+def test_dsa_producer_oversized_atom_uses_layout_base_chunks():
+    base = 4096
+    span = MAX_REGISTER_MEMORY_BYTES + 1
+
+    class FakeStorage:
+        def data_ptr(self):
+            return base
+
+        def nbytes(self):
+            return span
+
+    class FakeTensor:
+        ndim = 1
+        shape = (2,)
+
+        def numel(self):
+            return 2
+
+        def element_size(self):
+            return 1
+
+        def stride(self, dim):
+            assert dim == 0
+            return MAX_REGISTER_MEMORY_BYTES
+
+        def data_ptr(self):
+            return base
+
+        def untyped_storage(self):
+            return FakeStorage()
+
+    worker = object.__new__(MooncakeConnectorWorker)
+    regions, locations = worker._dsa_producer_register_regions({MAIN: (FakeTensor(),)})
+    assert regions.ptrs == [base, base + MAX_REGISTER_MEMORY_BYTES]
+    assert regions.lengths == [MAX_REGISTER_MEMORY_BYTES, 1]
+    assert locations == ["*", "*"]
+
+
+def test_dsa_shutdown_drains_workers_before_unregister(monkeypatch):
+    events = []
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker._dsa_decode = True
+    worker._closing = False
+    worker._dsa_dispatch_lock = threading.Lock()
+    worker.kv_send_thread = None
+    worker.kv_recv_thread = SimpleNamespace(
+        request_queue=SimpleNamespace(
+            join=lambda: events.append("queue_join"),
+            put=lambda value: events.append(("queue_put", value)),
+        ),
+        join=lambda: events.append("thread_join"),
+        executor=SimpleNamespace(shutdown=lambda wait: events.append(("executor_shutdown", wait))),
+    )
+    monkeypatch.setattr(
+        mooncake_connector.global_te,
+        "unregister_buffer",
+        lambda: events.append("unregister"),
+    )
+    worker.shutdown()
+    assert worker._closing
+    assert events == [
+        "queue_join",
+        ("queue_put", None),
+        "thread_join",
+        ("executor_shutdown", True),
+        "unregister",
+    ]
+
+
+def test_producer_shutdown_stops_server_before_unregister(monkeypatch):
+    events = []
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker._dsa_decode = False
+    worker.kv_recv_thread = None
+    worker.kv_send_thread = SimpleNamespace(
+        stop=lambda: events.append("server_stop"),
+        join=lambda: events.append("server_join"),
+    )
+    monkeypatch.setattr(
+        mooncake_connector.global_te,
+        "unregister_buffer",
+        lambda: events.append("unregister"),
+    )
+
+    worker.shutdown()
+
+    assert events == ["server_stop", "server_join", "unregister"]
+
+
+def test_non_dsa_consumer_shutdown_unregisters_after_drain(monkeypatch):
+    events = []
+    worker = object.__new__(MooncakeConnectorWorker)
+    worker._dsa_decode = False
+    worker.kv_send_thread = None
+    worker.kv_recv_thread = SimpleNamespace(
+        request_queue=SimpleNamespace(
+            join=lambda: events.append("queue_join"),
+            put=lambda value: events.append(("queue_put", value)),
+        ),
+        join=lambda: events.append("thread_join"),
+        executor=SimpleNamespace(shutdown=lambda wait: events.append(("executor_shutdown", wait))),
+    )
+    monkeypatch.setattr(
+        mooncake_connector.global_te,
+        "unregister_buffer",
+        lambda: events.append("unregister"),
+    )
+
+    worker.shutdown()
+
+    assert events == [
+        "queue_join",
+        ("queue_put", None),
+        "thread_join",
+        ("executor_shutdown", True),
+        "unregister",
+    ]
 
 
 def test_cancel_inflight_read_waits_for_sync_return_before_terminal_callback():

--- a/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py
@@ -43,6 +43,8 @@ def make_worker(rank=0, ptp=8, dcp=8, dtp=4):
     worker._dsa_active_commands = {}
     worker._dsa_cancel_events = {}
     worker._dsa_results = queue.SimpleQueue()
+    worker._dsa_dispatch_lock = threading.Lock()
+    worker._closing = False
     worker.vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(is_deepseek_mla=True),
         parallel_config=SimpleNamespace(tensor_parallel_size=dtp),

--- a/tests/ut/kv_offload/test_mooncake_dsa_transfer.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_transfer.py
@@ -5,8 +5,12 @@ from dataclasses import replace
 import pytest
 
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_transfer import (
+    MAX_REGISTER_MEMORY_BYTES,
     DsaCacheLayout,
+    DsaRegisterAtom,
     build_component_read,
+    collect_bounded_register_regions,
+    split_transfer_lists_at_region_boundaries,
 )
 
 
@@ -119,3 +123,109 @@ def test_physical_ids_must_fit_registered_capacity(source, destination):
         build_component_read(
             layout, layout, source, destination, 0, 4, cp_size=1, cp_rank=0, writer_rank=0, writer_size=1, indexer=False
         )
+
+
+@pytest.mark.parametrize(
+    "size,expected",
+    [
+        (MAX_REGISTER_MEMORY_BYTES - 1, [MAX_REGISTER_MEMORY_BYTES - 1]),
+        (MAX_REGISTER_MEMORY_BYTES, [MAX_REGISTER_MEMORY_BYTES]),
+        (MAX_REGISTER_MEMORY_BYTES + 1, [MAX_REGISTER_MEMORY_BYTES, 1]),
+        (2 * MAX_REGISTER_MEMORY_BYTES + 1, [MAX_REGISTER_MEMORY_BYTES, MAX_REGISTER_MEMORY_BYTES, 1]),
+    ],
+)
+def test_oversized_register_atom_is_split_from_its_layout_base(size, expected):
+    regions = collect_bounded_register_regions([DsaRegisterAtom(123, 123 + size, "npu:7", "host")])
+    assert regions.ptrs == [123 + sum(expected[:index]) for index in range(len(expected))]
+    assert regions.lengths == expected
+    assert regions.locations == ["npu:7"] * len(expected)
+
+
+def test_register_regions_merge_only_at_atom_boundaries():
+    limit = 16
+    regions = collect_bounded_register_regions(
+        [
+            DsaRegisterAtom(100, 108, "npu:0", "pool"),
+            DsaRegisterAtom(110, 118, "npu:0", "pool"),
+            DsaRegisterAtom(118, 126, "npu:0", "pool"),
+            DsaRegisterAtom(1000, 1008, "*", "hbm"),
+        ],
+        max_region_bytes=limit,
+    )
+    assert regions.ptrs == [100, 110, 1000]
+    assert regions.lengths == [8, 16, 8]
+    assert regions.locations == ["npu:0", "npu:0", "*"]
+
+
+def test_duplicate_oversized_alias_is_registered_only_once():
+    atom = DsaRegisterAtom(
+        100,
+        100 + MAX_REGISTER_MEMORY_BYTES + 1,
+        "*",
+        "shared-storage",
+    )
+    regions = collect_bounded_register_regions([atom, atom])
+    assert regions.ptrs == [100, 100 + MAX_REGISTER_MEMORY_BYTES]
+    assert regions.lengths == [MAX_REGISTER_MEMORY_BYTES, 1]
+
+
+def test_contained_alias_inside_oversized_chunk_is_safe():
+    base = 100
+    regions = collect_bounded_register_regions(
+        [
+            DsaRegisterAtom(base, base + MAX_REGISTER_MEMORY_BYTES + 10, "*", "shared-storage"),
+            DsaRegisterAtom(
+                base + MAX_REGISTER_MEMORY_BYTES, base + MAX_REGISTER_MEMORY_BYTES + 5, "*", "shared-storage"
+            ),
+        ]
+    )
+    assert regions.ptrs == [base, base + MAX_REGISTER_MEMORY_BYTES]
+    assert regions.lengths == [MAX_REGISTER_MEMORY_BYTES, 10]
+
+
+def test_overlapping_aliases_merge_only_when_union_fits_one_region():
+    atoms = [
+        DsaRegisterAtom(100, 112, "*", "shared-storage"),
+        DsaRegisterAtom(108, 116, "*", "shared-storage"),
+    ]
+    regions = collect_bounded_register_regions(atoms, max_region_bytes=16)
+    assert regions.ptrs == [100]
+    assert regions.lengths == [16]
+    with pytest.raises(ValueError, match="cross a registration boundary"):
+        collect_bounded_register_regions(atoms, max_region_bytes=15)
+
+
+def test_transfer_is_split_at_different_local_and_remote_edges():
+    plan = split_transfer_lists_at_region_boundaries(
+        [114],
+        [1004],
+        [20],
+        local_base=100,
+        remote_base=1000,
+        max_region_bytes=16,
+    )
+    assert plan == ([114, 116, 126, 132], [1004, 1006, 1016, 1022], [2, 10, 6, 2])
+
+
+def test_build_component_read_does_not_remerge_64_gib_registration_edge():
+    size = MAX_REGISTER_MEMORY_BYTES + 1
+    local = DsaCacheLayout("main", 0, 100, size, size, 1, 1, "bytes", 1)
+    remote = DsaCacheLayout("main", 0, 1000, size, size, 1, 1, "bytes", 1)
+    plan = build_component_read(
+        local,
+        remote,
+        (0,),
+        (0,),
+        0,
+        1,
+        cp_size=1,
+        cp_rank=0,
+        writer_rank=0,
+        writer_size=1,
+        indexer=False,
+    )
+    assert plan == (
+        [100, 100 + MAX_REGISTER_MEMORY_BYTES],
+        [1000, 1000 + MAX_REGISTER_MEMORY_BYTES],
+        [MAX_REGISTER_MEMORY_BYTES, 1],
+    )

--- a/tests/ut/kv_offload/test_mooncake_dsa_transfer.py
+++ b/tests/ut/kv_offload/test_mooncake_dsa_transfer.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+import math
+from dataclasses import replace
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_dsa_transfer import (
+    DsaCacheLayout,
+    build_component_read,
+)
+
+
+def byte_pairs(plan):
+    return [(dst + i, src + i) for dst, src, size in zip(*plan) for i in range(size)]
+
+
+@pytest.mark.parametrize("cp,writers", [(1, 1), (1, 4), (8, 4), (16, 8), (2, 4), (4, 8)])
+@pytest.mark.parametrize("pblock,dblock", [(4, 4), (4, 8), (8, 4)])
+@pytest.mark.parametrize("start,end", [(0, 3), (5, 39), (20, 20), (0, 71)])
+def test_main_exact_coverage_with_prefix_tail_and_page_geometry(cp, writers, pblock, dblock, start, end):
+    source = tuple(100 + 3 * i for i in range(math.ceil(end / pblock / cp)))
+    destination = tuple(200 - 2 * i for i in range(math.ceil(end / dblock)))
+    local = DsaCacheLayout("main", 0, 10000, dblock * 2, dblock * 2 + 8, 1, dblock, "bf16")
+    # Source pages are two tokens each, with padding between pages.
+    remote = DsaCacheLayout("main", 0, 100000, 4, 8, pblock // 2, pblock, "bf16")
+    seen = {}
+    expected = {}
+    for rank in range(writers):
+        for shard in range(cp):
+            plan = build_component_read(
+                local,
+                remote,
+                source,
+                destination,
+                start,
+                end,
+                cp_size=cp,
+                cp_rank=shard,
+                writer_rank=rank,
+                writer_size=writers,
+                indexer=False,
+            )
+            for dst, src in byte_pairs(plan):
+                assert dst not in seen
+                seen[dst] = (shard, src)
+            # Physical IDs have no relation to ordinal-based ownership.
+            owned = {destination[g] for g in range(len(destination)) if g % writers == rank}
+            assert all((dst - local.base) // local.stride in owned for dst, _ in byte_pairs(plan))
+    for token in range(start, end):
+        g, offset = divmod(token, dblock)
+        p, poffset = divmod(token, pblock)
+        src_page = source[p // cp] * remote.scale + poffset // 2
+        for byte in range(2):
+            expected[local.base + destination[g] * local.stride + offset * 2 + byte] = (
+                p % cp,
+                remote.base + src_page * remote.stride + poffset % 2 * 2 + byte,
+            )
+    assert seen == expected
+
+
+@pytest.mark.parametrize("cp", [1, 8, 16])
+@pytest.mark.parametrize("dtype,token_bytes", [("bf16", 2), ("int8", 1)])
+def test_each_rank_receives_full_indexer_pages(cp, dtype, token_bytes):
+    local = DsaCacheLayout("indexer", 0, 1000, 8 * token_bytes, 16 * token_bytes, 1, 8, dtype)
+    remote = DsaCacheLayout("indexer", 0, 10000, 2 * token_bytes, 4 * token_bytes, 2 * cp, 4, dtype)
+    source = (91, 27, 63, 20, 33)
+    dest = (12, 51, 32)
+    plans = [
+        build_component_read(
+            local, remote, source, dest, 5, 19, cp_size=cp, cp_rank=0, writer_rank=rank, writer_size=4, indexer=True
+        )
+        for rank in range(4)
+    ]
+    assert plans == [plans[0]] * 4
+    expected = []
+    for token in range(5, 19):
+        page = source[token // (4 * cp)] * remote.scale + token % (4 * cp) // 2
+        expected.extend(
+            (
+                local.base + dest[token // 8] * local.stride + token % 8 * token_bytes + i,
+                remote.base + page * remote.stride + token % 2 * token_bytes + i,
+            )
+            for i in range(token_bytes)
+        )
+    assert byte_pairs(plans[0]) == expected
+
+
+@pytest.mark.parametrize("change", [{"dtype": "int8"}, {"block_bytes": 7}, {"scale": 3}, {"stride": 1}])
+def test_incompatible_geometry_fails_before_transfer(change):
+    layout = DsaCacheLayout("main", 0, 1000, 8, 8, 1, 4, "bf16")
+    with pytest.raises(ValueError):
+        build_component_read(
+            layout,
+            replace(layout, **change),
+            (1,),
+            (2,),
+            0,
+            4,
+            cp_size=1,
+            cp_rank=0,
+            writer_rank=0,
+            writer_size=1,
+            indexer=False,
+        )
+
+
+def test_missing_source_cannot_be_silently_truncated():
+    layout = DsaCacheLayout("main", 0, 1000, 8, 8, 1, 4, "bf16")
+    with pytest.raises(ValueError, match="coverage"):
+        build_component_read(
+            layout, layout, (), (2,), 0, 4, cp_size=1, cp_rank=0, writer_rank=0, writer_size=1, indexer=False
+        )
+
+
+@pytest.mark.parametrize("source,destination", [((5,), (1,)), ((1,), (5,))])
+def test_physical_ids_must_fit_registered_capacity(source, destination):
+    layout = DsaCacheLayout("main", 0, 1000, 8, 8, 1, 4, "bf16", capacity=5)
+    with pytest.raises(ValueError, match="registered capacity"):
+        build_component_read(
+            layout, layout, source, destination, 0, 4, cp_size=1, cp_rank=0, writer_rank=0, writer_size=1, indexer=False
+        )

--- a/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
@@ -12,6 +12,9 @@ pytest.importorskip("memfabric_hybrid")
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (  # noqa: E402
     sparse_kv_offload_manager as manager_module,
 )
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (  # noqa: E402
+    MooncakeHostPool,
+)
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (  # noqa: E402
     FSA_EXTERNAL_PLAN_READY_MARKER,
     FSA_PAIRED_SELECTION_COPY_MARKER,
@@ -57,6 +60,10 @@ def _make_plan_manager():
     manager.current_kv_by_layer = {}
     manager.fused_overlap_membership_map = None
     manager.fused_overlap_membership_map_rows = 0
+    manager.fused_overlap_membership_region = None
+    manager.fused_overlap_planner_membership_map = None
+    manager.fused_overlap_membership_plan_device_staging = None
+    manager._host_kv_allocator = None
     manager.fused_overlap_plan_owner_layer_id = None
     manager.fused_overlap_plan_topk = None
     manager.fused_overlap_plan_num_tokens = 0
@@ -157,6 +164,194 @@ def test_mapped_membership_allocation_initializes_external_plan_control():
     assert control[:, 7].tolist() == [FSA_PAIRED_SELECTION_COPY_MARKER] * 3
     manager.tp_group.broadcast.assert_called_once()
     manager.tp_group.barrier.assert_called_once_with()
+
+
+def _enable_mooncake_membership_staging(manager):
+    allocator = object.__new__(MooncakeHostPool)
+    allocator.topology = SimpleNamespace()
+    manager._host_kv_allocator = allocator
+    return allocator
+
+
+def test_mooncake_membership_uses_compact_cpu_and_npu_staging():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.use_fused_overlap = True
+    manager.topk = 2048
+    manager.tp_rank = 0
+    manager.tp_group = MagicMock()
+    manager.fused_overlap_membership_map = None
+    manager.fused_overlap_membership_map_rows = 0
+    manager.fused_overlap_membership_region = None
+    manager.fused_overlap_planner_membership_map = None
+    manager.fused_overlap_membership_plan_device_staging = None
+    _enable_mooncake_membership_staging(manager)
+    region = SimpleNamespace(
+        tensor=torch.empty(
+            3 * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT * 2,
+            dtype=torch.int8,
+        ),
+        release=MagicMock(),
+    )
+    synchronization_order = []
+    manager.tp_group.barrier.side_effect = (
+        lambda: synchronization_order.append("barrier")
+    )
+    current_stream = MagicMock()
+    current_stream.synchronize.side_effect = (
+        lambda: synchronization_order.append("stream_sync")
+    )
+
+    with (
+        patch.object(
+            manager_module,
+            "allocate_mooncake_host_region",
+            return_value=region,
+        ) as allocate,
+        patch.object(
+            manager_module.torch_npu.npu,
+            "current_stream",
+            return_value=current_stream,
+        ),
+    ):
+        membership = manager.allocate_fused_overlap_membership_map(3)
+
+    planner = manager.fused_overlap_planner_membership_map
+    device_staging = manager.fused_overlap_membership_plan_device_staging
+    plan_shape = (
+        3,
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+    )
+    assert membership.shape == (
+        3,
+        FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT,
+    )
+    assert planner is not None
+    assert planner.shape == plan_shape
+    assert planner.is_contiguous()
+    assert planner.stride() == (plan_shape[1], 1)
+    assert device_staging is not None
+    assert device_staging.shape == plan_shape
+    assert device_staging.is_contiguous()
+    assert membership.data_ptr() != planner.data_ptr()
+    assert device_staging.data_ptr() != planner.data_ptr()
+    assert device_staging.data_ptr() != membership.data_ptr()
+    allocate.assert_called_once()
+    current_stream.synchronize.assert_called_once_with()
+    manager.tp_group.barrier.assert_called_once_with()
+    assert synchronization_order == ["stream_sync", "barrier"]
+
+
+def test_mooncake_eager_external_plan_publishes_through_npu_staging():
+    manager = _make_plan_manager()
+    _enable_mooncake_membership_staging(manager)
+    membership = torch.full(
+        (4, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT),
+        -1,
+        dtype=torch.int16,
+    )
+    plan_width = (
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+    )
+    planner_membership = torch.full(
+        (4, plan_width),
+        7,
+        dtype=torch.int16,
+    )
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = planner_membership
+    manager.fused_overlap_membership_plan_device_staging = torch.empty(
+        (4, plan_width),
+        dtype=torch.int16,
+    )
+    sparse_kv_ops = _make_sparse_kv_ops()
+
+    with patch.object(
+        manager_module,
+        "_sparse_kv_ops",
+        return_value=sparse_kv_ops,
+    ):
+        assert manager.prepare_fused_overlap_external_plan(
+            layer_name="layer.0",
+            num_tokens=2,
+            topk_indices_npu=torch.tensor(
+                [[1, 2, 3, 4], [4, 3, 2, 1]],
+                dtype=torch.int32,
+            ),
+            req_ids_npu=torch.tensor([101, 202], dtype=torch.int64),
+            stable_prefix_lens_npu=torch.tensor(
+                [10, 20], dtype=torch.int32
+            ),
+            visible_seq_lens_npu=torch.tensor(
+                [11, 21], dtype=torch.int32
+            ),
+            selection_membership_map=membership,
+            capturing=False,
+        )
+
+    plan_start = (
+        FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - manager.topk
+    )
+    plan_end = plan_start + plan_width
+    torch.testing.assert_close(
+        membership[:2, plan_start:plan_end],
+        planner_membership[:2],
+    )
+    torch.testing.assert_close(
+        manager.fused_overlap_membership_plan_device_staging[:2],
+        planner_membership[:2],
+    )
+    planner = (
+        sparse_kv_ops
+        .sparse_kv_lru_resident_compact_with_plan_stable_rows
+    )
+    assert planner.call_args.args[17] == planner_membership[:2].data_ptr()
+    assert planner.call_args.args[18] == plan_width
+
+
+def test_non_tp0_mooncake_plan_does_not_require_cpu_planner_storage():
+    manager = _make_plan_manager()
+    manager.tp_rank = 1
+    _enable_mooncake_membership_staging(manager)
+    membership = torch.full(
+        (4, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT),
+        -1,
+        dtype=torch.int16,
+    )
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = None
+    sparse_kv_ops = _make_sparse_kv_ops()
+
+    with patch.object(
+        manager_module,
+        "_sparse_kv_ops",
+        return_value=sparse_kv_ops,
+    ):
+        assert manager.prepare_fused_overlap_external_plan(
+            layer_name="layer.0",
+            num_tokens=1,
+            topk_indices_npu=torch.tensor(
+                [[1, 2, 3, 4]], dtype=torch.int32
+            ),
+            req_ids_npu=torch.tensor([101], dtype=torch.int64),
+            stable_prefix_lens_npu=torch.tensor([10], dtype=torch.int32),
+            visible_seq_lens_npu=torch.tensor([11], dtype=torch.int32),
+            selection_membership_map=membership,
+            capturing=False,
+        )
+
+    (
+        sparse_kv_ops
+        .sparse_kv_lru_resident_compact_with_plan_stable_rows
+        .assert_not_called()
+    )
+    (
+        sparse_kv_ops
+        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
+        .assert_not_called()
+    )
+    manager.tp_group.broadcast.assert_called_once_with(
+        manager.fused_plan_metadata_npu, src=0
+    )
 
 
 def test_external_lru_plan_is_reused_by_three_skip_layers_and_replanned_at_owner():
@@ -274,6 +469,21 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
         -1,
         dtype=torch.int16,
     )
+    plan_width = (
+        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+    )
+    planner_membership = torch.full(
+        (4, plan_width),
+        7,
+        dtype=torch.int16,
+    )
+    _enable_mooncake_membership_staging(manager)
+    manager.fused_overlap_membership_map = membership
+    manager.fused_overlap_planner_membership_map = planner_membership
+    manager.fused_overlap_membership_plan_device_staging = torch.empty(
+        (4, plan_width),
+        dtype=torch.int16,
+    )
     topk = torch.tensor([[1, 2, 3, 4]], dtype=torch.int32)
     req_ids = torch.tensor([101], dtype=torch.int64)
     stable_prefix_lens = torch.tensor([10], dtype=torch.int32)
@@ -316,9 +526,16 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
     assert current_stream.record_event.call_count == 2
     manager.current_kv_save_stream.wait_event.assert_called_once_with(input_event)
     manager.fused_plan_stream.wait_event.assert_called_once_with(input_event)
-    sparse_kv_ops.sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows.assert_called_once()
+    planner = (
+        sparse_kv_ops
+        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
+    )
+    planner.assert_called_once()
+    assert planner.call_args.args[17] == planner_membership[:1].data_ptr()
+    assert planner.call_args.args[18] == plan_width
     manager.tp_group.broadcast.assert_called_once_with(manager.fused_plan_metadata_npu, src=0)
-    current_stream.wait_stream.assert_called_once_with(manager.current_kv_save_stream)
+    current_stream.wait_stream.assert_any_call(manager.fused_plan_stream)
+    current_stream.wait_stream.assert_any_call(manager.current_kv_save_stream)
     assert manager.current_kv_by_layer[0][0].numel() == 1
     assert manager.current_kv_by_layer[0][1].numel() == 1
 

--- a/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
@@ -456,7 +456,7 @@ def test_eager_external_plan_copies_inputs_and_preserves_cpp_argument_order():
     manager.tp_group.broadcast.assert_called_once_with(manager.fused_plan_metadata_npu, src=0)
 
 
-def test_capture_external_plan_and_current_kv_use_separate_side_streams():
+def test_capture_external_plan_side_stream_and_mooncake_writeback_wait():
     manager = _make_plan_manager()
     sparse_kv_ops = _make_sparse_kv_ops()
     manager.current_kv_save_stream = MagicMock()
@@ -523,9 +523,11 @@ def test_capture_external_plan_and_current_kv_use_separate_side_streams():
         manager.inject_current_kv_into_selection = MagicMock()
         manager.wait_for_current_kv_writeback(capturing=True)
 
-    assert current_stream.record_event.call_count == 2
-    manager.current_kv_save_stream.wait_event.assert_called_once_with(input_event)
+    current_stream.record_event.assert_called_once_with()
+    manager.current_kv_save_stream.wait_event.assert_not_called()
     manager.fused_plan_stream.wait_event.assert_called_once_with(input_event)
+    writeback_args = manager._offload_new_kv_on_current_stream.call_args.args
+    assert writeback_args[-3:] == (False, True, True)
     planner = (
         sparse_kv_ops
         .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows

--- a/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py
@@ -173,7 +173,15 @@ def _enable_mooncake_membership_staging(manager):
     return allocator
 
 
-def test_mooncake_membership_uses_compact_cpu_and_npu_staging():
+def test_mooncake_membership_uses_compact_cpu_and_npu_staging(monkeypatch):
+    # CPU UT validates staging geometry/ordering, not accelerator pinning.
+    allocate_tensor = torch.empty
+
+    def cpu_empty(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return allocate_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", cpu_empty)
     manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
     manager.use_fused_overlap = True
     manager.topk = 2048
@@ -193,13 +201,9 @@ def test_mooncake_membership_uses_compact_cpu_and_npu_staging():
         release=MagicMock(),
     )
     synchronization_order = []
-    manager.tp_group.barrier.side_effect = (
-        lambda: synchronization_order.append("barrier")
-    )
+    manager.tp_group.barrier.side_effect = lambda: synchronization_order.append("barrier")
     current_stream = MagicMock()
-    current_stream.synchronize.side_effect = (
-        lambda: synchronization_order.append("stream_sync")
-    )
+    current_stream.synchronize.side_effect = lambda: synchronization_order.append("stream_sync")
 
     with (
         patch.object(
@@ -249,9 +253,7 @@ def test_mooncake_eager_external_plan_publishes_through_npu_staging():
         -1,
         dtype=torch.int16,
     )
-    plan_width = (
-        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
-    )
+    plan_width = manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
     planner_membership = torch.full(
         (4, plan_width),
         7,
@@ -278,19 +280,13 @@ def test_mooncake_eager_external_plan_publishes_through_npu_staging():
                 dtype=torch.int32,
             ),
             req_ids_npu=torch.tensor([101, 202], dtype=torch.int64),
-            stable_prefix_lens_npu=torch.tensor(
-                [10, 20], dtype=torch.int32
-            ),
-            visible_seq_lens_npu=torch.tensor(
-                [11, 21], dtype=torch.int32
-            ),
+            stable_prefix_lens_npu=torch.tensor([10, 20], dtype=torch.int32),
+            visible_seq_lens_npu=torch.tensor([11, 21], dtype=torch.int32),
             selection_membership_map=membership,
             capturing=False,
         )
 
-    plan_start = (
-        FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - manager.topk
-    )
+    plan_start = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - manager.topk
     plan_end = plan_start + plan_width
     torch.testing.assert_close(
         membership[:2, plan_start:plan_end],
@@ -300,10 +296,7 @@ def test_mooncake_eager_external_plan_publishes_through_npu_staging():
         manager.fused_overlap_membership_plan_device_staging[:2],
         planner_membership[:2],
     )
-    planner = (
-        sparse_kv_ops
-        .sparse_kv_lru_resident_compact_with_plan_stable_rows
-    )
+    planner = sparse_kv_ops.sparse_kv_lru_resident_compact_with_plan_stable_rows
     assert planner.call_args.args[17] == planner_membership[:2].data_ptr()
     assert planner.call_args.args[18] == plan_width
 
@@ -329,9 +322,7 @@ def test_non_tp0_mooncake_plan_does_not_require_cpu_planner_storage():
         assert manager.prepare_fused_overlap_external_plan(
             layer_name="layer.0",
             num_tokens=1,
-            topk_indices_npu=torch.tensor(
-                [[1, 2, 3, 4]], dtype=torch.int32
-            ),
+            topk_indices_npu=torch.tensor([[1, 2, 3, 4]], dtype=torch.int32),
             req_ids_npu=torch.tensor([101], dtype=torch.int64),
             stable_prefix_lens_npu=torch.tensor([10], dtype=torch.int32),
             visible_seq_lens_npu=torch.tensor([11], dtype=torch.int32),
@@ -339,19 +330,9 @@ def test_non_tp0_mooncake_plan_does_not_require_cpu_planner_storage():
             capturing=False,
         )
 
-    (
-        sparse_kv_ops
-        .sparse_kv_lru_resident_compact_with_plan_stable_rows
-        .assert_not_called()
-    )
-    (
-        sparse_kv_ops
-        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
-        .assert_not_called()
-    )
-    manager.tp_group.broadcast.assert_called_once_with(
-        manager.fused_plan_metadata_npu, src=0
-    )
+    (sparse_kv_ops.sparse_kv_lru_resident_compact_with_plan_stable_rows.assert_not_called())
+    (sparse_kv_ops.sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows.assert_not_called())
+    manager.tp_group.broadcast.assert_called_once_with(manager.fused_plan_metadata_npu, src=0)
 
 
 def test_external_lru_plan_is_reused_by_three_skip_layers_and_replanned_at_owner():
@@ -469,9 +450,7 @@ def test_capture_external_plan_side_stream_and_mooncake_writeback_wait():
         -1,
         dtype=torch.int16,
     )
-    plan_width = (
-        manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
-    )
+    plan_width = manager.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
     planner_membership = torch.full(
         (4, plan_width),
         7,
@@ -528,10 +507,7 @@ def test_capture_external_plan_side_stream_and_mooncake_writeback_wait():
     manager.fused_plan_stream.wait_event.assert_called_once_with(input_event)
     writeback_args = manager._offload_new_kv_on_current_stream.call_args.args
     assert writeback_args[-3:] == (False, True, True)
-    planner = (
-        sparse_kv_ops
-        .sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
-    )
+    planner = sparse_kv_ops.sparse_kv_enqueue_lru_resident_compact_with_plan_stable_rows
     planner.assert_called_once()
     assert planner.call_args.args[17] == planner_membership[:1].data_ptr()
     assert planner.call_args.args[18] == plan_width
@@ -607,3 +583,43 @@ def test_current_kv_injection_uses_planner_linear_slots_and_sentinel():
     torch.testing.assert_close(selection_kv[0], torch.tensor([0.0, 1.0]))
     torch.testing.assert_close(selection_rope[0], torch.tensor([0.0]))
     assert scatter_op.call_count == 2
+
+
+@pytest.mark.parametrize("peer_change", [None, "offset", "invalid"])
+def test_mooncake_local_views_and_fused_inputs_share_mapping(peer_change):
+    manager = _make_plan_manager()
+    manager.tp_rank = 1
+    manager.offload_layer_names = ["layer.0"]
+    manager.kv_cache_config = SimpleNamespace(num_blocks=4)
+    pool = MooncakeHostPool(
+        manager_module.HostMemoryRegion(torch.empty(256, dtype=torch.int8)),
+        manager_module.HostPoolTopology(tp_rank=1, tp_size=2),
+    )
+    manager._host_kv_allocator = pool
+    k, v = [t.view(torch.bfloat16).reshape(4, 2, 1, 2) for t in pool.allocate_tensors([32, 32], 16)]
+    manager.k_caches_cpu, manager.v_caches_cpu = [k], [v]
+
+    def gather(output, value, group):
+        descriptor, error = value
+        assert error is None
+        peer = value
+        if peer_change == "offset":
+            peer = ((descriptor[0] + 16, *descriptor[1:]), None)
+        elif peer_change == "invalid":
+            peer = (None, "outside pool")
+        output[:] = [peer, value]
+
+    with patch.object(torch.distributed, "all_gather_object", side_effect=gather):
+        if peer_change:
+            with pytest.raises(ValueError, match="layout mismatch"):
+                manager._register_local_mooncake_views()
+            return
+        manager._register_local_mooncake_views()
+    local = manager.get_local_host_kv_views("layer.0")
+    fused = manager.get_fused_overlap_cpu_kv_inputs("layer.0")
+    assert local[0] is fused[0] is k
+    assert local[1] is fused[1] is v
+    assert manager.gvas_k_bases == [k.data_ptr()]
+    assert manager.gvas_v_bases == [v.data_ptr()]
+    assert manager.cpu_block_lens == [(8, 8)]
+    manager.tp_group.broadcast.assert_not_called()

--- a/tests/ut/kv_offload/test_sparse_kv_offload_index_copy.py
+++ b/tests/ut/kv_offload/test_sparse_kv_offload_index_copy.py
@@ -1,0 +1,233 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("vllm")
+pytest.importorskip("torch_npu")
+pytest.importorskip("memfabric_hybrid")
+
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (  # noqa: E402
+    sparse_kv_offload_manager as manager_module,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (  # noqa: E402
+    MooncakeHostPool,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (  # noqa: E402
+    SparseKVOffloadManager,
+)
+
+
+def _set_mooncake_allocator(manager):
+    allocator = object.__new__(MooncakeHostPool)
+    allocator.topology = SimpleNamespace()
+    manager._host_kv_allocator = allocator
+
+
+def test_eager_current_kv_index_copy_filters_invalid_slots():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.token_size_bytes_k = 2 * torch.bfloat16.itemsize
+    manager.token_size_bytes_v = 1 * torch.bfloat16.itemsize
+    manager.max_d2h_index_copy_tokens = 4
+
+    host_k = torch.zeros((8, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((8, 1), dtype=torch.bfloat16)
+    current_k = torch.tensor(
+        [[1, 2], [3, 4], [5, 6]], dtype=torch.bfloat16
+    )
+    current_v = torch.tensor([[7], [8], [9]], dtype=torch.bfloat16)
+
+    manager._offload_new_kv_via_index_copy(
+        slot_mapping=torch.tensor([3, -1, 5], dtype=torch.int64),
+        k_cache_cpu=host_k,
+        v_cache_cpu=host_v,
+        k=current_k,
+        v=current_v,
+        capturing=False,
+    )
+
+    assert torch.equal(host_k[3], current_k[0])
+    assert torch.equal(host_v[3], current_v[0])
+    assert torch.equal(host_k[5], current_k[2])
+    assert torch.equal(host_v[5], current_v[2])
+    assert torch.count_nonzero(host_k[0]).item() == 0
+    assert torch.count_nonzero(host_v[0]).item() == 0
+
+
+def test_graph_mooncake_writeback_waits_for_save_stream():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.tp_rank = 0
+    manager.use_fused_overlap = True
+    manager.layer_name_to_offload_id = {"layer.0": 0}
+    manager.current_kv_by_layer = {}
+    manager._offload_new_kv_on_current_stream = MagicMock()
+    _set_mooncake_allocator(manager)
+    manager.current_kv_save_stream = MagicMock()
+    current_stream = MagicMock()
+    current_kv_ready = object()
+    current_stream.record_event.return_value = current_kv_ready
+
+    slot_mapping = torch.tensor([2], dtype=torch.int64)
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.ones((1, 2), dtype=torch.bfloat16)
+    current_v = torch.ones((1, 1), dtype=torch.bfloat16)
+
+    with (
+        patch.object(manager_module.torch_npu.npu, "current_stream", return_value=current_stream),
+        patch.object(
+            manager_module.torch_npu.npu,
+            "stream",
+            side_effect=lambda _: nullcontext(),
+        ),
+    ):
+        manager.offload_new_kv(
+            "layer.0",
+            slot_mapping,
+            host_k,
+            host_v,
+            None,
+            None,
+            current_k,
+            current_v,
+            capturing=True,
+        )
+        manager.wait_for_current_kv_writeback(capturing=True)
+
+    manager._offload_new_kv_on_current_stream.assert_called_once_with(
+        slot_mapping,
+        host_k,
+        host_v,
+        None,
+        None,
+        current_k,
+        current_v,
+        False,
+        True,
+        True,
+    )
+    assert manager.current_kv_by_layer[0] == (current_k, current_v)
+    current_stream.record_event.assert_not_called()
+    manager.current_kv_save_stream.wait_event.assert_not_called()
+    current_stream.wait_stream.assert_called_once_with(manager.current_kv_save_stream)
+
+
+def test_graph_mooncake_index_copy_runs_on_save_stream():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.token_size_bytes_k = 2 * torch.bfloat16.itemsize
+    manager.token_size_bytes_v = torch.bfloat16.itemsize
+    manager.max_d2h_index_copy_tokens = 4
+    manager.d2h_slot_mapping_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_src_idx_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_dst_idx_cpu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_index_count_cpu = torch.zeros(1, dtype=torch.int32)
+    manager.d2h_src_idx_npu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_dst_idx_npu = torch.zeros(4, dtype=torch.int64)
+    manager.d2h_index_count_npu = torch.zeros(1, dtype=torch.int32)
+    manager.current_kv_save_stream = MagicMock()
+    current_stream = MagicMock()
+    descriptors_ready = object()
+    current_stream.record_event.return_value = descriptors_ready
+
+    def enqueue_descriptors(
+        slot_mapping,
+        num_actual_tokens,
+        max_num_tokens,
+        num_host_slots,
+        src_idx,
+        dst_idx,
+        count,
+    ):
+        assert slot_mapping[0].item() == 2
+        assert num_actual_tokens == 1
+        assert max_num_tokens == 4
+        assert num_host_slots == 4
+        src_idx.zero_()
+        dst_idx.fill_(2)
+        count.fill_(1)
+
+    sparse_kv_ops = SimpleNamespace(
+        sparse_kv_enqueue_current_kv_index_copy_descriptors=MagicMock(
+            side_effect=enqueue_descriptors,
+        ),
+    )
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.tensor([[1, 2]], dtype=torch.bfloat16)
+    current_v = torch.tensor([[3]], dtype=torch.bfloat16)
+
+    with (
+        patch.object(manager_module, "_sparse_kv_ops", return_value=sparse_kv_ops),
+        patch.object(manager_module.torch_npu.npu, "current_stream", return_value=current_stream),
+        patch.object(
+            manager_module.torch_npu.npu,
+            "stream",
+            side_effect=lambda _: nullcontext(),
+        ),
+    ):
+        manager._offload_new_kv_via_index_copy(
+            slot_mapping=torch.tensor([2], dtype=torch.int64),
+            k_cache_cpu=host_k,
+            v_cache_cpu=host_v,
+            k=current_k,
+            v=current_v,
+            capturing=True,
+            prepare_descriptors=True,
+        )
+
+    assert torch.equal(host_k[2], current_k[0])
+    assert torch.equal(host_v[2], current_v[0])
+    current_stream.record_event.assert_called_once_with()
+    manager.current_kv_save_stream.wait_event.assert_called_once_with(
+        descriptors_ready
+    )
+    sparse_kv_ops.sparse_kv_enqueue_current_kv_index_copy_descriptors.assert_called_once()
+
+
+def test_graph_mooncake_prepares_descriptors_on_first_layer_only():
+    manager = SparseKVOffloadManager.__new__(SparseKVOffloadManager)
+    manager.tp_rank = 0
+    manager.use_fused_overlap = True
+    manager.layer_name_to_offload_id = {
+        "layer.0": 0,
+        "layer.1": 1,
+    }
+    manager.current_kv_by_layer = {}
+    manager._offload_new_kv_on_current_stream = MagicMock()
+    _set_mooncake_allocator(manager)
+
+    slot_mapping = torch.tensor([2], dtype=torch.int64)
+    host_k = torch.zeros((4, 2), dtype=torch.bfloat16)
+    host_v = torch.zeros((4, 1), dtype=torch.bfloat16)
+    current_k = torch.ones((1, 2), dtype=torch.bfloat16)
+    current_v = torch.ones((1, 1), dtype=torch.bfloat16)
+
+    for layer_name in ("layer.0", "layer.1"):
+        manager.offload_new_kv(
+            layer_name,
+            slot_mapping,
+            host_k,
+            host_v,
+            None,
+            None,
+            current_k,
+            current_v,
+            capturing=True,
+        )
+
+    assert manager._offload_new_kv_on_current_stream.call_count == 2
+    first_call, second_call = (
+        manager._offload_new_kv_on_current_stream.call_args_list
+    )
+    assert first_call.args[-3:] == (
+        False,
+        True,
+        True,
+    )
+    assert second_call.args[-3:] == (
+        False,
+        True,
+        False,
+    )

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -679,6 +679,7 @@ class TestSparseKVOffloadConfig(TestBase):
                 "dram_size_per_dp_GB": "64",
                 "keep_device_kv_cache": "false",
                 "use_fused_overlap": "true",
+                "host_backend": "mooncake",
             },
         )
 
@@ -687,6 +688,72 @@ class TestSparseKVOffloadConfig(TestBase):
         self.assertEqual(config.dram_size_per_dp_GB, 64)
         self.assertFalse(config.keep_device_kv_cache)
         self.assertTrue(config.use_fused_overlap)
+        self.assertEqual(config.host_backend, "mooncake")
+
+    def test_sparse_kv_host_backend_defaults_to_memfabric(self):
+        config = SparseKVOffloadConfig.from_additional_config(
+            SimpleNamespace(),
+            {"enabled": "false"},
+        )
+        self.assertEqual(config.host_backend, "memfabric")
+
+    def test_invalid_sparse_kv_host_backend_is_rejected(self):
+        with self.assertRaises(ValueError):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {"enabled": "false", "host_backend": "unknown"},
+            )
+
+    def test_mooncake_host_backend_requires_fused_overlap(self):
+        with self.assertRaisesRegex(ValueError, "requires use_fused_overlap"):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {"enabled": "true", "host_backend": "mooncake"},
+            )
+
+    def test_mooncake_host_backend_rejects_colocate_staging(self):
+        with self.assertRaisesRegex(ValueError, "keep_device_kv_cache"):
+            SparseKVOffloadConfig.from_additional_config(
+                SimpleNamespace(),
+                {
+                    "enabled": "true",
+                    "host_backend": "mooncake",
+                    "use_fused_overlap": "true",
+                    "keep_device_kv_cache": "true",
+                },
+            )
+
+    def test_mooncake_host_backend_valid_config_passes_validation(self):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(hf_text_config=SimpleNamespace(index_topk=128)),
+            parallel_config=SimpleNamespace(
+                prefill_context_parallel_size=1,
+                decode_context_parallel_size=1,
+                pipeline_parallel_size=1,
+            ),
+            kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+            use_v2_model_runner=False,
+        )
+
+        config = SparseKVOffloadConfig.from_additional_config(
+            vllm_config,
+            {
+                "enabled": "true",
+                "host_backend": "mooncake",
+                "use_fused_overlap": "true",
+                "keep_device_kv_cache": "false",
+            },
+        )
+
+        self.assertEqual(config.host_backend, "mooncake")
+
+    def test_mooncake_validation_skipped_when_disabled(self):
+        config = SparseKVOffloadConfig.from_additional_config(
+            SimpleNamespace(),
+            {"enabled": "false", "host_backend": "mooncake"},
+        )
+
+        self.assertEqual(config.host_backend, "mooncake")
 
     def test_unknown_key_is_rejected_even_when_disabled(self):
         with self.assertRaises(ValueError):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1300,6 +1300,7 @@ class SparseKVOffloadConfig:
     keep_device_kv_cache: bool = False
     topk: int = dataclasses.field(default=0, init=False)
     use_fused_overlap: bool = False
+    host_backend: Literal["memfabric", "mooncake"] = "memfabric"
 
     @model_validator(mode="after")
     def _validate_values(self):
@@ -1307,6 +1308,15 @@ class SparseKVOffloadConfig:
             raise ValueError("sparse_kv_offload_config.topk_buffer_size must be positive")
         if self.dram_size_per_dp_GB <= 0:
             raise ValueError("sparse_kv_offload_config.dram_size_per_dp_GB must be positive")
+        if self.enabled and self.host_backend == "mooncake":
+            if not self.use_fused_overlap:
+                raise ValueError("sparse_kv_offload_config.host_backend='mooncake' requires use_fused_overlap=true")
+            if self.keep_device_kv_cache:
+                raise ValueError(
+                    "sparse_kv_offload_config.host_backend='mooncake' is "
+                    "only supported for PD-disaggregated decode; "
+                    "keep_device_kv_cache must be false"
+                )
         return self
 
     @classmethod

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -529,7 +529,9 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             or self._fused_overlap_selection_capacity[3] < cache_blocks_per_row
             or self.selection_kv_block_table.device != device
             or self.selection_kv_block_status.device != device
-            or self.selection_membership_map.device.type != "cpu"
+            or not get_sparse_kv_offload_manager().is_fused_membership_storage(
+                self.selection_membership_map
+            )
             or self.fused_overlap_last_req_ids.device != device
         )
         if needs_realloc:

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import psutil
 import regex as re
 from vllm.logger import logger
+from vllm_ascend import envs
 
 from vllm_ascend.device.hardware_profile import (
     CPUBindingMode,
@@ -644,6 +645,13 @@ class CpuAlloc:
             anchor_cpu = cpu_pool[0]
             return self.cpu_node.get(anchor_cpu)
 
+        if envs.VLLM_ASCEND_SKIP_MIGRATEPAGES:
+            logger.info(
+                "[migrate] skipped because "
+                "VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding "
+                "continues."
+            )
+            return
         if not shutil.which("migratepages"):
             logger.info("The 'migratepages' command is not available, skipping memory binding.")
             return

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 import psutil
 import regex as re
 from vllm.logger import logger
-from vllm_ascend import envs
 
+from vllm_ascend import envs
 from vllm_ascend.device.hardware_profile import (
     CPUBindingMode,
     DeviceAddressingMode,
@@ -646,11 +646,7 @@ class CpuAlloc:
             return self.cpu_node.get(anchor_cpu)
 
         if envs.VLLM_ASCEND_SKIP_MIGRATEPAGES:
-            logger.info(
-                "[migrate] skipped because "
-                "VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding "
-                "continues."
-            )
+            logger.info("[migrate] skipped because VLLM_ASCEND_SKIP_MIGRATEPAGES=1; CPU thread binding continues.")
             return
         if not shutil.which("migratepages"):
             logger.info("The 'migratepages' command is not available, skipping memory binding.")

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2137,23 +2137,14 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
         main_block_ids = groups[self.main_group_idx]
         if num_external_tokens > 0 and bound_blocks > len(main_block_ids):
             raise ValueError("vLLM has not allocated enough Main Host blocks")
-        invalid_block_ids = groups[0]
-        if num_external_tokens > 0 and tracker.num_computed_tokens > 0:
-            # Diagnostic only: do not silently narrow the current reporting range.
-            # A partially cached block overlaps the read and is not protected here.
-            group0_block_size = self.block_size[0]
-            prefix_blocks = tracker.num_computed_tokens // group0_block_size
-            prefix_block_ids = groups[0][:prefix_blocks]
-            misreported_prefix_ids = sorted(set(invalid_block_ids).intersection(prefix_block_ids))
-            assert not misreported_prefix_ids, (
-                "Mooncake DSA failure-reporting range includes untouched prefix blocks before transfer: "
-                f"request={request.request_id}, group=0, group_block_size={group0_block_size}, "
-                f"read_tokens=[{tracker.num_computed_tokens}, {bound_tokens}), "
-                f"invalid_block_ids={invalid_block_ids}, "
-                f"untouched_prefix_block_ids={misreported_prefix_ids}. "
-                "A later load failure would invalidate these locally cached blocks; "
-                "no transfer failure or impact on other requests has been observed by this check."
-            )
+        unhashed_block_ids = (
+            blocks.get_unhashed_block_ids_all_groups()
+            if num_external_tokens > 0
+            else ()
+        )
+        invalid_block_ids = (
+            tuple(unhashed_block_ids[0]) if unhashed_block_ids else ()
+        )
         tracker.source = replace(tracker.source, num_external_tokens=num_external_tokens)
         tracker.allocated = True
         tracker.notify_only = num_external_tokens == 0

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -95,7 +95,13 @@ from .mooncake_dsa_metadata import (
     RemoteEndpoint,
     RemoteSource,
 )
-from .mooncake_dsa_transfer import DsaCacheLayout, build_component_read
+from .mooncake_dsa_transfer import (
+    DsaCacheLayout,
+    DsaRegisterAtom,
+    build_component_read,
+    collect_bounded_register_regions,
+    layout_span_bytes,
+)
 
 # isort: off
 if TYPE_CHECKING:
@@ -3196,15 +3202,104 @@ class MooncakeConnectorWorker:
 
         return ptrs, lengths
 
-    def _dsa_consumer_device_register_regions(self, kv_caches: dict[str, torch.Tensor]) -> RegisterRegions:
-        indexer_caches = {
-            name: self._as_kv_cache_tuple(cache) for name, cache in kv_caches.items() if "indexer" in name.lower()
-        }
-        if not indexer_caches:
-            raise ValueError("Blockwise DSA Decode has no Indexer device cache")
-        return collect_storage_merged_register_regions(indexer_caches)
+    def _dsa_consumer_register_regions(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        layouts: tuple[list[DsaCacheLayout], list[DsaCacheLayout]],
+    ) -> tuple[RegisterRegions, list[str]]:
+        """Collect Host Main and HBM Indexer atoms for one TE registration."""
+        indexer_layouts, main_layouts = layouts
+        manager = get_sparse_kv_offload_manager()
+        pool = manager.get_mooncake_host_pool()
+        pool_start = pool.data_ptr
+        pool_end = pool_start + pool.nbytes
+        host_location = f"npu:{pool.topology.device_id}"
+        atoms: list[DsaRegisterAtom] = []
 
-    def _build_dsa_local_layouts(self, kv_caches, layer_name_to_idx):
+        for layout in main_layouts:
+            end = layout.base + layout_span_bytes(layout)
+            if layout.base < pool_start or end > pool_end:
+                raise ValueError(f"DSA Host component {layout.layer_name} is outside the Mooncake Host pool")
+            atoms.append(
+                DsaRegisterAtom(
+                    layout.base,
+                    end,
+                    host_location,
+                    ("host", pool_start),
+                )
+            )
+
+        for layout in indexer_layouts:
+            tensors = self._as_kv_cache_tuple(kv_caches[layout.layer_name])
+            if layout.position >= len(tensors):
+                raise ValueError(f"missing DSA Indexer tensor position {layout.position}")
+            tensor = tensors[layout.position]
+            storage = tensor.untyped_storage()
+            storage_start = tensor_storage_key(tensor)
+            storage_end = storage_start + storage.nbytes()
+            end = layout.base + layout_span_bytes(layout)
+            if layout.base < storage_start or end > storage_end:
+                raise ValueError(f"DSA Indexer component {layout.layer_name} is outside its storage")
+            atoms.append(
+                DsaRegisterAtom(
+                    layout.base,
+                    end,
+                    "*",
+                    ("hbm", storage_start),
+                )
+            )
+
+        bounded = collect_bounded_register_regions(atoms)
+        regions = RegisterRegions(
+            ptrs=bounded.ptrs,
+            lengths=bounded.lengths,
+            logical_tensor_count=len(atoms),
+            logical_total_bytes=sum(atom.end - atom.start for atom in atoms),
+        )
+        return regions, bounded.locations
+
+    def _dsa_producer_register_regions(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+    ) -> tuple[RegisterRegions, list[str]]:
+        """Collect DSA source HBM atoms with layout-base-aligned splits."""
+        atoms: list[DsaRegisterAtom] = []
+        for caches in kv_caches.values():
+            for tensor in self._as_kv_cache_tuple(caches):
+                if tensor.numel() == 0:
+                    continue
+                if tensor.ndim < 1 or tensor.shape[0] <= 0:
+                    raise ValueError("DSA producer tensor must have a physical page dimension")
+                block_bytes = tensor.element_size() * math.prod(tensor.shape[1:])
+                stride = tensor.stride(0) * tensor.element_size()
+                if stride < block_bytes:
+                    raise ValueError("DSA producer tensor has overlapping physical pages")
+                start = tensor.data_ptr()
+                end = start + (tensor.shape[0] - 1) * stride + block_bytes
+                storage = tensor.untyped_storage()
+                storage_start = tensor_storage_key(tensor)
+                if start < storage_start or end > storage_start + storage.nbytes():
+                    raise ValueError("DSA producer tensor is outside its storage")
+                atoms.append(
+                    DsaRegisterAtom(
+                        start,
+                        end,
+                        "*",
+                        ("hbm", storage_start),
+                    )
+                )
+        if not atoms:
+            raise ValueError("Blockwise DSA producer has no HBM cache tensors")
+        bounded = collect_bounded_register_regions(atoms)
+        regions = RegisterRegions(
+            ptrs=bounded.ptrs,
+            lengths=bounded.lengths,
+            logical_tensor_count=len(atoms),
+            logical_total_bytes=sum(atom.end - atom.start for atom in atoms),
+        )
+        return regions, bounded.locations
+
+    def _build_dsa_local_layouts(self, kv_caches):
         from vllm.v1.worker.utils import extract_layer_index
 
         self._dsa_transformer_layers = {
@@ -3212,7 +3307,6 @@ class MooncakeConnectorWorker:
             for name in kv_caches
         }
         manager = get_sparse_kv_offload_manager()
-        pool = manager.get_mooncake_host_pool()
         indexer, main = [], []
         for name, caches in kv_caches.items():
             is_indexer = "indexer" in name.lower()
@@ -3237,7 +3331,6 @@ class MooncakeConnectorWorker:
                 (indexer if is_indexer else main).append(entry)
         if not indexer or not main:
             raise ValueError("DSA requires Main and Indexer component layouts")
-        pool.register_local_writer(self.engine)
         return indexer, main
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
@@ -3294,13 +3387,20 @@ class MooncakeConnectorWorker:
 
         dsa_local_layouts = None
         if self._dsa_decode:
-            dsa_local_layouts = self._build_dsa_local_layouts(kv_caches, layer_name_to_idx)
+            dsa_local_layouts = self._build_dsa_local_layouts(kv_caches)
 
+        register_locations = None
         if has_mamba_group:
             ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
         elif self._dsa_decode:
-            register_regions = self._dsa_consumer_device_register_regions(kv_caches)
+            assert dsa_local_layouts is not None
+            register_regions, register_locations = self._dsa_consumer_register_regions(
+                kv_caches,
+                dsa_local_layouts,
+            )
+        elif self._dsa_pd_offload:
+            register_regions, register_locations = self._dsa_producer_register_regions(kv_caches)
         elif self.use_hybrid:
             ptrs, lengths = self._get_registered_kv_tensor_buffers_hybrid(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
@@ -3311,7 +3411,14 @@ class MooncakeConnectorWorker:
             register_regions = collect_storage_merged_register_regions(kv_caches)
 
         validate_register_region_count(register_regions)
-        global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
+        if register_locations is None:
+            global_te.register_buffer(register_regions.ptrs, register_regions.lengths)
+        else:
+            global_te.register_buffer(
+                register_regions.ptrs,
+                register_regions.lengths,
+                register_locations,
+            )
 
         logger.debug(
             "Mooncake register kv caches metadata: kv_group2layeridx=%s, kv_caches_base_addr=%s, "

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -328,6 +328,14 @@ class KVCacheTaskTracker:
             if count != expected:
                 raise ValueError("DSA expected notification count changed")
             seen.add(participant)
+            logger.debug(
+                "DSA producer received completion request=%s participant=%s progress=%s/%s complete=%s",
+                request_id,
+                participant,
+                len(seen),
+                expected,
+                len(seen) == expected,
+            )
             if len(seen) == expected:
                 self.finished_requests.add(request_id)
                 self.reqs_to_process.discard(request_id)
@@ -745,6 +753,22 @@ class KVCacheRecvingThread(threading.Thread):
         cancelled: threading.Event,
         all_task_done: bool,
     ) -> None:
+        logger.debug(
+            "DSA enqueue request=%s decode_rank=%s remote=%s:%s cp_rank=%s "
+            "pp_rank=%s include_indexer=%s expected_notifications=%s "
+            "notify_only=%s cancelled=%s all_task_done=%s",
+            command.request_id,
+            self.tp_rank,
+            remote_endpoint.remote_host,
+            remote_endpoint.remote_port,
+            cp_rank,
+            pp_rank,
+            include_indexer,
+            expected,
+            command.notify_only,
+            cancelled.is_set(),
+            all_task_done,
+        )
         self.request_queue.put(
             dict(
                 request_id=command.request_id,
@@ -765,12 +789,37 @@ class KVCacheRecvingThread(threading.Thread):
 
     def _execute_dsa_receive(self, task: dict[str, Any]) -> None:
         command = task["dsa_command"]
-        if command.notify_only or task["expected"] == 0 or task["cancelled"].is_set():
+        skip_reason = None
+        if command.notify_only:
+            skip_reason = "notify_only"
+        elif task["expected"] == 0:
+            skip_reason = "zero_reader_cleanup"
+        elif task["cancelled"].is_set():
+            skip_reason = "cancelled"
+        if skip_reason is not None:
+            logger.debug(
+                "DSA skip transfer request=%s decode_rank=%s reason=%s",
+                command.request_id,
+                self.tp_rank,
+                skip_reason,
+            )
             return
         endpoint = task["dsa_remote_endpoint"]
         engine_id, port, host = endpoint.remote_engine_id, endpoint.remote_port, endpoint.remote_host
         with self.remote_metadata_lock:
             has_metadata = self.remote_metadata_hosts.get(engine_id, {}).get(port) == host
+        logger.debug(
+            "DSA begin endpoint request=%s decode_rank=%s remote=%s:%s "
+            "metadata_cached=%s cp_rank=%s pp_rank=%s include_indexer=%s",
+            command.request_id,
+            self.tp_rank,
+            host,
+            port,
+            has_metadata,
+            task["cp_rank"],
+            task["pp_rank"],
+            task["include_indexer"],
+        )
         if not has_metadata:
             self._get_remote_metadata(host, port)
         with self.remote_metadata_lock:
@@ -846,8 +895,24 @@ class KVCacheRecvingThread(threading.Thread):
                 for output, values in zip(combined, part):
                     output.extend(values)
             plans.append((indexer, combined, statistics))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "DSA built transfer plans request=%s decode_rank=%s phases=%s token_range=[%s,%s) pp_layers=[%s,%s)",
+                command.request_id,
+                self.tp_rank,
+                [("indexer" if indexer else "main", len(plan[0]), sum(plan[2])) for indexer, plan, _ in plans],
+                start,
+                end,
+                first,
+                last,
+            )
         for indexer, plan, statistics in plans:
             if task["cancelled"].is_set():
+                logger.debug(
+                    "DSA stop remaining phases request=%s decode_rank=%s reason=cancelled",
+                    command.request_id,
+                    self.tp_rank,
+                )
                 break
             task["failure_phase"] = DsaTransferPhase.INDEXER_D2D if indexer else DsaTransferPhase.MAIN_D2RH
             if plan[0]:
@@ -870,9 +935,23 @@ class KVCacheRecvingThread(threading.Thread):
         command = task["dsa_command"]
         endpoint = task["dsa_remote_endpoint"]
         task["failure_phase"] = DsaTransferPhase.MAIN_D2RH
+        logger.debug(
+            "DSA handle endpoint request=%s decode_rank=%s participant=%s remote=%s:%s",
+            command.request_id,
+            self.tp_rank,
+            task["participant"],
+            endpoint.remote_host,
+            endpoint.remote_port,
+        )
         try:
             if not self._is_failed_recv_request(command.request_id):
                 self._execute_dsa_receive(task)
+            else:
+                logger.debug(
+                    "DSA skip endpoint request=%s decode_rank=%s reason=prior_endpoint_failure",
+                    command.request_id,
+                    self.tp_rank,
+                )
         except Exception:
             # The upstream invalid-block interface uses cache group 0's ID
             # space (R1). Preserve that space; never report Host IDs as group 0.
@@ -889,6 +968,13 @@ class KVCacheRecvingThread(threading.Thread):
                     {endpoint.remote_port: {"num": task["expected"], "host": endpoint.remote_host}},
                     participant=task["participant"],
                 )
+                logger.debug(
+                    "DSA sent completion notification request=%s decode_rank=%s participant=%s expected=%s",
+                    command.request_id,
+                    self.tp_rank,
+                    task["participant"],
+                    task["expected"],
+                )
             except Exception:
                 logger.exception("DSA endpoint done notification failed: %s", command.request_id)
             if self._mark_request_task_done(command.request_id, task["all_task_done"]):
@@ -896,6 +982,13 @@ class KVCacheRecvingThread(threading.Thread):
                 with self.failed_recv_requests_lock:
                     phase = self.dsa_failure_phases.pop(command.request_id, DsaTransferPhase.MAIN_D2RH)
                 self._clear_failed_recv_request(command.request_id)
+                logger.debug(
+                    "DSA local request complete request=%s decode_rank=%s failed=%s failure_phase=%s",
+                    command.request_id,
+                    self.tp_rank,
+                    failed,
+                    phase if failed else None,
+                )
                 task["dsa_on_result"](
                     DsaLocalResult(
                         command.request_id,
@@ -2004,6 +2097,20 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
             num_computed_tokens=num_computed_tokens,
             num_external_tokens=external_tokens,
         )
+        logger.debug(
+            "DSA scheduler matched request=%s remote_request=%s computed_tokens=%s "
+            "external_tokens=%s remote_blocks(main=%s,indexer=%s) remote_topology=(tp=%s,pcp=%s,dcp=%s,pp=%s)",
+            request.request_id,
+            source.remote_request_id,
+            num_computed_tokens,
+            external_tokens,
+            len(source.main_block_ids),
+            len(source.indexer_block_ids),
+            source.remote_ptp_size,
+            source.remote_pcp_size,
+            source.remote_dcp_size,
+            source.remote_pp_size,
+        )
         return external_tokens, external_tokens > 0
 
     def update_state_after_alloc(
@@ -2053,6 +2160,16 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
         tracker.invalid_block_ids = invalid_block_ids
         tracker.indexer_hbm_block_ids = indexer_block_ids
         tracker.main_block_ids = main_block_ids[:bound_blocks]
+        logger.debug(
+            "DSA scheduler allocated request=%s external_tokens=%s notify_only=%s "
+            "local_blocks(main=%s,indexer=%s,invalid=%s)",
+            request.request_id,
+            num_external_tokens,
+            tracker.notify_only,
+            len(tracker.main_block_ids),
+            len(tracker.indexer_hbm_block_ids),
+            len(tracker.invalid_block_ids),
+        )
         if isinstance(request.kv_transfer_params, dict):
             request.kv_transfer_params["do_remote_prefill"] = False
 
@@ -2082,6 +2199,13 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
                 self._dsa_requests.pop(command.request_id, None)
         cancelled = tuple(getattr(self, "_dsa_cancelled", ()))
         self._dsa_cancelled = set()
+        if (requests or cancelled) and logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "DSA scheduler emitted metadata requests=%s notify_only=%s cancelled=%s",
+                [command.request_id for command in requests],
+                [command.request_id for command in requests if command.notify_only],
+                list(cancelled),
+            )
         return DsaConnectorMetadata(tuple(requests), cancelled)
 
     def update_connector_output(self, connector_output: Any) -> None:
@@ -2107,6 +2231,17 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
                     raise ValueError(f"conflicting DSA result for {result.identity}")
                 continue
             tracker.results_by_rank[result.tp_rank] = result
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "DSA scheduler received result request=%s rank=%s kind=%s phase=%s "
+                    "received_ranks=%s expected_ranks=%s",
+                    result.request_id,
+                    result.tp_rank,
+                    result.kind,
+                    result.failure_phase,
+                    sorted(tracker.results_by_rank),
+                    sorted(self._expected_tp_ranks),
+                )
             if set(tracker.results_by_rank) != self._expected_tp_ranks:
                 continue
             # Invalid blocks are reported by the receiving worker before this
@@ -2118,6 +2253,7 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
             connector_output.finished_recving = finished
             for request_id in completed:
                 self._dsa_requests.pop(request_id, None)
+            logger.debug("DSA scheduler completed requests=%s", completed)
 
     def set_xfer_handshake_metadata(
         self,
@@ -2147,10 +2283,16 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
             tracker.allocated = True
             tracker.notify_only = True
             request.kv_transfer_params["do_remote_prefill"] = False
+            logger.debug("DSA scheduler marked request=%s notify_only before allocation", request.request_id)
             return False, None
         if not hasattr(self, "_dsa_cancelled"):
             self._dsa_cancelled = set()
         self._dsa_cancelled.add(request.request_id)
+        logger.debug(
+            "DSA scheduler cancelled request=%s notify_only=%s",
+            request.request_id,
+            tracker.notify_only,
+        )
         return not tracker.notify_only, None
 
 
@@ -2188,6 +2330,14 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
                     raise ValueError("Blockwise DSA Decode requires fused overlap")
                 if offload.host_backend != "mooncake":
                     raise ValueError("Blockwise DSA Decode requires host_backend='mooncake'")
+            logger.debug(
+                "DSA connector enabled role=%s connector_role=%s prefill_tp=%s decode_tp=%s decode_mode=%s",
+                kv_role,
+                role,
+                prefill_tp,
+                decode_tp,
+                self._dsa_decode,
+            )
         self._connector_metadata = MooncakeConnectorMetadata()
 
         if role == KVConnectorRole.SCHEDULER:
@@ -2824,6 +2974,17 @@ class MooncakeConnectorWorker:
             self._dsa_results: queue.SimpleQueue[DsaLocalResult] = queue.SimpleQueue()
             self._dsa_dispatch_lock = threading.Lock()
             self._closing = False
+            logger.debug(
+                "DSA worker enabled engine=%s decode_rank=%s/%s prefill_topology=(tp=%s,pp=%s) "
+                "local_context_parallel=(pcp=%s,dcp=%s)",
+                self.engine_id,
+                self.tp_rank,
+                self.tp_size,
+                self._prefill_tp_size,
+                self._prefill_pp_size,
+                self.pcp_size,
+                self.dcp_size,
+            )
 
     def _get_prefill_decode_size(self, vllm_config: VllmConfig):
         # get prefill tp and dp size from extra config
@@ -3331,6 +3492,12 @@ class MooncakeConnectorWorker:
                 (indexer if is_indexer else main).append(entry)
         if not indexer or not main:
             raise ValueError("DSA requires Main and Indexer component layouts")
+        logger.debug(
+            "DSA local layouts ready decode_rank=%s indexer_components=%s main_components=%s",
+            self.tp_rank,
+            len(indexer),
+            len(main),
+        )
         return indexer, main
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
@@ -4532,6 +4699,13 @@ class MooncakeConnectorWorker:
     ):
         """Start loading KV blocks from remote engine."""
         if isinstance(metadata, DsaConnectorMetadata):
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "DSA worker received metadata decode_rank=%s requests=%s cancelled=%s",
+                    self.tp_rank,
+                    [command.request_id for command in metadata.requests],
+                    list(metadata.cancelled_requests),
+                )
             scheduled_ids = {command.request_id for command in metadata.requests}
             for request_id in metadata.cancelled_requests:
                 if request_id in self._dsa_active_commands or request_id in scheduled_ids:
@@ -4732,9 +4906,31 @@ class MooncakeConnectorWorker:
             if existing is not None:
                 if existing != command:
                     raise ValueError(f"conflicting DSA receive for {command.request_id!r}")
+                logger.debug(
+                    "DSA ignore duplicate command request=%s decode_rank=%s",
+                    command.request_id,
+                    self.tp_rank,
+                )
                 continue
             plan = self._plan_dsa_endpoints(command)
-            logger.debug("DSA plan request=%s rank=%s endpoint_tasks=%s", command.request_id, self.tp_rank, len(plan))
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "DSA plan request=%s decode_rank=%s notify_only=%s endpoint_tasks=%s tasks=%s",
+                    command.request_id,
+                    self.tp_rank,
+                    command.notify_only,
+                    len(plan),
+                    [
+                        {
+                            "prefill_rank": rank,
+                            "cp_rank": cp_rank,
+                            "pp_rank": pp_rank,
+                            "indexer": indexer,
+                            "expected": expected,
+                        }
+                        for rank, cp_rank, pp_rank, indexer, expected, _ in plan
+                    ],
+                )
             self._dsa_active_commands[command.request_id] = command
             cancelled = self._dsa_cancel_events.setdefault(command.request_id, threading.Event())
             for index, (rank, cp_rank, pp_rank, indexer, expected, task_index) in enumerate(plan):
@@ -4757,11 +4953,25 @@ class MooncakeConnectorWorker:
         result: DsaLocalResult,
     ) -> None:
         if self._dsa_active_commands.get(command.request_id) != command:
+            logger.debug(
+                "DSA ignore stale local result request=%s decode_rank=%s kind=%s",
+                command.request_id,
+                self.tp_rank,
+                result.kind,
+            )
             return
         self._dsa_active_commands.pop(command.request_id, None)
         self._dsa_cancel_events.pop(command.request_id, None)
         if not command.notify_only:
             self._dsa_results.put(result)
+        logger.debug(
+            "DSA worker finalized request=%s decode_rank=%s kind=%s phase=%s notify_only=%s",
+            command.request_id,
+            self.tp_rank,
+            result.kind,
+            result.failure_phase,
+            command.notify_only,
+        )
 
     def build_connector_worker_meta(
         self,
@@ -4774,6 +4984,12 @@ class MooncakeConnectorWorker:
                 break
         if not results:
             return None
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "DSA worker emitted results decode_rank=%s results=%s",
+                self.tp_rank,
+                [(result.request_id, result.kind, result.failure_phase) for result in results],
+            )
         return DsaWorkerResultMetadata(tuple(results))
 
     def _get_tp_num_need_pulls(self, prefill_tp_size: int | None) -> int:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -13,7 +13,7 @@ import time
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import msgspec
@@ -58,6 +58,12 @@ from vllm.v1.request import RequestStatus
 
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec, AscendSlidingWindowMLASpec
+from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.scheduler import (
+    SFAPDRD2HScheduler,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    get_sparse_kv_offload_manager,
+)
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     PD_QOS_DEFAULT,
@@ -79,6 +85,17 @@ from vllm_ascend.utils import (
     model_uses_sfa_sparse,
 )
 
+from .mooncake_dsa_metadata import (
+    DsaConnectorMetadata,
+    DsaLocalResult,
+    DsaLocalResultKind,
+    DsaStepRequest,
+    DsaTransferPhase,
+    DsaWorkerResultMetadata,
+    RemoteEndpoint,
+    RemoteSource,
+)
+
 # isort: off
 if TYPE_CHECKING:
     from vllm.v1.attention.backend import AttentionMetadata  # type: ignore
@@ -96,6 +113,65 @@ DONE_RECVING_MSG = b"done_recving_msg"
 # other peers already waiting in the global executor queue can make progress.
 MAX_REQUESTS_PER_PEER_HANDLER = 5
 KV_CACHE_BUFFER_ALIGNMENT = 2 * 1024 * 1024
+
+
+def _resolve_remote_endpoint(
+    base_port: int,
+    remote_handshake_port: int,
+    remote_host: str,
+    remote_engine_id: str,
+    remote_multi_nodes_meta_mapping: Mapping[str, Mapping[str, object]] | None,
+) -> RemoteEndpoint:
+    rank = str(remote_handshake_port - base_port)
+    info = None if remote_multi_nodes_meta_mapping is None else remote_multi_nodes_meta_mapping.get(rank)
+    if info is None:
+        return RemoteEndpoint(remote_host, remote_handshake_port, remote_engine_id)
+    if not isinstance(info, Mapping):
+        raise TypeError(f"remote endpoint mapping for rank {rank} must be a mapping")
+    return RemoteEndpoint(
+        str(info.get("host", remote_host)),
+        int(info.get("handshake_port", remote_handshake_port)),
+        str(info.get("engine_id", remote_engine_id)),
+    )
+
+
+def _project_remote_endpoints(
+    *,
+    remote_host: str,
+    remote_port: int,
+    remote_engine_id: str,
+    remote_multi_nodes_meta_mapping: Mapping[str, Mapping[str, object]] | None,
+    prefill_tp_size: int,
+) -> tuple[RemoteEndpoint, ...]:
+    if isinstance(prefill_tp_size, bool) or not isinstance(prefill_tp_size, int) or prefill_tp_size <= 0:
+        raise ValueError("prefill_tp_size must be a positive integer")
+    mapping = {} if remote_multi_nodes_meta_mapping is None else remote_multi_nodes_meta_mapping
+    if not isinstance(mapping, Mapping):
+        raise TypeError("remote_multi_nodes_meta_mapping must be a mapping")
+    if mapping:
+        numeric_mapping = {int(rank): info for rank, info in mapping.items()}
+        ranks = sorted(numeric_mapping)
+        if len(ranks) == prefill_tp_size and ranks != list(range(prefill_tp_size)):
+            base = ranks[0]
+            if ranks == list(range(base, base + prefill_tp_size)):
+                numeric_mapping = {rank - base: info for rank, info in numeric_mapping.items()}
+        expected = set(range(prefill_tp_size))
+        if set(numeric_mapping) != expected:
+            raise ValueError(
+                "remote endpoint mapping must cover Prefill TP ranks "
+                f"0..{prefill_tp_size - 1}, got {sorted(numeric_mapping)}"
+            )
+        mapping = {str(rank): numeric_mapping[rank] for rank in expected}
+    return tuple(
+        _resolve_remote_endpoint(
+            remote_port,
+            remote_port + rank,
+            remote_host,
+            remote_engine_id,
+            mapping,
+        )
+        for rank in range(prefill_tp_size)
+    )
 
 
 class RemotePortInfo(TypedDict):
@@ -473,6 +549,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_te_port: dict[str, dict[int, int]] = SizedDict()
         self.remote_block_size_scale: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_block_stride_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_block_len_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
+        self.remote_metadata_hosts: dict[str, dict[int, str]] = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
         self.remote_metadata_lock = threading.Lock()
         # Reformat metadata keyed by request_id then CP shard index. Populated by the
@@ -606,6 +684,296 @@ class KVCacheRecvingThread(threading.Thread):
         logger.debug("Adding request %s to the queue.Trans info:%s", request_id, trans_info)
         self.request_queue.put(trans_info)
 
+    def add_dsa_request(
+        self,
+        command: DsaStepRequest,
+        remote_endpoint: RemoteEndpoint,
+        on_result: Any,
+    ) -> None:
+        self.request_queue.put(
+            {
+                "request_id": command.request_id,
+                "remote_host": remote_endpoint.remote_host,
+                "remote_handshake_port": remote_endpoint.remote_port,
+                "dsa_command": command,
+                "dsa_remote_endpoint": remote_endpoint,
+                "dsa_on_result": on_result,
+            }
+        )
+
+    @staticmethod
+    def _expand_dsa_block_ids(
+        block_ids: tuple[int, ...], scale: int
+    ) -> list[int]:
+        if scale <= 0:
+            raise ValueError(
+                "DSA positional block scale must be positive"
+            )
+        return [
+            block_id * scale + offset
+            for block_id in block_ids
+            for offset in range(scale)
+        ]
+
+    @staticmethod
+    def _dsa_indexer_token_scale(
+        *, remote_block_len: int, local_block_len: int
+    ) -> int:
+        if (
+            remote_block_len <= 0
+            or local_block_len <= 0
+            or local_block_len % remote_block_len
+        ):
+            return 1
+        return local_block_len // remote_block_len
+
+    def _build_dsa_transfer_lists(
+        self,
+        local_layout: list[list[tuple[int, int, int, int, int]]],
+        remote_base_addrs: list[list[int]],
+        remote_strides: list[list[int]],
+        remote_scales: list[list[int]],
+        remote_lens: list[list[int]],
+        source_block_ids: tuple[int, ...],
+        destination_block_ids: tuple[int, ...],
+        *,
+        allow_empty: bool = False,
+    ) -> tuple[list[int], list[int], list[int]]:
+        local_addresses: list[int] = []
+        remote_addresses: list[int] = []
+        lengths: list[int] = []
+        for layer_idx, layer_layout in enumerate(local_layout):
+            remote_n = (
+                len(remote_base_addrs[layer_idx])
+                if layer_idx < len(remote_base_addrs)
+                else 0
+            )
+            for position, base, block_len, stride, local_scale in layer_layout:
+                if position >= remote_n:
+                    continue
+                try:
+                    remote_base = remote_base_addrs[layer_idx][position]
+                    remote_stride = remote_strides[layer_idx][position]
+                    remote_scale = remote_scales[layer_idx][position]
+                    remote_len = remote_lens[layer_idx][position]
+                except IndexError as exc:
+                    raise ValueError(
+                        "incomplete DSA positional handshake arrays: "
+                        f"layer={layer_idx} position={position}"
+                    ) from exc
+                source_physical = self._expand_dsa_block_ids(
+                    source_block_ids, remote_scale
+                )
+                token_scale = self._dsa_indexer_token_scale(
+                    remote_block_len=remote_len,
+                    local_block_len=block_len,
+                )
+                if token_scale > 1:
+                    if not destination_block_ids:
+                        raise ValueError(
+                            "DSA Indexer destination blocks are empty"
+                        )
+                    max_src = len(destination_block_ids) * token_scale
+                    for index, source_id in enumerate(
+                        source_physical[:max_src]
+                    ):
+                        destination_id = destination_block_ids[
+                            index // token_scale
+                        ]
+                        page_slot = index % token_scale
+                        local_addresses.append(
+                            base
+                            + destination_id * block_len
+                            + page_slot * remote_len
+                        )
+                        remote_addresses.append(
+                            remote_base + source_id * remote_len
+                        )
+                        lengths.append(remote_len)
+                    continue
+                if block_len != remote_len:
+                    raise ValueError(
+                        "DSA positional block length mismatch: "
+                        f"local={block_len}, remote={remote_len}, "
+                        f"layer={layer_idx}, position={position}"
+                    )
+                destination_physical = self._expand_dsa_block_ids(
+                    destination_block_ids, local_scale
+                )
+                if len(source_physical) != len(destination_physical):
+                    raise ValueError(
+                        "DSA source/destination block coverage mismatch: "
+                        f"source={len(source_physical)}, "
+                        f"destination={len(destination_physical)}"
+                    )
+                for source_id, destination_id in zip(
+                    source_physical, destination_physical
+                ):
+                    local_addresses.append(
+                        base + destination_id * stride
+                    )
+                    remote_addresses.append(
+                        remote_base + source_id * remote_stride
+                    )
+                    lengths.append(block_len)
+        if not local_addresses and not allow_empty:
+            raise ValueError("DSA transfer phase must not be empty")
+        return local_addresses, remote_addresses, lengths
+
+    def _execute_dsa_receive(
+        self,
+        command: DsaStepRequest,
+        remote_endpoint: RemoteEndpoint,
+        on_result: Any,
+    ) -> None:
+        source = command.source
+        remote_engine_id = remote_endpoint.remote_engine_id
+        remote_host = remote_endpoint.remote_host
+        remote_port = remote_endpoint.remote_port
+        result_kind = DsaLocalResultKind.TRANSFER_FAILED
+        failure_phase: DsaTransferPhase | None = (
+            DsaTransferPhase.INDEXER_D2D
+        )
+        try:
+            if source is None:
+                raise ValueError("DSA receive requires a remote source")
+            with self.remote_metadata_lock:
+                has_metadata = (
+                    remote_engine_id in self.kv_caches_base_addr
+                    and remote_port
+                    in self.kv_caches_base_addr[remote_engine_id]
+                    and self.remote_metadata_hosts.get(
+                        remote_engine_id, {}
+                    ).get(remote_port)
+                    == remote_host
+                )
+            if not has_metadata:
+                self._get_remote_metadata(remote_host, remote_port)
+            with self.remote_metadata_lock:
+                if (
+                    remote_engine_id not in self.kv_caches_base_addr
+                    or remote_port
+                    not in self.kv_caches_base_addr[remote_engine_id]
+                    or self.remote_metadata_hosts.get(
+                        remote_engine_id, {}
+                    ).get(remote_port)
+                    != remote_host
+                ):
+                    raise ValueError(
+                        "DSA GET_META identity did not match endpoint "
+                        f"{remote_engine_id!r} at "
+                        f"{remote_host}:{remote_port}"
+                    )
+                remote_bases = self.kv_caches_base_addr[
+                    remote_engine_id
+                ][remote_port]
+                remote_strides = self.remote_block_stride_per_addr[
+                    remote_engine_id
+                ][remote_port]
+                remote_scales = self.remote_block_size_scale[
+                    remote_engine_id
+                ][remote_port]
+                remote_lens = self.remote_block_len_per_addr[
+                    remote_engine_id
+                ][remote_port]
+                remote_te_port = self.remote_te_port[
+                    remote_engine_id
+                ][remote_port]
+            session_id = f"{remote_host}:{remote_te_port}"
+            indexer_lists = self._build_dsa_transfer_lists(
+                self._dsa_indexer_local_layout,
+                remote_bases,
+                remote_strides,
+                remote_scales,
+                remote_lens,
+                source.indexer_block_ids,
+                command.indexer_hbm_block_ids,
+                allow_empty=True,
+            )
+            if (
+                indexer_lists[0]
+                and self.engine.batch_transfer_sync_read(
+                    session_id, *indexer_lists
+                )
+                < 0
+            ):
+                logger.error(
+                    "Blockwise DSA Indexer transfer failed: "
+                    "request_id=%s, entries=%s",
+                    command.request_id,
+                    len(indexer_lists[0]),
+                )
+            else:
+                failure_phase = DsaTransferPhase.MAIN_D2RH
+                if self._dsa_main_owner:
+                    main_lists = self._build_dsa_transfer_lists(
+                        self._dsa_main_local_layout,
+                        remote_bases,
+                        remote_strides,
+                        remote_scales,
+                        remote_lens,
+                        source.main_block_ids,
+                        command.main_host_block_ids,
+                    )
+                else:
+                    main_lists = ([], [], [])
+                if (
+                    main_lists[0]
+                    and self.engine.batch_transfer_sync_read(
+                        session_id, *main_lists
+                    )
+                    < 0
+                ):
+                    logger.error(
+                        "Blockwise DSA Main transfer failed: "
+                        "request_id=%s, entries=%s",
+                        command.request_id,
+                        len(main_lists[0]),
+                    )
+                else:
+                    result_kind = DsaLocalResultKind.RECEIVE_COMPLETE
+                    failure_phase = None
+        except Exception:
+            logger.exception(
+                "Blockwise DSA receive failed: request_id=%s, phase=%s",
+                command.request_id,
+                failure_phase,
+            )
+        finally:
+            if source is not None:
+                try:
+                    self._send_done_recv_signal(
+                        source.remote_request_id,
+                        remote_host,
+                        remote_port,
+                        {},
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to send blockwise DSA completion signal: "
+                        "request_id=%s",
+                        command.request_id,
+                    )
+        on_result(
+            DsaLocalResult(
+                command.request_id,
+                self.tp_rank,
+                result_kind,
+                failure_phase,
+            )
+        )
+
+    def _handle_dsa_request(self, request_data: dict[str, Any]) -> None:
+        on_result = request_data["dsa_on_result"]
+        try:
+            self._execute_dsa_receive(
+                request_data["dsa_command"],
+                request_data["dsa_remote_endpoint"],
+                on_result,
+            )
+        finally:
+            self.request_queue.task_done()
+
     def get_and_clear_finished_requests(self) -> set[str]:
         """
         Get and clear the requests that have been completed.
@@ -650,7 +1018,8 @@ class KVCacheRecvingThread(threading.Thread):
 
     def _submit_request(self, request_data: dict[str, Any]) -> None:
         peer_key = (request_data["remote_host"], request_data["remote_handshake_port"])
-        self._mark_request_task_submitted(request_data)
+        if "dsa_command" not in request_data:
+            self._mark_request_task_submitted(request_data)
         should_start_worker = False
         with self.peer_request_queues_lock:
             self.peer_request_queues[peer_key].append(request_data)
@@ -674,7 +1043,10 @@ class KVCacheRecvingThread(threading.Thread):
 
             requests_handled += 1
             try:
-                self._handle_request(req_meta)
+                if "dsa_command" in req_meta:
+                    self._handle_dsa_request(req_meta)
+                else:
+                    self._handle_request(req_meta)
             except Exception:
                 logger.exception(
                     "Error handling KV cache transfer request for peer %s:%d.",
@@ -1489,6 +1861,8 @@ class KVCacheRecvingThread(threading.Thread):
                 self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
                 self.remote_block_size_scale[engine_id][remote_handshake_port] = agent_meta.block_size_scale
                 self.remote_block_stride_per_addr[engine_id][remote_handshake_port] = agent_meta.block_strides
+                self.remote_block_len_per_addr[engine_id][remote_handshake_port] = agent_meta.block_lens
+                self.remote_metadata_hosts[engine_id][remote_handshake_port] = remote_host
         except Exception:
             if isinstance(sock, zmq.Socket):  # type: ignore
                 sock.close()
@@ -1605,6 +1979,227 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         )
 
 
+@dataclass(slots=True)
+class _DsaSchedulerRequest:
+    request: Any
+    source: RemoteSource
+    num_computed_tokens: int
+    num_external_tokens: int
+    main_block_ids: tuple[int, ...] = ()
+    indexer_hbm_block_ids: tuple[int, ...] = ()
+    command_emitted: bool = False
+    results_by_rank: dict[int, DsaLocalResult] = field(default_factory=dict)
+
+
+class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
+    """Build one-shot blockwise Mooncake receives for Decode workers."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig | None,
+    ) -> None:
+        super().__init__(vllm_config, True, kv_cache_config)
+        self._main_block_size = self.block_size[self.main_group_idx]
+        self._dsa_requests: dict[str, _DsaSchedulerRequest] = {}
+        prefill = vllm_config.kv_transfer_config.get_from_extra_config(
+            "prefill", {}
+        )
+        self._dsa_prefill_tp_size = int(prefill.get("tp_size", 0))
+        if self._dsa_prefill_tp_size <= 0:
+            raise ValueError(
+                "Blockwise DSA requires kv_connector_extra_config."
+                "prefill.tp_size"
+            )
+        self._expected_tp_ranks = frozenset(
+            range(vllm_config.parallel_config.tensor_parallel_size)
+        )
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        existing = self._dsa_requests.get(request.request_id)
+        if existing is not None:
+            return existing.num_external_tokens, True
+        params = request.kv_transfer_params
+        if params is None or not params.get("do_remote_prefill"):
+            return 0, False
+        prompt_tokens = len(request.prompt_token_ids or ())
+        external_tokens = max(prompt_tokens - num_computed_tokens, 0)
+        if external_tokens == 0:
+            return 0, False
+        remote_groups = tuple(
+            tuple(group) for group in params["remote_block_ids"]
+        )
+        if not remote_groups:
+            raise ValueError(
+                "remote_block_ids must contain at least one group"
+            )
+        source = RemoteSource(
+            remote_request_id=params["remote_request_id"],
+            endpoints_by_prefill_rank=_project_remote_endpoints(
+                remote_host=params["remote_host"],
+                remote_port=params["remote_port"],
+                remote_engine_id=params["remote_engine_id"],
+                remote_multi_nodes_meta_mapping=params.get(
+                    "remote_multi_nodes_meta_mapping"
+                ),
+                prefill_tp_size=self._dsa_prefill_tp_size,
+            ),
+            indexer_block_ids=(
+                remote_groups[0]
+                if len(remote_groups) == 1
+                else remote_groups[self.indexer_group_idx]
+            ),
+            main_block_ids=(
+                remote_groups[0]
+                if len(remote_groups) == 1
+                else remote_groups[self.main_group_idx]
+            ),
+        )
+        self._dsa_requests[request.request_id] = _DsaSchedulerRequest(
+            request=request,
+            source=source,
+            num_computed_tokens=num_computed_tokens,
+            num_external_tokens=external_tokens,
+        )
+        return external_tokens, True
+
+    def update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+    ) -> None:
+        tracker = self._dsa_requests.get(request.request_id)
+        if tracker is None:
+            return
+        groups = tuple(tuple(group) for group in blocks.get_block_ids())
+        required_group = max(self.main_group_idx, self.indexer_group_idx)
+        if len(groups) <= required_group:
+            raise ValueError(
+                "Blockwise DSA allocation is missing SFA KV cache groups: "
+                f"required={required_group + 1}, got={len(groups)}"
+            )
+        indexer_block_ids = groups[self.indexer_group_idx]
+        if not indexer_block_ids:
+            raise ValueError(
+                "Indexer destination block IDs must not be empty"
+            )
+        bound_tokens = tracker.num_computed_tokens + num_external_tokens
+        bound_blocks = cdiv(bound_tokens, self._main_block_size)
+        main_block_ids = groups[self.main_group_idx]
+        if bound_blocks > len(main_block_ids):
+            raise ValueError(
+                "vLLM has not allocated enough Main Host blocks"
+            )
+        tracker.indexer_hbm_block_ids = indexer_block_ids
+        tracker.main_block_ids = main_block_ids[:bound_blocks]
+        if isinstance(request.kv_transfer_params, dict):
+            request.kv_transfer_params["do_remote_prefill"] = False
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> DsaConnectorMetadata:
+        del scheduler_output
+        requests: list[DsaStepRequest] = []
+        for request_id in sorted(self._dsa_requests):
+            tracker = self._dsa_requests[request_id]
+            if (
+                tracker.command_emitted
+                or not tracker.indexer_hbm_block_ids
+                or not tracker.main_block_ids
+            ):
+                continue
+            requests.append(
+                DsaStepRequest(
+                    request_id=request_id,
+                    source=tracker.source,
+                    main_host_block_ids=tracker.main_block_ids,
+                    indexer_hbm_block_ids=tracker.indexer_hbm_block_ids,
+                )
+            )
+            tracker.command_emitted = True
+        return DsaConnectorMetadata(tuple(requests))
+
+    def update_connector_output(self, connector_output: Any) -> None:
+        metadata = connector_output.kv_connector_worker_meta
+        if metadata is None:
+            return
+        if not isinstance(metadata, DsaWorkerResultMetadata):
+            raise TypeError(
+                "kv_connector_worker_meta must be "
+                "DsaWorkerResultMetadata"
+            )
+        completed: list[str] = []
+        for result in metadata.results:
+            tracker = self._dsa_requests.get(result.request_id)
+            if tracker is None:
+                logger.warning_once(
+                    "Ignoring DSA result for released request %r",
+                    result.request_id,
+                )
+                continue
+            if result.tp_rank not in self._expected_tp_ranks:
+                raise ValueError(
+                    f"illegal Decode TP rank {result.tp_rank}"
+                )
+            existing = tracker.results_by_rank.get(result.tp_rank)
+            if existing is not None:
+                if existing != result:
+                    raise ValueError(
+                        f"conflicting DSA result for {result.identity}"
+                    )
+                continue
+            tracker.results_by_rank[result.tp_rank] = result
+            if set(tracker.results_by_rank) != self._expected_tp_ranks:
+                continue
+            if any(
+                item.kind is DsaLocalResultKind.TRANSFER_FAILED
+                for item in tracker.results_by_rank.values()
+            ):
+                tracker.request.num_computed_tokens = 0
+                logger.error(
+                    "Blockwise DSA receive failed for %s; "
+                    "falling back to local recompute",
+                    result.request_id,
+                )
+            completed.append(result.request_id)
+        if completed:
+            finished = set(connector_output.finished_recving or ())
+            finished.update(completed)
+            connector_output.finished_recving = finished
+            for request_id in completed:
+                self._dsa_requests.pop(request_id, None)
+
+    def set_xfer_handshake_metadata(
+        self,
+        metadata: Mapping[
+            int | tuple[int, ...], KVConnectorHandshakeMetadata
+        ],
+    ) -> None:
+        del metadata
+
+    def set_xfer_handshake_metadata_from_workers(
+        self,
+        metadata: Mapping[
+            int | tuple[int, ...], KVConnectorHandshakeMetadata
+        ],
+    ) -> None:
+        del metadata
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: Any,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        del block_ids
+        return request.request_id in self._dsa_requests, None
+
+
 class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def __init__(  # type: ignore[misc]
         self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None
@@ -1612,12 +2207,74 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config is not None
         self._kv_transfer_config = vllm_config.kv_transfer_config
         self.engine_id = vllm_config.kv_transfer_config.engine_id
+        self._dsa_pd_offload = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "dsa_pd_offload", False
+            )
+        )
+        if not isinstance(self._dsa_pd_offload, bool):
+            raise ValueError(
+                "kv_connector_extra_config.dsa_pd_offload must be bool"
+            )
+        self._dsa_decode = (
+            self._dsa_pd_offload
+            and vllm_config.kv_transfer_config.kv_role == "kv_consumer"
+        )
+        if self._dsa_pd_offload:
+            kv_role = vllm_config.kv_transfer_config.kv_role
+            if kv_role not in ("kv_producer", "kv_consumer"):
+                raise ValueError(
+                    "Blockwise DSA requires kv_role='kv_producer' or "
+                    "kv_role='kv_consumer'"
+                )
+            prefill = vllm_config.kv_transfer_config.get_from_extra_config(
+                "prefill", {}
+            )
+            decode = vllm_config.kv_transfer_config.get_from_extra_config(
+                "decode", {}
+            )
+            prefill_tp = int(prefill.get("tp_size", 0))
+            decode_tp = int(decode.get("tp_size", 0))
+            if (
+                prefill_tp <= 0
+                or decode_tp <= 0
+                or prefill_tp < decode_tp
+                or prefill_tp % decode_tp
+            ):
+                raise ValueError(
+                    "Blockwise DSA currently requires positive P_TP/D_TP "
+                    "with P_TP >= D_TP and P_TP % D_TP == 0"
+                )
+            init_ascend_config(vllm_config)
+            offload = get_ascend_config().sparse_kv_offload_config
+            if kv_role == "kv_producer" and offload.enabled:
+                raise ValueError(
+                    "Blockwise DSA Prefill requires sparse KV offload disabled"
+                )
+            if kv_role == "kv_consumer":
+                if not offload.enabled:
+                    raise ValueError(
+                        "Blockwise DSA Decode requires sparse KV offload enabled"
+                    )
+                if not offload.use_fused_overlap:
+                    raise ValueError(
+                        "Blockwise DSA Decode requires fused overlap"
+                    )
+                if offload.host_backend != "mooncake":
+                    raise ValueError(
+                        "Blockwise DSA Decode requires host_backend='mooncake'"
+                    )
         self._connector_metadata = MooncakeConnectorMetadata()
 
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler: MooncakeConnectorScheduler | None = MooncakeConnectorScheduler(
-                vllm_config, str(self.engine_id), kv_cache_config
-            )
+            if self._dsa_decode:
+                self.connector_scheduler = _MooncakeDsaDecodeScheduler(
+                    vllm_config, kv_cache_config
+                )
+            else:
+                self.connector_scheduler = MooncakeConnectorScheduler(
+                    vllm_config, str(self.engine_id), kv_cache_config
+                )
             self.connector_worker: MooncakeConnectorWorker | None = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
@@ -1641,6 +2298,13 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> KVConnectorMetadata:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def update_connector_output(self, connector_output: Any) -> None:
+        assert self.connector_scheduler is not None
+        if isinstance(
+            self.connector_scheduler, _MooncakeDsaDecodeScheduler
+        ):
+            self.connector_scheduler.update_connector_output(connector_output)
 
     def request_finished(
         self,
@@ -1668,7 +2332,7 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
         """Get the finished recving and sending requests."""
         assert self.connector_worker is not None
-        return self.connector_worker.get_finished()
+        return self.connector_worker.get_finished(finished_req_ids)
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         """Get the block ids whose KV load failed."""
@@ -1677,8 +2341,23 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
-        assert isinstance(self._connector_metadata, MooncakeConnectorMetadata)
+        if self._dsa_decode:
+            assert isinstance(
+                self._connector_metadata, DsaConnectorMetadata
+            )
+        else:
+            assert isinstance(
+                self._connector_metadata, MooncakeConnectorMetadata
+            )
         self.connector_worker.start_load_kv(self._connector_metadata)
+
+    def build_connector_worker_meta(
+        self,
+    ) -> DsaWorkerResultMetadata | None:
+        if not self._dsa_decode:
+            return None
+        assert self.connector_worker is not None
+        return self.connector_worker.build_connector_worker_meta()
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """MooncakeConnector does not do layerwise saving."""
@@ -2203,6 +2882,19 @@ class MooncakeConnectorWorker:
             self.tp_num_need_pulls = num_d_block_heads // num_p_block_heads
         self.local_remote_block_port_mapping: dict[str, list[list[int]] | None] = {}
         self.remote_port_send_num: dict[str, dict[int, RemotePortInfo]] = {}
+        self._dsa_pd_offload = (
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "dsa_pd_offload", False
+            )
+        )
+        self._dsa_decode = (
+            self._dsa_pd_offload and self.kv_role == "kv_consumer"
+        )
+        if self._dsa_decode:
+            self._dsa_active_commands: dict[str, DsaStepRequest] = {}
+            self._dsa_results: queue.SimpleQueue[DsaLocalResult] = (
+                queue.SimpleQueue()
+            )
 
     def _get_prefill_decode_size(self, vllm_config: VllmConfig):
         # get prefill tp and dp size from extra config
@@ -2567,6 +3259,90 @@ class MooncakeConnectorWorker:
 
         return ptrs, lengths
 
+    def _dsa_consumer_device_register_regions(
+        self, kv_caches: dict[str, torch.Tensor]
+    ) -> RegisterRegions:
+        indexer_caches = {
+            name: self._as_kv_cache_tuple(cache)
+            for name, cache in kv_caches.items()
+            if "indexer" in name.lower()
+        }
+        if not indexer_caches:
+            raise ValueError(
+                "Blockwise DSA Decode has no Indexer device cache"
+            )
+        return collect_storage_merged_register_regions(indexer_caches)
+
+    def _build_dsa_local_layouts(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        layer_name_to_idx: dict[str, int],
+    ) -> tuple[
+        list[list[tuple[int, int, int, int, int]]],
+        list[list[tuple[int, int, int, int, int]]],
+        bool,
+    ]:
+        manager = get_sparse_kv_offload_manager()
+        pool = manager.get_mooncake_host_pool()
+        layer_count = len(self.kv_caches_base_addr)
+        indexer_layout = [[] for _ in range(layer_count)]
+        main_layout = [[] for _ in range(layer_count)]
+
+        def tensor_entry(
+            position: int,
+            tensor: torch.Tensor,
+            require_exact_capacity: bool,
+        ) -> tuple[int, int, int, int, int]:
+            tensor_blocks = int(tensor.shape[0])
+            if require_exact_capacity and tensor_blocks != self.num_blocks:
+                raise RuntimeError(
+                    "Mooncake Host Main capacity must match "
+                    f"kv_cache_config: tensor_blocks={tensor_blocks}, "
+                    f"configured_blocks={self.num_blocks}"
+                )
+            if tensor_blocks % self.num_blocks:
+                raise ValueError(
+                    "DSA tensor block count must be divisible by "
+                    "kv_cache_config.num_blocks"
+                )
+            return (
+                position,
+                tensor.data_ptr(),
+                tensor.element_size() * math.prod(tensor.shape[1:]),
+                tensor.stride(0) * tensor.element_size(),
+                tensor_blocks // self.num_blocks,
+            )
+
+        for layer_name, cache in kv_caches.items():
+            if "indexer" not in layer_name.lower():
+                continue
+            layer_idx = layer_name_to_idx[layer_name]
+            for position, tensor in enumerate(
+                self._as_kv_cache_tuple(cache)
+            ):
+                indexer_layout[layer_idx].append(
+                    tensor_entry(position, tensor, False)
+                )
+        if not any(indexer_layout):
+            raise ValueError(
+                "Blockwise DSA Decode has no Indexer layout"
+            )
+
+        if pool.is_owner:
+            pool.register(self.engine)
+            for layer_name in manager.offload_layer_names:
+                layer_idx = layer_name_to_idx[layer_name]
+                host_k, host_v = (
+                    manager.get_fused_overlap_cpu_kv_inputs(layer_name)
+                )
+                main_layout[layer_idx].extend(
+                    (
+                        tensor_entry(0, host_k, True),
+                        tensor_entry(1, host_v, True),
+                    )
+                )
+        return indexer_layout, main_layout, pool.is_owner
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data."""
         self.use_mla = self.vllm_config.model_config.is_deepseek_mla
@@ -2606,6 +3382,8 @@ class MooncakeConnectorWorker:
         # TODO: For DSV4 use_compress, metadata/transfer can be optimized by
         # aggregating layer views that share the same raw KVCacheTensor.
         for layer_name, kv_cache_tuple in kv_caches.items():
+            if self._dsa_decode and "indexer" not in layer_name.lower():
+                continue
             layer_idx = layer_name_to_idx[layer_name]
             for single_kv_cache in self._as_kv_cache_tuple(kv_cache_tuple):
                 tensor_num_blocks = single_kv_cache.shape[0]
@@ -2617,9 +3395,19 @@ class MooncakeConnectorWorker:
                 self.block_size_scale[layer_idx].append(block_size_scale)
                 self.kv_caches_base_addr[layer_idx].append(single_kv_cache.data_ptr())
 
+        dsa_local_layouts = None
+        if self._dsa_decode:
+            dsa_local_layouts = self._build_dsa_local_layouts(
+                kv_caches, layer_name_to_idx
+            )
+
         if has_mamba_group:
             ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
+        elif self._dsa_decode:
+            register_regions = (
+                self._dsa_consumer_device_register_regions(kv_caches)
+            )
         elif self.use_hybrid:
             ptrs, lengths = self._get_registered_kv_tensor_buffers_hybrid(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
@@ -2696,6 +3484,12 @@ class MooncakeConnectorWorker:
                 self.kv_group2layeridx,
                 self.block_size_scale,
             )
+            if dsa_local_layouts is not None:
+                (
+                    self.kv_recv_thread._dsa_indexer_local_layout,
+                    self.kv_recv_thread._dsa_main_local_layout,
+                    self.kv_recv_thread._dsa_main_owner,
+                ) = dsa_local_layouts
             self.kv_recv_thread.start()
         start_wait_time = time.time()
         thread = self.kv_send_thread if self.kv_role == "kv_producer" else self.kv_recv_thread
@@ -2707,7 +3501,12 @@ class MooncakeConnectorWorker:
                 raise RuntimeError("Timeout waiting for KV Cache thread to be ready.")
             time.sleep(3)
 
-    def get_finished(self) -> tuple[set[str], set[str]]:
+    def get_finished(
+        self, finished_req_ids: set[str] | None = None
+    ) -> tuple[set[str], set[str]]:
+        if self._dsa_decode:
+            for request_id in finished_req_ids or ():
+                self._dsa_active_commands.pop(request_id, None)
         done_sending = (
             self.kv_send_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
             )
@@ -3694,8 +4493,14 @@ class MooncakeConnectorWorker:
 
         return (local_block_ids,), (remote_block_ids,)
 
-    def start_load_kv(self, metadata: MooncakeConnectorMetadata):
+    def start_load_kv(
+        self,
+        metadata: MooncakeConnectorMetadata | DsaConnectorMetadata,
+    ):
         """Start loading KV blocks from remote engine."""
+        if isinstance(metadata, DsaConnectorMetadata):
+            self._dispatch_dsa_commands(metadata.requests)
+            return
         for req_id in metadata.reqs_in_batch:
             if self.kv_send_thread is not None:
                 self.kv_send_thread.task_tracker.add_req_to_process(req_id)
@@ -3791,7 +4596,16 @@ class MooncakeConnectorWorker:
 
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size == 1:
             for req_id, delay_start_time in metadata.requests_to_send.items():
-                if self.tp_rank in self._prefill_get_remote_rank(req_id):
+                source_ranks = (
+                    range(
+                        0,
+                        self._prefill_tp_size,
+                        self._prefill_tp_size // self._decode_tp_size,
+                    )
+                    if self._dsa_pd_offload
+                    else self._prefill_get_remote_rank(req_id)
+                )
+                if self.tp_rank in source_ranks:
                     self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
                 else:
                     self.kv_send_thread.add_not_transfer_request(req_id)
@@ -3799,6 +4613,67 @@ class MooncakeConnectorWorker:
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size > 1:
             for req_id, delay_start_time in metadata.requests_to_send.items():
                 self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
+
+    def _dispatch_dsa_commands(
+        self,
+        commands: tuple[DsaStepRequest, ...],
+    ) -> None:
+        if not self._dsa_decode:
+            raise RuntimeError(
+                "DSA commands are valid only on the Decode consumer"
+            )
+        for command in commands:
+            existing = self._dsa_active_commands.get(
+                command.request_id
+            )
+            if existing is not None:
+                if existing != command:
+                    raise ValueError(
+                        "conflicting blockwise DSA receive for "
+                        f"{command.request_id!r}"
+                    )
+                continue
+            leader_rank = self.tp_rank * (
+                self._prefill_tp_size // self._decode_tp_size
+            )
+            endpoints = command.source.endpoints_by_prefill_rank
+            if len(endpoints) != self._prefill_tp_size:
+                raise ValueError(
+                    "DSA endpoint tuple must contain "
+                    f"{self._prefill_tp_size} Prefill ranks"
+                )
+            self._dsa_active_commands[command.request_id] = command
+            assert self.kv_recv_thread is not None
+            self.kv_recv_thread.add_dsa_request(
+                command,
+                endpoints[leader_rank],
+                lambda result, request=command: (
+                    self._finish_dsa_receive(request, result)
+                ),
+            )
+
+    def _finish_dsa_receive(
+        self,
+        command: DsaStepRequest,
+        result: DsaLocalResult,
+    ) -> None:
+        if self._dsa_active_commands.get(command.request_id) != command:
+            return
+        self._dsa_active_commands.pop(command.request_id, None)
+        self._dsa_results.put(result)
+
+    def build_connector_worker_meta(
+        self,
+    ) -> DsaWorkerResultMetadata | None:
+        results: list[DsaLocalResult] = []
+        while True:
+            try:
+                results.append(self._dsa_results.get_nowait())
+            except queue.Empty:
+                break
+        if not results:
+            return None
+        return DsaWorkerResultMetadata(tuple(results))
 
     def _get_tp_num_need_pulls(self, prefill_tp_size: int | None) -> int:
         if prefill_tp_size is None:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -382,8 +382,13 @@ class KVCacheSendingThread(threading.Thread):
         self.kv_caches = kv_caches
         self.pcp_rank = pcp_rank
         self.port_send_num: dict[str, int] = {}
+        self._stop_event = threading.Event()
 
         self.task_tracker = KVCacheTaskTracker()
+
+    def stop(self) -> None:
+        """Stop serving metadata before its registered buffers are released."""
+        self._stop_event.set()
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -438,8 +443,10 @@ class KVCacheSendingThread(threading.Thread):
             logger.debug("Size of encoded MooncakeAgentMetadata: %s bytes", str(size_in_bytes))
 
         decoder = msgspec.msgpack.Decoder(type=tuple)
-        while True:
+        while not self._stop_event.is_set():
             try:
+                if not sock.poll(timeout=100):
+                    continue
                 frames = sock.recv_multipart()
                 if len(frames) < 2:
                     logger.error(
@@ -493,7 +500,7 @@ class KVCacheSendingThread(threading.Thread):
                     else:
                         self.task_tracker.update_done_task_count(request_id)
                     # Acknowledge the request completion.
-                    while True:
+                    while not self._stop_event.is_set():
                         try:
                             # Send ACK to the sender.
                             sock.send_multipart((identity, b"", b"ACK"), flags=zmq.NOBLOCK)  # type: ignore
@@ -2809,6 +2816,8 @@ class MooncakeConnectorWorker:
             self._dsa_active_commands: dict[str, DsaStepRequest] = {}
             self._dsa_cancel_events: dict[str, threading.Event] = {}
             self._dsa_results: queue.SimpleQueue[DsaLocalResult] = queue.SimpleQueue()
+            self._dsa_dispatch_lock = threading.Lock()
+            self._closing = False
 
     def _get_prefill_decode_size(self, vllm_config: VllmConfig):
         # get prefill tp and dp size from extra config
@@ -4528,14 +4537,20 @@ class MooncakeConnectorWorker:
                 self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
 
     def shutdown(self) -> None:
-        self._closing = True
-        if self.kv_recv_thread is not None:
-            self.kv_recv_thread.request_queue.join()
-            self.kv_recv_thread.request_queue.put(None)
-            self.kv_recv_thread.join()
-            self.kv_recv_thread.executor.shutdown(wait=True)
-            if self._dsa_decode:
-                get_sparse_kv_offload_manager().get_mooncake_host_pool().unregister()
+        if self._dsa_decode:
+            with self._dsa_dispatch_lock:
+                self._closing = True
+        try:
+            if self.kv_send_thread is not None:
+                self.kv_send_thread.stop()
+                self.kv_send_thread.join()
+            if self.kv_recv_thread is not None:
+                self.kv_recv_thread.request_queue.join()
+                self.kv_recv_thread.request_queue.put(None)
+                self.kv_recv_thread.join()
+                self.kv_recv_thread.executor.shutdown(wait=True)
+        finally:
+            global_te.unregister_buffer()
 
     def _plan_dsa_endpoints(self, command: DsaStepRequest):
         """Adapt ordinary source participants; writer filtering cannot remove tasks."""
@@ -4597,8 +4612,14 @@ class MooncakeConnectorWorker:
         return tasks
 
     def _dispatch_dsa_commands(self, commands: tuple[DsaStepRequest, ...]) -> None:
-        if not self._dsa_decode or getattr(self, "_closing", False):
+        if not self._dsa_decode:
             raise RuntimeError("DSA commands require an active Decode consumer")
+        with self._dsa_dispatch_lock:
+            if self._closing:
+                raise RuntimeError("DSA commands require an active Decode consumer")
+            self._enqueue_dsa_commands(commands)
+
+    def _enqueue_dsa_commands(self, commands: tuple[DsaStepRequest, ...]) -> None:
         for command in commands:
             existing = self._dsa_active_commands.get(command.request_id)
             if existing is not None:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -13,7 +13,7 @@ import time
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import msgspec
@@ -95,6 +95,7 @@ from .mooncake_dsa_metadata import (
     RemoteEndpoint,
     RemoteSource,
 )
+from .mooncake_dsa_transfer import DsaCacheLayout, build_component_read
 
 # isort: off
 if TYPE_CHECKING:
@@ -191,6 +192,7 @@ class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     block_strides: list[list[int]]
     local_ip: str = ""
     handshake_port: int = 0
+    cache_dtypes: list[list[str]] = []
 
 
 @dataclass
@@ -262,12 +264,14 @@ class KVCacheTaskTracker:
         # be force-freed.
         self.delayed_free_requests: OrderedDict[str, float] = OrderedDict()
         self.reqs_to_process: set[str] = set()
+        self.received_participants: dict[str, tuple[int, set[str]]] = {}
 
     def add_req_to_process(self, request_id: str):
         self.reqs_to_process.add(request_id)
 
     def add_not_transfer_request(self, request_id: str):
         with self.done_task_lock:
+            self.received_participants.pop(request_id, None)
             self.finished_requests.add(request_id)
             self.reqs_to_process.discard(request_id)
 
@@ -277,6 +281,7 @@ class KVCacheTaskTracker:
                 self.finished_requests.add(request_id)
                 self.reqs_to_process.discard(request_id)
                 self.delayed_free_requests.pop(request_id, None)
+                self.received_participants.pop(request_id, None)
             else:
                 logger.warning(
                     "MooncakeConnector finish req not in reqs to process. "
@@ -305,6 +310,24 @@ class KVCacheTaskTracker:
             if request_id in self.reqs_to_process:
                 self.delayed_free_requests[request_id] = delay_start_time
 
+    def record_participant_done(self, request_id: str, participant: str, expected: int) -> None:
+        """Idempotent done counting within the existing tracker lifecycle."""
+        if not participant or expected < 0:
+            raise ValueError("invalid DSA completion participant/count")
+        expected = max(expected, 1)  # designated zero-reader cleanup
+        with self.done_task_lock:
+            if request_id not in self.reqs_to_process:
+                return  # late messages must not recreate completed/expired state
+            count, seen = self.received_participants.setdefault(request_id, (expected, set()))
+            if count != expected:
+                raise ValueError("DSA expected notification count changed")
+            seen.add(participant)
+            if len(seen) == expected:
+                self.finished_requests.add(request_id)
+                self.reqs_to_process.discard(request_id)
+                self.delayed_free_requests.pop(request_id, None)
+                self.received_participants.pop(request_id, None)
+
     def _retrieve_expired_requests(self):
         """Retrieve all expired delayed requests."""
         expired_requests: set[str] = set()
@@ -315,6 +338,7 @@ class KVCacheTaskTracker:
             delay_start_time = self.delayed_free_requests[request_id]
             if current_time - delay_start_time > envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT:
                 self.delayed_free_requests.popitem(last=False)
+                self.received_participants.pop(request_id, None)
                 self.reqs_to_process.discard(request_id)
                 expired_requests.add(request_id)
                 logger.error(
@@ -450,7 +474,14 @@ class KVCacheSendingThread(threading.Thread):
                     logger.debug("Got DONE_RECVING_MSG for request %s", msg[1])
                     request_id = msg[1]
                     remote_port_send_num = msg[2]
-                    if remote_port_send_num:
+                    if len(msg) > 3:
+                        handshake_port = self.metadata.handshake_port
+                        self.task_tracker.record_participant_done(
+                            request_id,
+                            msg[3],
+                            remote_port_send_num[handshake_port]["num"],
+                        )
+                    elif remote_port_send_num:
                         if request_id not in self.port_send_num:
                             self.port_send_num[request_id] = 0
                         self.port_send_num[request_id] += 1
@@ -551,6 +582,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.remote_block_stride_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_block_len_per_addr: dict[str, dict[int, list[list[int]]]] = SizedDict()
         self.remote_metadata_hosts: dict[str, dict[int, str]] = SizedDict()
+        self.remote_cache_dtypes = SizedDict()
+        self.remote_num_blocks = SizedDict()
         self.remote_kv_group2layeridx: dict[str, dict[int, dict[int, tuple[dict[str, Any], list[int]]]]] = SizedDict()
         self.remote_metadata_lock = threading.Lock()
         # Reformat metadata keyed by request_id then CP shard index. Populated by the
@@ -626,6 +659,7 @@ class KVCacheRecvingThread(threading.Thread):
         self.proc_not_transfer_request: dict[str, bool] = {}
         self.proc_not_transfer_request_lock = threading.Lock()
         self.failed_recv_requests: set[str] = set()
+        self.dsa_failure_phases: dict[str, DsaTransferPhase] = {}
         self.invalid_block_ids: set[int] = set()
         self.failed_recv_requests_lock = threading.Lock()
 
@@ -689,289 +723,174 @@ class KVCacheRecvingThread(threading.Thread):
         command: DsaStepRequest,
         remote_endpoint: RemoteEndpoint,
         on_result: Any,
+        *,
+        cp_rank: int,
+        pp_rank: int,
+        include_indexer: bool,
+        expected: int,
+        participant: str,
+        cancelled: threading.Event,
+        all_task_done: bool,
     ) -> None:
         self.request_queue.put(
-            {
-                "request_id": command.request_id,
-                "remote_host": remote_endpoint.remote_host,
-                "remote_handshake_port": remote_endpoint.remote_port,
-                "dsa_command": command,
-                "dsa_remote_endpoint": remote_endpoint,
-                "dsa_on_result": on_result,
+            dict(
+                request_id=command.request_id,
+                remote_host=remote_endpoint.remote_host,
+                remote_handshake_port=remote_endpoint.remote_port,
+                dsa_command=command,
+                dsa_remote_endpoint=remote_endpoint,
+                dsa_on_result=on_result,
+                cp_rank=cp_rank,
+                pp_rank=pp_rank,
+                include_indexer=include_indexer,
+                expected=expected,
+                participant=participant,
+                cancelled=cancelled,
+                all_task_done=all_task_done,
+            )
+        )
+
+    def _execute_dsa_receive(self, task: dict[str, Any]) -> None:
+        command = task["dsa_command"]
+        if command.notify_only or task["expected"] == 0 or task["cancelled"].is_set():
+            return
+        endpoint = task["dsa_remote_endpoint"]
+        engine_id, port, host = endpoint.remote_engine_id, endpoint.remote_port, endpoint.remote_host
+        with self.remote_metadata_lock:
+            has_metadata = self.remote_metadata_hosts.get(engine_id, {}).get(port) == host
+        if not has_metadata:
+            self._get_remote_metadata(host, port)
+        with self.remote_metadata_lock:
+            if self.remote_metadata_hosts.get(engine_id, {}).get(port) != host:
+                raise ValueError("DSA GET_META identity does not match endpoint")
+            groups = self.remote_kv_group2layeridx[engine_id][port]
+            layers = build_layer_name_to_metadata_idx(groups)
+            remote_groups = {
+                name: spec.get("kv_cache_group_id", group_id)
+                for group_id, (spec, _) in groups.items()
+                for name in spec.get("layer_names", ())
             }
-        )
-
-    @staticmethod
-    def _expand_dsa_block_ids(
-        block_ids: tuple[int, ...], scale: int
-    ) -> list[int]:
-        if scale <= 0:
-            raise ValueError(
-                "DSA positional block scale must be positive"
-            )
-        return [
-            block_id * scale + offset
-            for block_id in block_ids
-            for offset in range(scale)
-        ]
-
-    @staticmethod
-    def _dsa_indexer_token_scale(
-        *, remote_block_len: int, local_block_len: int
-    ) -> int:
-        if (
-            remote_block_len <= 0
-            or local_block_len <= 0
-            or local_block_len % remote_block_len
-        ):
-            return 1
-        return local_block_len // remote_block_len
-
-    def _build_dsa_transfer_lists(
-        self,
-        local_layout: list[list[tuple[int, int, int, int, int]]],
-        remote_base_addrs: list[list[int]],
-        remote_strides: list[list[int]],
-        remote_scales: list[list[int]],
-        remote_lens: list[list[int]],
-        source_block_ids: tuple[int, ...],
-        destination_block_ids: tuple[int, ...],
-        *,
-        allow_empty: bool = False,
-    ) -> tuple[list[int], list[int], list[int]]:
-        local_addresses: list[int] = []
-        remote_addresses: list[int] = []
-        lengths: list[int] = []
-        for layer_idx, layer_layout in enumerate(local_layout):
-            remote_n = (
-                len(remote_base_addrs[layer_idx])
-                if layer_idx < len(remote_base_addrs)
-                else 0
-            )
-            for position, base, block_len, stride, local_scale in layer_layout:
-                if position >= remote_n:
-                    continue
-                try:
-                    remote_base = remote_base_addrs[layer_idx][position]
-                    remote_stride = remote_strides[layer_idx][position]
-                    remote_scale = remote_scales[layer_idx][position]
-                    remote_len = remote_lens[layer_idx][position]
-                except IndexError as exc:
-                    raise ValueError(
-                        "incomplete DSA positional handshake arrays: "
-                        f"layer={layer_idx} position={position}"
-                    ) from exc
-                source_physical = self._expand_dsa_block_ids(
-                    source_block_ids, remote_scale
-                )
-                token_scale = self._dsa_indexer_token_scale(
-                    remote_block_len=remote_len,
-                    local_block_len=block_len,
-                )
-                if token_scale > 1:
-                    if not destination_block_ids:
-                        raise ValueError(
-                            "DSA Indexer destination blocks are empty"
-                        )
-                    max_src = len(destination_block_ids) * token_scale
-                    for index, source_id in enumerate(
-                        source_physical[:max_src]
-                    ):
-                        destination_id = destination_block_ids[
-                            index // token_scale
-                        ]
-                        page_slot = index % token_scale
-                        local_addresses.append(
-                            base
-                            + destination_id * block_len
-                            + page_slot * remote_len
-                        )
-                        remote_addresses.append(
-                            remote_base + source_id * remote_len
-                        )
-                        lengths.append(remote_len)
-                    continue
-                if block_len != remote_len:
-                    raise ValueError(
-                        "DSA positional block length mismatch: "
-                        f"local={block_len}, remote={remote_len}, "
-                        f"layer={layer_idx}, position={position}"
-                    )
-                destination_physical = self._expand_dsa_block_ids(
-                    destination_block_ids, local_scale
-                )
-                if len(source_physical) != len(destination_physical):
-                    raise ValueError(
-                        "DSA source/destination block coverage mismatch: "
-                        f"source={len(source_physical)}, "
-                        f"destination={len(destination_physical)}"
-                    )
-                for source_id, destination_id in zip(
-                    source_physical, destination_physical
-                ):
-                    local_addresses.append(
-                        base + destination_id * stride
-                    )
-                    remote_addresses.append(
-                        remote_base + source_id * remote_stride
-                    )
-                    lengths.append(block_len)
-        if not local_addresses and not allow_empty:
-            raise ValueError("DSA transfer phase must not be empty")
-        return local_addresses, remote_addresses, lengths
-
-    def _execute_dsa_receive(
-        self,
-        command: DsaStepRequest,
-        remote_endpoint: RemoteEndpoint,
-        on_result: Any,
-    ) -> None:
+            bases = self.kv_caches_base_addr[engine_id][port]
+            strides = self.remote_block_stride_per_addr[engine_id][port]
+            scales = self.remote_block_size_scale[engine_id][port]
+            lengths = self.remote_block_len_per_addr[engine_id][port]
+            dtypes = self.remote_cache_dtypes[engine_id][port]
+            remote_capacity = self.remote_num_blocks[engine_id][port]
+            if remote_capacity <= 0:
+                raise ValueError("DSA handshake requires positive registered capacity")
+            session = f"{host}:{self.remote_te_port[engine_id][port]}"
         source = command.source
-        remote_engine_id = remote_endpoint.remote_engine_id
-        remote_host = remote_endpoint.remote_host
-        remote_port = remote_endpoint.remote_port
-        result_kind = DsaLocalResultKind.TRANSFER_FAILED
-        failure_phase: DsaTransferPhase | None = (
-            DsaTransferPhase.INDEXER_D2D
-        )
-        try:
-            if source is None:
-                raise ValueError("DSA receive requires a remote source")
-            with self.remote_metadata_lock:
-                has_metadata = (
-                    remote_engine_id in self.kv_caches_base_addr
-                    and remote_port
-                    in self.kv_caches_base_addr[remote_engine_id]
-                    and self.remote_metadata_hosts.get(
-                        remote_engine_id, {}
-                    ).get(remote_port)
-                    == remote_host
+        start = source.num_computed_tokens
+        end = start + source.num_external_tokens
+        first, last = self.pp_layer_indices[task["pp_rank"]]
+        if task["pp_rank"] == self._prefill_pp_size - 1:
+            last += self.num_draft_layers
+        # Assemble both phases before Transfer Engine submission so missing components cannot
+        # silently yield a partial successful transfer. No device reformat for Host.
+        plans = []
+        for indexer, layout in ((True, self._dsa_indexer_local_layout), (False, self._dsa_main_local_layout)):
+            if indexer and not task["include_indexer"]:
+                continue
+            combined = ([], [], [])
+            statistics = {}
+            for local in layout:
+                transformer_layer = self._dsa_transformer_layers[local.layer_name]
+                if not first <= transformer_layer < last:
+                    continue
+                if local.layer_name not in layers:
+                    raise ValueError(f"missing DSA remote component {local.layer_name}")
+                expected_group = source.remote_indexer_group_id if indexer else source.remote_main_group_id
+                if expected_group is not None and remote_groups[local.layer_name] != expected_group:
+                    raise ValueError(f"DSA remote cache-group identity mismatch: {local.layer_name}")
+                remote_layer = layers[local.layer_name]
+                position = local.position
+                remote = DsaCacheLayout(
+                    local.layer_name,
+                    position,
+                    bases[remote_layer][position],
+                    lengths[remote_layer][position],
+                    strides[remote_layer][position],
+                    scales[remote_layer][position],
+                    (source.remote_indexer_block_size if indexer else source.remote_main_block_size)
+                    or source.remote_block_size,
+                    dtypes[remote_layer][position],
+                    remote_capacity,
                 )
-            if not has_metadata:
-                self._get_remote_metadata(remote_host, remote_port)
-            with self.remote_metadata_lock:
-                if (
-                    remote_engine_id not in self.kv_caches_base_addr
-                    or remote_port
-                    not in self.kv_caches_base_addr[remote_engine_id]
-                    or self.remote_metadata_hosts.get(
-                        remote_engine_id, {}
-                    ).get(remote_port)
-                    != remote_host
-                ):
-                    raise ValueError(
-                        "DSA GET_META identity did not match endpoint "
-                        f"{remote_engine_id!r} at "
-                        f"{remote_host}:{remote_port}"
-                    )
-                remote_bases = self.kv_caches_base_addr[
-                    remote_engine_id
-                ][remote_port]
-                remote_strides = self.remote_block_stride_per_addr[
-                    remote_engine_id
-                ][remote_port]
-                remote_scales = self.remote_block_size_scale[
-                    remote_engine_id
-                ][remote_port]
-                remote_lens = self.remote_block_len_per_addr[
-                    remote_engine_id
-                ][remote_port]
-                remote_te_port = self.remote_te_port[
-                    remote_engine_id
-                ][remote_port]
-            session_id = f"{remote_host}:{remote_te_port}"
-            indexer_lists = self._build_dsa_transfer_lists(
-                self._dsa_indexer_local_layout,
-                remote_bases,
-                remote_strides,
-                remote_scales,
-                remote_lens,
-                source.indexer_block_ids,
-                command.indexer_hbm_block_ids,
-                allow_empty=True,
-            )
-            if (
-                indexer_lists[0]
-                and self.engine.batch_transfer_sync_read(
-                    session_id, *indexer_lists
+                part = build_component_read(
+                    local,
+                    remote,
+                    source.indexer_block_ids if indexer else source.main_block_ids,
+                    command.indexer_hbm_block_ids if indexer else command.main_host_block_ids,
+                    start,
+                    end,
+                    cp_size=source.remote_pcp_size * source.remote_dcp_size,
+                    cp_rank=task["cp_rank"],
+                    writer_rank=self.tp_rank,
+                    writer_size=self.vllm_config.parallel_config.tensor_parallel_size,
+                    indexer=indexer,
+                    statistics=statistics,
                 )
-                < 0
-            ):
-                logger.error(
-                    "Blockwise DSA Indexer transfer failed: "
-                    "request_id=%s, entries=%s",
+                for output, values in zip(combined, part):
+                    output.extend(values)
+            plans.append((indexer, combined, statistics))
+        for indexer, plan, statistics in plans:
+            if task["cancelled"].is_set():
+                break
+            task["failure_phase"] = DsaTransferPhase.INDEXER_D2D if indexer else DsaTransferPhase.MAIN_D2RH
+            if plan[0]:
+                started = time.perf_counter()
+                result = self.engine.batch_transfer_sync_read(session, *plan)
+                logger.debug(
+                    "DSA receive request=%s rank=%s indexer=%s bytes=%s entries=%s seconds=%s coalescing=%s",
                     command.request_id,
-                    len(indexer_lists[0]),
+                    self.tp_rank,
+                    indexer,
+                    sum(plan[2]),
+                    len(plan[0]),
+                    time.perf_counter() - started,
+                    statistics,
                 )
-            else:
-                failure_phase = DsaTransferPhase.MAIN_D2RH
-                if self._dsa_main_owner:
-                    main_lists = self._build_dsa_transfer_lists(
-                        self._dsa_main_local_layout,
-                        remote_bases,
-                        remote_strides,
-                        remote_scales,
-                        remote_lens,
-                        source.main_block_ids,
-                        command.main_host_block_ids,
-                    )
-                else:
-                    main_lists = ([], [], [])
-                if (
-                    main_lists[0]
-                    and self.engine.batch_transfer_sync_read(
-                        session_id, *main_lists
-                    )
-                    < 0
-                ):
-                    logger.error(
-                        "Blockwise DSA Main transfer failed: "
-                        "request_id=%s, entries=%s",
-                        command.request_id,
-                        len(main_lists[0]),
-                    )
-                else:
-                    result_kind = DsaLocalResultKind.RECEIVE_COMPLETE
-                    failure_phase = None
-        except Exception:
-            logger.exception(
-                "Blockwise DSA receive failed: request_id=%s, phase=%s",
-                command.request_id,
-                failure_phase,
-            )
-        finally:
-            if source is not None:
-                try:
-                    self._send_done_recv_signal(
-                        source.remote_request_id,
-                        remote_host,
-                        remote_port,
-                        {},
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to send blockwise DSA completion signal: "
-                        "request_id=%s",
-                        command.request_id,
-                    )
-        on_result(
-            DsaLocalResult(
-                command.request_id,
-                self.tp_rank,
-                result_kind,
-                failure_phase,
-            )
-        )
+                if result < 0:
+                    raise RuntimeError(f"DSA transfer failed: {result}")
 
-    def _handle_dsa_request(self, request_data: dict[str, Any]) -> None:
-        on_result = request_data["dsa_on_result"]
+    def _handle_dsa_request(self, task: dict[str, Any]) -> None:
+        command = task["dsa_command"]
+        endpoint = task["dsa_remote_endpoint"]
+        task["failure_phase"] = DsaTransferPhase.MAIN_D2RH
         try:
-            self._execute_dsa_receive(
-                request_data["dsa_command"],
-                request_data["dsa_remote_endpoint"],
-                on_result,
-            )
+            if not self._is_failed_recv_request(command.request_id):
+                self._execute_dsa_receive(task)
+        except Exception:
+            # The upstream invalid-block interface uses cache group 0's ID
+            # space (R1). Preserve that space; never report Host IDs as group 0.
+            self._mark_failed_recv_request(command.request_id, (list(command.invalid_block_ids),))
+            with self.failed_recv_requests_lock:
+                self.dsa_failure_phases.setdefault(command.request_id, task["failure_phase"])
+            logger.exception("DSA endpoint receive failed: %s", command.request_id)
         finally:
+            try:
+                self._send_done_recv_signal(
+                    command.source.remote_request_id,
+                    endpoint.remote_host,
+                    endpoint.remote_port,
+                    {endpoint.remote_port: {"num": task["expected"], "host": endpoint.remote_host}},
+                    participant=task["participant"],
+                )
+            except Exception:
+                logger.exception("DSA endpoint done notification failed: %s", command.request_id)
+            if self._mark_request_task_done(command.request_id, task["all_task_done"]):
+                failed = self._is_failed_recv_request(command.request_id)
+                with self.failed_recv_requests_lock:
+                    phase = self.dsa_failure_phases.pop(command.request_id, DsaTransferPhase.MAIN_D2RH)
+                self._clear_failed_recv_request(command.request_id)
+                task["dsa_on_result"](
+                    DsaLocalResult(
+                        command.request_id,
+                        self.tp_rank,
+                        DsaLocalResultKind.TRANSFER_FAILED if failed else DsaLocalResultKind.RECEIVE_COMPLETE,
+                        phase if failed else None,
+                    )
+                )
             self.request_queue.task_done()
 
     def get_and_clear_finished_requests(self) -> set[str]:
@@ -1009,17 +928,15 @@ class KVCacheRecvingThread(threading.Thread):
             try:
                 request_data = self.request_queue.get()
                 if request_data is None:
-                    logger.warning("Received a None request. ")
                     self.request_queue.task_done()
-                    continue
+                    return
                 self._submit_request(request_data)
             except Exception as e:
                 logger.error("Error in KVCacheTransferThread. error=%s. ", e)
 
     def _submit_request(self, request_data: dict[str, Any]) -> None:
         peer_key = (request_data["remote_host"], request_data["remote_handshake_port"])
-        if "dsa_command" not in request_data:
-            self._mark_request_task_submitted(request_data)
+        self._mark_request_task_submitted(request_data)
         should_start_worker = False
         with self.peer_request_queues_lock:
             self.peer_request_queues[peer_key].append(request_data)
@@ -1856,6 +1773,8 @@ class KVCacheRecvingThread(threading.Thread):
                     self.kv_group2layeridx,
                 )
             with self.remote_metadata_lock:
+                self.remote_num_blocks.setdefault(engine_id, {})[remote_handshake_port] = agent_meta.num_blocks
+                self.remote_cache_dtypes.setdefault(engine_id, {})[remote_handshake_port] = agent_meta.cache_dtypes
                 self.remote_kv_group2layeridx[engine_id][remote_handshake_port] = agent_meta.kv_group2layeridx
                 self.kv_caches_base_addr[engine_id][remote_handshake_port] = agent_meta.kv_caches_base_addr
                 self.remote_te_port[engine_id][remote_handshake_port] = agent_meta.te_rpc_port
@@ -1879,6 +1798,8 @@ class KVCacheRecvingThread(threading.Thread):
         remote_host: str,
         remote_handshake_port: int,
         remote_port_send_num: dict[int, RemotePortInfo],
+        *,
+        participant: str | None = None,
     ):
         logger.debug(
             "Sending done recving signal for request %s to %s:%d", request_id, remote_host, remote_handshake_port
@@ -1886,7 +1807,10 @@ class KVCacheRecvingThread(threading.Thread):
         sock: zmq.Socket | None = None  # type: ignore
         try:
             sock = self._get_remote_socket(remote_host, remote_handshake_port)
-            data_bytes = self.encoder.encode((DONE_RECVING_MSG, request_id, remote_port_send_num))
+            message = (DONE_RECVING_MSG, request_id, remote_port_send_num)
+            if participant is not None:
+                message += (participant,)
+            data_bytes = self.encoder.encode(message)
             ensure_zmq_send(sock, data_bytes, f"{remote_host}:{remote_handshake_port}")
             resp = ensure_zmq_recv(sock, f"{remote_host}:{remote_handshake_port}")
             if logger.isEnabledFor(logging.DEBUG):
@@ -1988,6 +1912,9 @@ class _DsaSchedulerRequest:
     main_block_ids: tuple[int, ...] = ()
     indexer_hbm_block_ids: tuple[int, ...] = ()
     command_emitted: bool = False
+    allocated: bool = False
+    notify_only: bool = False
+    invalid_block_ids: tuple[int, ...] = ()
     results_by_rank: dict[int, DsaLocalResult] = field(default_factory=dict)
 
 
@@ -2002,18 +1929,12 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
         super().__init__(vllm_config, True, kv_cache_config)
         self._main_block_size = self.block_size[self.main_group_idx]
         self._dsa_requests: dict[str, _DsaSchedulerRequest] = {}
-        prefill = vllm_config.kv_transfer_config.get_from_extra_config(
-            "prefill", {}
-        )
+        self._dsa_cancelled: set[str] = set()
+        prefill = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {})
         self._dsa_prefill_tp_size = int(prefill.get("tp_size", 0))
         if self._dsa_prefill_tp_size <= 0:
-            raise ValueError(
-                "Blockwise DSA requires kv_connector_extra_config."
-                "prefill.tp_size"
-            )
-        self._expected_tp_ranks = frozenset(
-            range(vllm_config.parallel_config.tensor_parallel_size)
-        )
+            raise ValueError("Blockwise DSA requires kv_connector_extra_config.prefill.tp_size")
+        self._expected_tp_ranks = frozenset(range(vllm_config.parallel_config.tensor_parallel_size))
 
     def get_num_new_matched_tokens(
         self,
@@ -2022,42 +1943,47 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
     ) -> tuple[int, bool]:
         existing = self._dsa_requests.get(request.request_id)
         if existing is not None:
-            return existing.num_external_tokens, True
+            return existing.num_external_tokens, existing.num_external_tokens > 0
         params = request.kv_transfer_params
         if params is None or not params.get("do_remote_prefill"):
             return 0, False
         prompt_tokens = len(request.prompt_token_ids or ())
         external_tokens = max(prompt_tokens - num_computed_tokens, 0)
-        if external_tokens == 0:
-            return 0, False
-        remote_groups = tuple(
-            tuple(group) for group in params["remote_block_ids"]
-        )
+        remote_groups = tuple(tuple(group) for group in params["remote_block_ids"])
         if not remote_groups:
-            raise ValueError(
-                "remote_block_ids must contain at least one group"
-            )
+            raise ValueError("remote_block_ids must contain at least one group")
+        remote_main = params.get("dsa_main_group_id")
+        remote_indexer = params.get("dsa_indexer_group_id")
+        if len(remote_groups) == 1:
+            remote_main = remote_indexer = 0
+        if remote_main is None or remote_indexer is None:
+            raise ValueError("DSA remote multi-group metadata requires explicit Main/Indexer group IDs")
+        remote_tp = int(params.get("remote_ptp_size", self._dsa_prefill_tp_size))
+        remote_pcp = int(params.get("remote_pcp_size", 1))
+        remote_pp = int(params.get("remote_pp_size", 1))
         source = RemoteSource(
             remote_request_id=params["remote_request_id"],
             endpoints_by_prefill_rank=_project_remote_endpoints(
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
                 remote_engine_id=params["remote_engine_id"],
-                remote_multi_nodes_meta_mapping=params.get(
-                    "remote_multi_nodes_meta_mapping"
-                ),
-                prefill_tp_size=self._dsa_prefill_tp_size,
+                remote_multi_nodes_meta_mapping=params.get("remote_multi_nodes_meta_mapping"),
+                prefill_tp_size=remote_tp * remote_pcp * remote_pp,
             ),
-            indexer_block_ids=(
-                remote_groups[0]
-                if len(remote_groups) == 1
-                else remote_groups[self.indexer_group_idx]
-            ),
-            main_block_ids=(
-                remote_groups[0]
-                if len(remote_groups) == 1
-                else remote_groups[self.main_group_idx]
-            ),
+            indexer_block_ids=remote_groups[remote_indexer],
+            main_block_ids=remote_groups[remote_main],
+            remote_ptp_size=remote_tp,
+            remote_pcp_size=remote_pcp,
+            remote_pp_size=remote_pp,
+            remote_dcp_size=int(params.get("remote_dcp_size", 1)),
+            remote_block_size=int(params.get("remote_block_size", self._main_block_size)),
+            num_prompt_blocks=int(params.get("num_prompt_blocks", 0)),
+            remote_main_group_id=remote_main,
+            remote_indexer_group_id=remote_indexer,
+            remote_main_block_size=int(params.get("dsa_main_block_size", 0)),
+            remote_indexer_block_size=int(params.get("dsa_indexer_block_size", 0)),
+            num_computed_tokens=num_computed_tokens,
+            num_external_tokens=external_tokens,
         )
         self._dsa_requests[request.request_id] = _DsaSchedulerRequest(
             request=request,
@@ -2065,7 +1991,7 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
             num_computed_tokens=num_computed_tokens,
             num_external_tokens=external_tokens,
         )
-        return external_tokens, True
+        return external_tokens, external_tokens > 0
 
     def update_state_after_alloc(
         self,
@@ -2084,17 +2010,34 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
                 f"required={required_group + 1}, got={len(groups)}"
             )
         indexer_block_ids = groups[self.indexer_group_idx]
-        if not indexer_block_ids:
-            raise ValueError(
-                "Indexer destination block IDs must not be empty"
-            )
+        if num_external_tokens > 0 and (not indexer_block_ids or not groups[0]):
+            raise ValueError("DSA receive requires allocated Indexer and failure-reporting blocks")
         bound_tokens = tracker.num_computed_tokens + num_external_tokens
         bound_blocks = cdiv(bound_tokens, self._main_block_size)
         main_block_ids = groups[self.main_group_idx]
-        if bound_blocks > len(main_block_ids):
-            raise ValueError(
-                "vLLM has not allocated enough Main Host blocks"
+        if num_external_tokens > 0 and bound_blocks > len(main_block_ids):
+            raise ValueError("vLLM has not allocated enough Main Host blocks")
+        invalid_block_ids = groups[0]
+        if num_external_tokens > 0 and tracker.num_computed_tokens > 0:
+            # Diagnostic only: do not silently narrow the current reporting range.
+            # A partially cached block overlaps the read and is not protected here.
+            group0_block_size = self.block_size[0]
+            prefix_blocks = tracker.num_computed_tokens // group0_block_size
+            prefix_block_ids = groups[0][:prefix_blocks]
+            misreported_prefix_ids = sorted(set(invalid_block_ids).intersection(prefix_block_ids))
+            assert not misreported_prefix_ids, (
+                "Mooncake DSA failure-reporting range includes untouched prefix blocks before transfer: "
+                f"request={request.request_id}, group=0, group_block_size={group0_block_size}, "
+                f"read_tokens=[{tracker.num_computed_tokens}, {bound_tokens}), "
+                f"invalid_block_ids={invalid_block_ids}, "
+                f"untouched_prefix_block_ids={misreported_prefix_ids}. "
+                "A later load failure would invalidate these locally cached blocks; "
+                "no transfer failure or impact on other requests has been observed by this check."
             )
+        tracker.source = replace(tracker.source, num_external_tokens=num_external_tokens)
+        tracker.allocated = True
+        tracker.notify_only = num_external_tokens == 0
+        tracker.invalid_block_ids = invalid_block_ids
         tracker.indexer_hbm_block_ids = indexer_block_ids
         tracker.main_block_ids = main_block_ids[:bound_blocks]
         if isinstance(request.kv_transfer_params, dict):
@@ -2108,11 +2051,7 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
         requests: list[DsaStepRequest] = []
         for request_id in sorted(self._dsa_requests):
             tracker = self._dsa_requests[request_id]
-            if (
-                tracker.command_emitted
-                or not tracker.indexer_hbm_block_ids
-                or not tracker.main_block_ids
-            ):
+            if tracker.command_emitted or not tracker.allocated:
                 continue
             requests.append(
                 DsaStepRequest(
@@ -2120,20 +2059,24 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
                     source=tracker.source,
                     main_host_block_ids=tracker.main_block_ids,
                     indexer_hbm_block_ids=tracker.indexer_hbm_block_ids,
+                    invalid_block_ids=tracker.invalid_block_ids,
+                    notify_only=tracker.notify_only,
                 )
             )
             tracker.command_emitted = True
-        return DsaConnectorMetadata(tuple(requests))
+        for command in requests:
+            if command.notify_only:
+                self._dsa_requests.pop(command.request_id, None)
+        cancelled = tuple(getattr(self, "_dsa_cancelled", ()))
+        self._dsa_cancelled = set()
+        return DsaConnectorMetadata(tuple(requests), cancelled)
 
     def update_connector_output(self, connector_output: Any) -> None:
         metadata = connector_output.kv_connector_worker_meta
         if metadata is None:
             return
         if not isinstance(metadata, DsaWorkerResultMetadata):
-            raise TypeError(
-                "kv_connector_worker_meta must be "
-                "DsaWorkerResultMetadata"
-            )
+            raise TypeError("kv_connector_worker_meta must be DsaWorkerResultMetadata")
         completed: list[str] = []
         for result in metadata.results:
             tracker = self._dsa_requests.get(result.request_id)
@@ -2144,29 +2087,17 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
                 )
                 continue
             if result.tp_rank not in self._expected_tp_ranks:
-                raise ValueError(
-                    f"illegal Decode TP rank {result.tp_rank}"
-                )
+                raise ValueError(f"illegal Decode TP rank {result.tp_rank}")
             existing = tracker.results_by_rank.get(result.tp_rank)
             if existing is not None:
                 if existing != result:
-                    raise ValueError(
-                        f"conflicting DSA result for {result.identity}"
-                    )
+                    raise ValueError(f"conflicting DSA result for {result.identity}")
                 continue
             tracker.results_by_rank[result.tp_rank] = result
             if set(tracker.results_by_rank) != self._expected_tp_ranks:
                 continue
-            if any(
-                item.kind is DsaLocalResultKind.TRANSFER_FAILED
-                for item in tracker.results_by_rank.values()
-            ):
-                tracker.request.num_computed_tokens = 0
-                logger.error(
-                    "Blockwise DSA receive failed for %s; "
-                    "falling back to local recompute",
-                    result.request_id,
-                )
+            # Invalid blocks are reported by the receiving worker before this
+            # callback. Never recompute without a full device Main cache (Q1).
             completed.append(result.request_id)
         if completed:
             finished = set(connector_output.finished_recving or ())
@@ -2177,17 +2108,13 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
 
     def set_xfer_handshake_metadata(
         self,
-        metadata: Mapping[
-            int | tuple[int, ...], KVConnectorHandshakeMetadata
-        ],
+        metadata: Mapping[int | tuple[int, ...], KVConnectorHandshakeMetadata],
     ) -> None:
         del metadata
 
     def set_xfer_handshake_metadata_from_workers(
         self,
-        metadata: Mapping[
-            int | tuple[int, ...], KVConnectorHandshakeMetadata
-        ],
+        metadata: Mapping[int | tuple[int, ...], KVConnectorHandshakeMetadata],
     ) -> None:
         del metadata
 
@@ -2197,7 +2124,21 @@ class _MooncakeDsaDecodeScheduler(SFAPDRD2HScheduler):
         block_ids: Any,
     ) -> tuple[bool, dict[str, Any] | None]:
         del block_ids
-        return request.request_id in self._dsa_requests, None
+        tracker = self._dsa_requests.get(request.request_id)
+        if tracker is None and (request.kv_transfer_params or {}).get("do_remote_prefill"):
+            self.get_num_new_matched_tokens(request, len(request.prompt_token_ids or ()))
+            tracker = self._dsa_requests[request.request_id]
+        if tracker is None:
+            return False, None
+        if not tracker.allocated:
+            tracker.allocated = True
+            tracker.notify_only = True
+            request.kv_transfer_params["do_remote_prefill"] = False
+            return False, None
+        if not hasattr(self, "_dsa_cancelled"):
+            self._dsa_cancelled = set()
+        self._dsa_cancelled.add(request.request_id)
+        return not tracker.notify_only, None
 
 
 class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
@@ -2207,74 +2148,40 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config is not None
         self._kv_transfer_config = vllm_config.kv_transfer_config
         self.engine_id = vllm_config.kv_transfer_config.engine_id
-        self._dsa_pd_offload = (
-            vllm_config.kv_transfer_config.get_from_extra_config(
-                "dsa_pd_offload", False
-            )
-        )
+        self._dsa_pd_offload = vllm_config.kv_transfer_config.get_from_extra_config("dsa_pd_offload", False)
         if not isinstance(self._dsa_pd_offload, bool):
-            raise ValueError(
-                "kv_connector_extra_config.dsa_pd_offload must be bool"
-            )
-        self._dsa_decode = (
-            self._dsa_pd_offload
-            and vllm_config.kv_transfer_config.kv_role == "kv_consumer"
-        )
+            raise ValueError("kv_connector_extra_config.dsa_pd_offload must be bool")
+        self._dsa_decode = self._dsa_pd_offload and vllm_config.kv_transfer_config.kv_role == "kv_consumer"
         if self._dsa_pd_offload:
             kv_role = vllm_config.kv_transfer_config.kv_role
             if kv_role not in ("kv_producer", "kv_consumer"):
-                raise ValueError(
-                    "Blockwise DSA requires kv_role='kv_producer' or "
-                    "kv_role='kv_consumer'"
-                )
-            prefill = vllm_config.kv_transfer_config.get_from_extra_config(
-                "prefill", {}
-            )
-            decode = vllm_config.kv_transfer_config.get_from_extra_config(
-                "decode", {}
-            )
+                raise ValueError("Blockwise DSA requires kv_role='kv_producer' or kv_role='kv_consumer'")
+            prefill = vllm_config.kv_transfer_config.get_from_extra_config("prefill", {})
+            decode = vllm_config.kv_transfer_config.get_from_extra_config("decode", {})
             prefill_tp = int(prefill.get("tp_size", 0))
             decode_tp = int(decode.get("tp_size", 0))
-            if (
-                prefill_tp <= 0
-                or decode_tp <= 0
-                or prefill_tp < decode_tp
-                or prefill_tp % decode_tp
-            ):
-                raise ValueError(
-                    "Blockwise DSA currently requires positive P_TP/D_TP "
-                    "with P_TP >= D_TP and P_TP % D_TP == 0"
-                )
+            if prefill_tp <= 0 or decode_tp <= 0:
+                raise ValueError("Blockwise DSA requires positive P_TP/D_TP")
             init_ascend_config(vllm_config)
             offload = get_ascend_config().sparse_kv_offload_config
             if kv_role == "kv_producer" and offload.enabled:
-                raise ValueError(
-                    "Blockwise DSA Prefill requires sparse KV offload disabled"
-                )
+                raise ValueError("Blockwise DSA Prefill requires sparse KV offload disabled")
             if kv_role == "kv_consumer":
+                if vllm_config.kv_transfer_config.kv_load_failure_policy != "fail":
+                    raise ValueError("DSA Host offload requires kv_load_failure_policy='fail'")
                 if not offload.enabled:
-                    raise ValueError(
-                        "Blockwise DSA Decode requires sparse KV offload enabled"
-                    )
+                    raise ValueError("Blockwise DSA Decode requires sparse KV offload enabled")
                 if not offload.use_fused_overlap:
-                    raise ValueError(
-                        "Blockwise DSA Decode requires fused overlap"
-                    )
+                    raise ValueError("Blockwise DSA Decode requires fused overlap")
                 if offload.host_backend != "mooncake":
-                    raise ValueError(
-                        "Blockwise DSA Decode requires host_backend='mooncake'"
-                    )
+                    raise ValueError("Blockwise DSA Decode requires host_backend='mooncake'")
         self._connector_metadata = MooncakeConnectorMetadata()
 
         if role == KVConnectorRole.SCHEDULER:
             if self._dsa_decode:
-                self.connector_scheduler = _MooncakeDsaDecodeScheduler(
-                    vllm_config, kv_cache_config
-                )
+                self.connector_scheduler = _MooncakeDsaDecodeScheduler(vllm_config, kv_cache_config)
             else:
-                self.connector_scheduler = MooncakeConnectorScheduler(
-                    vllm_config, str(self.engine_id), kv_cache_config
-                )
+                self.connector_scheduler = MooncakeConnectorScheduler(vllm_config, str(self.engine_id), kv_cache_config)
             self.connector_worker: MooncakeConnectorWorker | None = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
@@ -2301,9 +2208,7 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
 
     def update_connector_output(self, connector_output: Any) -> None:
         assert self.connector_scheduler is not None
-        if isinstance(
-            self.connector_scheduler, _MooncakeDsaDecodeScheduler
-        ):
+        if isinstance(self.connector_scheduler, _MooncakeDsaDecodeScheduler):
             self.connector_scheduler.update_connector_output(connector_output)
 
     def request_finished(
@@ -2342,13 +2247,9 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
         if self._dsa_decode:
-            assert isinstance(
-                self._connector_metadata, DsaConnectorMetadata
-            )
+            assert isinstance(self._connector_metadata, DsaConnectorMetadata)
         else:
-            assert isinstance(
-                self._connector_metadata, MooncakeConnectorMetadata
-            )
+            assert isinstance(self._connector_metadata, MooncakeConnectorMetadata)
         self.connector_worker.start_load_kv(self._connector_metadata)
 
     def build_connector_worker_meta(
@@ -2372,6 +2273,10 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_save(self):
         """MooncakeConnector does not save explicitly."""
         pass
+
+    def shutdown(self) -> None:
+        if self.connector_worker is not None:
+            self.connector_worker.shutdown()
 
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
@@ -2720,7 +2625,23 @@ class MooncakeConnectorScheduler:
             logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
+        component_groups = {}
+        if self.vllm_config.kv_transfer_config.get_from_extra_config("dsa_pd_offload", False):
+            for group_id, group in enumerate(self.kv_cache_groups):
+                for name in group.layer_names:
+                    key = "dsa_indexer_group_id" if "indexer" in name.lower() else "dsa_main_group_id"
+                    if key in component_groups and component_groups[key] != group_id:
+                        raise ValueError("DSA component spans multiple manager groups")
+                    component_groups[key] = group_id
+            component_groups["dsa_main_block_size"] = self.kv_cache_groups[
+                component_groups["dsa_main_group_id"]
+            ].kv_cache_spec.block_size
+            component_groups["dsa_indexer_block_size"] = self.kv_cache_groups[
+                component_groups["dsa_indexer_group_id"]
+            ].kv_cache_spec.block_size
         return delay_free_blocks, dict(
+            **component_groups,
+            remote_pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
             do_remote_prefill=True,
             do_remote_decode=False,
             remote_block_ids=computed_block_ids,
@@ -2882,19 +2803,12 @@ class MooncakeConnectorWorker:
             self.tp_num_need_pulls = num_d_block_heads // num_p_block_heads
         self.local_remote_block_port_mapping: dict[str, list[list[int]] | None] = {}
         self.remote_port_send_num: dict[str, dict[int, RemotePortInfo]] = {}
-        self._dsa_pd_offload = (
-            vllm_config.kv_transfer_config.get_from_extra_config(
-                "dsa_pd_offload", False
-            )
-        )
-        self._dsa_decode = (
-            self._dsa_pd_offload and self.kv_role == "kv_consumer"
-        )
+        self._dsa_pd_offload = vllm_config.kv_transfer_config.get_from_extra_config("dsa_pd_offload", False)
+        self._dsa_decode = self._dsa_pd_offload and self.kv_role == "kv_consumer"
         if self._dsa_decode:
             self._dsa_active_commands: dict[str, DsaStepRequest] = {}
-            self._dsa_results: queue.SimpleQueue[DsaLocalResult] = (
-                queue.SimpleQueue()
-            )
+            self._dsa_cancel_events: dict[str, threading.Event] = {}
+            self._dsa_results: queue.SimpleQueue[DsaLocalResult] = queue.SimpleQueue()
 
     def _get_prefill_decode_size(self, vllm_config: VllmConfig):
         # get prefill tp and dp size from extra config
@@ -3056,6 +2970,16 @@ class MooncakeConnectorWorker:
         index_cache_plane_base = self.total_layers * 2
         next_mtp_layer_idx = self.total_layers
         transfer_group_id = 0
+        dsa_layer_indices = (
+            {
+                name: idx
+                for idx, name in enumerate(
+                    dict.fromkeys(name for group in self.kv_cache_config.kv_cache_groups for name in group.layer_names)
+                )
+            }
+            if getattr(self, "_dsa_pd_offload", False)
+            else {}
+        )
         for kv_cache_group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
             layer_entries: list[tuple[str, int]] = []
             # For eagle3 method there is no "mtp" in layer names, and upstream model initiation assigns the layer id
@@ -3064,7 +2988,11 @@ class MooncakeConnectorWorker:
             # assigned to previous layers. If the layer id has been assigned, we treat the current layer as
             # an eagle layer and assign a new layer id starting from total_layers.
             for layer_name in group_spec.layer_names:
-                if "mtp" in layer_name or "eagle" in layer_name:
+                if dsa_layer_indices:
+                    # DSA Main and Indexer have independent tensor arrays even
+                    # when they share a transformer or a manager cache group.
+                    layer_idx = dsa_layer_indices[layer_name]
+                elif "mtp" in layer_name or "eagle" in layer_name:
                     layer_idx = next_mtp_layer_idx
                     next_mtp_layer_idx += 1
                 elif self._is_index_cache_layer(layer_name):
@@ -3259,89 +3187,49 @@ class MooncakeConnectorWorker:
 
         return ptrs, lengths
 
-    def _dsa_consumer_device_register_regions(
-        self, kv_caches: dict[str, torch.Tensor]
-    ) -> RegisterRegions:
+    def _dsa_consumer_device_register_regions(self, kv_caches: dict[str, torch.Tensor]) -> RegisterRegions:
         indexer_caches = {
-            name: self._as_kv_cache_tuple(cache)
-            for name, cache in kv_caches.items()
-            if "indexer" in name.lower()
+            name: self._as_kv_cache_tuple(cache) for name, cache in kv_caches.items() if "indexer" in name.lower()
         }
         if not indexer_caches:
-            raise ValueError(
-                "Blockwise DSA Decode has no Indexer device cache"
-            )
+            raise ValueError("Blockwise DSA Decode has no Indexer device cache")
         return collect_storage_merged_register_regions(indexer_caches)
 
-    def _build_dsa_local_layouts(
-        self,
-        kv_caches: dict[str, torch.Tensor],
-        layer_name_to_idx: dict[str, int],
-    ) -> tuple[
-        list[list[tuple[int, int, int, int, int]]],
-        list[list[tuple[int, int, int, int, int]]],
-        bool,
-    ]:
+    def _build_dsa_local_layouts(self, kv_caches, layer_name_to_idx):
+        from vllm.v1.worker.utils import extract_layer_index
+
+        self._dsa_transformer_layers = {
+            name: self.total_layers if "mtp" in name or "eagle" in name else extract_layer_index(name)
+            for name in kv_caches
+        }
         manager = get_sparse_kv_offload_manager()
         pool = manager.get_mooncake_host_pool()
-        layer_count = len(self.kv_caches_base_addr)
-        indexer_layout = [[] for _ in range(layer_count)]
-        main_layout = [[] for _ in range(layer_count)]
-
-        def tensor_entry(
-            position: int,
-            tensor: torch.Tensor,
-            require_exact_capacity: bool,
-        ) -> tuple[int, int, int, int, int]:
-            tensor_blocks = int(tensor.shape[0])
-            if require_exact_capacity and tensor_blocks != self.num_blocks:
-                raise RuntimeError(
-                    "Mooncake Host Main capacity must match "
-                    f"kv_cache_config: tensor_blocks={tensor_blocks}, "
-                    f"configured_blocks={self.num_blocks}"
+        indexer, main = [], []
+        for name, caches in kv_caches.items():
+            is_indexer = "indexer" in name.lower()
+            tensors = self._as_kv_cache_tuple(caches) if is_indexer else manager.get_local_host_kv_views(name)
+            for position, tensor in enumerate(tensors):
+                if tensor.shape[0] % self.num_blocks:
+                    raise ValueError("DSA tensor pages must divide manager blocks")
+                scale = tensor.shape[0] // self.num_blocks
+                if not is_indexer and scale != 1:
+                    raise ValueError("Host Main requires one view block per manager block")
+                entry = DsaCacheLayout(
+                    name,
+                    position,
+                    tensor.data_ptr(),
+                    tensor.element_size() * math.prod(tensor.shape[1:]),
+                    tensor.stride(0) * tensor.element_size(),
+                    scale,
+                    self._get_layer_spec(name).block_size,
+                    str(tensor.dtype),
+                    self.num_blocks,
                 )
-            if tensor_blocks % self.num_blocks:
-                raise ValueError(
-                    "DSA tensor block count must be divisible by "
-                    "kv_cache_config.num_blocks"
-                )
-            return (
-                position,
-                tensor.data_ptr(),
-                tensor.element_size() * math.prod(tensor.shape[1:]),
-                tensor.stride(0) * tensor.element_size(),
-                tensor_blocks // self.num_blocks,
-            )
-
-        for layer_name, cache in kv_caches.items():
-            if "indexer" not in layer_name.lower():
-                continue
-            layer_idx = layer_name_to_idx[layer_name]
-            for position, tensor in enumerate(
-                self._as_kv_cache_tuple(cache)
-            ):
-                indexer_layout[layer_idx].append(
-                    tensor_entry(position, tensor, False)
-                )
-        if not any(indexer_layout):
-            raise ValueError(
-                "Blockwise DSA Decode has no Indexer layout"
-            )
-
-        if pool.is_owner:
-            pool.register(self.engine)
-            for layer_name in manager.offload_layer_names:
-                layer_idx = layer_name_to_idx[layer_name]
-                host_k, host_v = (
-                    manager.get_fused_overlap_cpu_kv_inputs(layer_name)
-                )
-                main_layout[layer_idx].extend(
-                    (
-                        tensor_entry(0, host_k, True),
-                        tensor_entry(1, host_v, True),
-                    )
-                )
-        return indexer_layout, main_layout, pool.is_owner
+                (indexer if is_indexer else main).append(entry)
+        if not indexer or not main:
+            raise ValueError("DSA requires Main and Indexer component layouts")
+        pool.register_local_writer(self.engine)
+        return indexer, main
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data."""
@@ -3397,17 +3285,13 @@ class MooncakeConnectorWorker:
 
         dsa_local_layouts = None
         if self._dsa_decode:
-            dsa_local_layouts = self._build_dsa_local_layouts(
-                kv_caches, layer_name_to_idx
-            )
+            dsa_local_layouts = self._build_dsa_local_layouts(kv_caches, layer_name_to_idx)
 
         if has_mamba_group:
             ptrs, lengths = self._get_registered_kv_tensor_buffers(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
         elif self._dsa_decode:
-            register_regions = (
-                self._dsa_consumer_device_register_regions(kv_caches)
-            )
+            register_regions = self._dsa_consumer_device_register_regions(kv_caches)
         elif self.use_hybrid:
             ptrs, lengths = self._get_registered_kv_tensor_buffers_hybrid(kv_caches)
             register_regions = RegisterRegions(ptrs=ptrs, lengths=lengths)
@@ -3434,7 +3318,12 @@ class MooncakeConnectorWorker:
             register_regions.lengths,
         )
         # After KV Caches registered, start the sending or receiving thread.
+        cache_dtypes = [[] for _ in self.kv_caches_base_addr]
+        for name, caches in kv_caches.items():
+            if not self._dsa_decode or "indexer" in name.lower():
+                cache_dtypes[layer_name_to_idx[name]] = [str(t.dtype) for t in self._as_kv_cache_tuple(caches)]
         metadata = MooncakeAgentMetadata(
+            cache_dtypes=cache_dtypes,
             engine_id=self.engine_id,
             te_rpc_port=self.te_rpc_port,
             kv_group2layeridx=self.kv_group2layeridx,
@@ -3488,8 +3377,8 @@ class MooncakeConnectorWorker:
                 (
                     self.kv_recv_thread._dsa_indexer_local_layout,
                     self.kv_recv_thread._dsa_main_local_layout,
-                    self.kv_recv_thread._dsa_main_owner,
                 ) = dsa_local_layouts
+                self.kv_recv_thread._dsa_transformer_layers = self._dsa_transformer_layers
             self.kv_recv_thread.start()
         start_wait_time = time.time()
         thread = self.kv_send_thread if self.kv_role == "kv_producer" else self.kv_recv_thread
@@ -3501,12 +3390,12 @@ class MooncakeConnectorWorker:
                 raise RuntimeError("Timeout waiting for KV Cache thread to be ready.")
             time.sleep(3)
 
-    def get_finished(
-        self, finished_req_ids: set[str] | None = None
-    ) -> tuple[set[str], set[str]]:
+    def get_finished(self, finished_req_ids: set[str] | None = None) -> tuple[set[str], set[str]]:
         if self._dsa_decode:
             for request_id in finished_req_ids or ():
-                self._dsa_active_commands.pop(request_id, None)
+                event = self._dsa_cancel_events.get(request_id)
+                if event is not None:
+                    event.set()
         done_sending = (
             self.kv_send_thread.get_and_clear_finished_requests(  # type: ignore[union-attr]
             )
@@ -3709,75 +3598,8 @@ class MooncakeConnectorWorker:
         r_blk = self.block_size // remote_block_size if self.block_size > remote_block_size else 1
         return remote_block_size, local_cp_rank, local_cp_size, remote_cp_size, r_blk
 
-    def _get_kv_split_metadata(
-        self,
-        req_id: str,
-        meta: ReqMeta,
-    ) -> tuple[list[list[int]], list[BlockIds], list[BlockIds]]:
-        """Build per-transfer port and block-id metadata for remote KV reads.
-
-        Args:
-            req_id: Remote request id used as the stable hash key when choosing
-                prefill TP ranks.
-            meta: Request-level transfer metadata from the scheduler. It
-                contains remote/local block ids, remote P-side port base,
-                remote P-side PCP/DCP/PTP sizes, and prompt/prefix-cache
-                token counts.
-
-        Returns:
-            A tuple of three aligned lists. Index ``i`` describes one transfer
-            shard for this local D-side rank:
-            * remote_handshake_port_list[i]: remote P worker handshake ports
-              to pull from. The inner list length is the number of TP pulls
-              needed for that shard.
-            * local_block_ids_list[i]: local kernel block ids, grouped by KV cache
-              group, where received blocks are written.
-            * remote_block_ids_list[i]: remote kernel block ids, grouped by KV cache
-              group, where blocks are read from.
-
-        In PCP/DCP scenarios, prompt blocks can be split across multiple remote
-        P workers. This method also accounts for unequal P/D prefix-cache hits
-        by reducing the number of remote blocks that still need to be pulled.
-        """
-        prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
-
-        if meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size == 1:
-            if self._is_hma_required:
-                chosen_rank_list, _ = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
-            else:
-                chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
-
-            remote_handshake_port_list = [[x + meta.remote_port for x in chosen_rank_list]]
-            # No CP: expand logical blocks into kernel blocks here so the transfer
-            # stage consumes kernel-level ids directly (chunk_starts no longer needed).
-            use_transfer_group_block_ids = transfer_groups_need_independent_block_ids(
-                self.kv_group2layeridx,
-                self.block_size_scale,
-            )
-            local_block_ids: list[list[int]]
-            remote_block_ids: list[list[int]]
-            if use_transfer_group_block_ids:
-                local_block_ids = [[] for _ in self.kv_group2layeridx]
-                remote_block_ids = [[] for _ in self.kv_group2layeridx]
-            else:
-                local_block_ids = [[] for _ in meta.local_block_ids]
-                remote_block_ids = [[] for _ in meta.remote_block_ids]
-            for group_idx, (group_spec, layer_indices) in self.kv_group2layeridx.items():
-                local_kernel_block_ids, remote_kernel_block_ids = self._get_kernel_block_ids(
-                    layer_indices, meta, group_idx, group_spec
-                )
-                block_id_idx = (
-                    group_idx if use_transfer_group_block_ids else self._get_kv_cache_group_id(group_idx, group_spec)
-                )
-                local_block_ids[block_id_idx] = local_kernel_block_ids
-                remote_block_ids[block_id_idx] = remote_kernel_block_ids
-            local_block_ids_list = [tuple(local_block_ids) for _ in remote_handshake_port_list]
-            remote_block_ids_list = [tuple(remote_block_ids) for _ in remote_handshake_port_list]
-            return (
-                remote_handshake_port_list,
-                local_block_ids_list,
-                remote_block_ids_list,
-            )
+    def _get_cp_source_ports(self, meta: ReqMeta, prefill_tp_size: int, r_blk: int):
+        """Shared ordinary CP source mapping and logical notification counts."""
 
         def context_parallel_parameters_check():
             assert (meta.remote_pcp_size * meta.remote_dcp_size) % (self.pcp_size * self.dcp_size) == 0
@@ -3905,6 +3727,105 @@ class MooncakeConnectorWorker:
                         remote_port_send_num[remote_port]["num"] += 1
             return remote_port_send_num
 
+        mappings = get_local_remote_block_port_mappings()
+        if self._prefill_pp_size > 1:
+            # Inspect selected sources, not advertised endpoints or zero-reader
+            # notification entries. DCP is inside TP; PCP is inside each PP stage.
+            stage_width = prefill_tp_size * meta.remote_pcp_size
+            selected_ports = {port for groups in mappings.values() for ports in groups for port in ports}
+            selected_shards = set()
+            for port in selected_ports:
+                pp_rank, stage_rank = divmod(port - meta.remote_port, stage_width)
+                pcp_rank, tp_rank = divmod(stage_rank, prefill_tp_size)
+                selected_shards.add((pp_rank, pcp_rank * meta.remote_dcp_size + tp_rank % meta.remote_dcp_size))
+            required_shards = {
+                (pp_rank, cp_rank)
+                for pp_rank in range(self._prefill_pp_size)
+                for cp_rank in range(meta.remote_pcp_size * meta.remote_dcp_size)
+            }
+            missing_shards = required_shards - selected_shards
+            assert not missing_shards, (
+                "Mooncake KV source coverage incomplete before transfer: "
+                f"request={getattr(meta, 'remote_request_id', '<unknown>')}, remote_engine={meta.remote_engine_id}, "
+                f"P(TP={prefill_tp_size}, PCP={meta.remote_pcp_size}, "
+                f"DCP={meta.remote_dcp_size}, PP={self._prefill_pp_size}), "
+                f"D(TP={self.tp_size}, PCP={self.pcp_size}, DCP={self.dcp_size}), "
+                f"base_port={meta.remote_port}, selected_ports={sorted(selected_ports)}, "
+                f"missing_(pp_rank,cp_rank)={sorted(missing_shards)}. "
+                "These source shards have no planned reader; KV byte contents have not been checked."
+            )
+        return mappings, get_remote_port_send_num(mappings)
+
+    def _get_kv_split_metadata(
+        self,
+        req_id: str,
+        meta: ReqMeta,
+    ) -> tuple[list[list[int]], list[BlockIds], list[BlockIds]]:
+        """Build per-transfer port and block-id metadata for remote KV reads.
+
+        Args:
+            req_id: Remote request id used as the stable hash key when choosing
+                prefill TP ranks.
+            meta: Request-level transfer metadata from the scheduler. It
+                contains remote/local block ids, remote P-side port base,
+                remote P-side PCP/DCP/PTP sizes, and prompt/prefix-cache
+                token counts.
+
+        Returns:
+            A tuple of three aligned lists. Index ``i`` describes one transfer
+            shard for this local D-side rank:
+            * remote_handshake_port_list[i]: remote P worker handshake ports
+              to pull from. The inner list length is the number of TP pulls
+              needed for that shard.
+            * local_block_ids_list[i]: local kernel block ids, grouped by KV cache
+              group, where received blocks are written.
+            * remote_block_ids_list[i]: remote kernel block ids, grouped by KV cache
+              group, where blocks are read from.
+
+        In PCP/DCP scenarios, prompt blocks can be split across multiple remote
+        P workers. This method also accounts for unequal P/D prefix-cache hits
+        by reducing the number of remote blocks that still need to be pulled.
+        """
+        prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
+
+        if meta.remote_pcp_size * meta.remote_dcp_size * self.pcp_size * self.dcp_size == 1:
+            if self._is_hma_required:
+                chosen_rank_list, _ = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
+            else:
+                chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
+
+            remote_handshake_port_list = [[x + meta.remote_port for x in chosen_rank_list]]
+            # No CP: expand logical blocks into kernel blocks here so the transfer
+            # stage consumes kernel-level ids directly (chunk_starts no longer needed).
+            use_transfer_group_block_ids = transfer_groups_need_independent_block_ids(
+                self.kv_group2layeridx,
+                self.block_size_scale,
+            )
+            local_block_ids: list[list[int]]
+            remote_block_ids: list[list[int]]
+            if use_transfer_group_block_ids:
+                local_block_ids = [[] for _ in self.kv_group2layeridx]
+                remote_block_ids = [[] for _ in self.kv_group2layeridx]
+            else:
+                local_block_ids = [[] for _ in meta.local_block_ids]
+                remote_block_ids = [[] for _ in meta.remote_block_ids]
+            for group_idx, (group_spec, layer_indices) in self.kv_group2layeridx.items():
+                local_kernel_block_ids, remote_kernel_block_ids = self._get_kernel_block_ids(
+                    layer_indices, meta, group_idx, group_spec
+                )
+                block_id_idx = (
+                    group_idx if use_transfer_group_block_ids else self._get_kv_cache_group_id(group_idx, group_spec)
+                )
+                local_block_ids[block_id_idx] = local_kernel_block_ids
+                remote_block_ids[block_id_idx] = remote_kernel_block_ids
+            local_block_ids_list = [tuple(local_block_ids) for _ in remote_handshake_port_list]
+            remote_block_ids_list = [tuple(remote_block_ids) for _ in remote_handshake_port_list]
+            return (
+                remote_handshake_port_list,
+                local_block_ids_list,
+                remote_block_ids_list,
+            )
+
         def _set_hma_shared_port(prefill_tp_size, meta, remote_handshake_port_list, req_id):
             """Rewrite remote attention ports for HMA load balancing and append Mamba ports.
 
@@ -3923,7 +3844,7 @@ class MooncakeConnectorWorker:
             """
             if self._is_hma_required and not (self.use_mla or self.use_sparse):
                 remote_dcp = max(meta.remote_dcp_size, 1)
-                group_span = prefill_tp_size // len(get_kv_head_groups(prefill_tp_size))
+                group_span = prefill_tp_size // min(self.num_key_value_heads, prefill_tp_size)
                 n_replica = max(group_span // remote_dcp, 1)
                 chosen_tp_list = self._get_remote_rank(req_id, prefill_tp_size)
                 if n_replica > 1:
@@ -3959,13 +3880,9 @@ class MooncakeConnectorWorker:
             self.local_remote_block_port_mapping[meta.remote_engine_id] = None
 
         if self.local_remote_block_port_mapping[meta.remote_engine_id] is None:
-            local_remote_block_port_mappings = get_local_remote_block_port_mappings()
-            self.local_remote_block_port_mapping[meta.remote_engine_id] = local_remote_block_port_mappings[
-                self.handshake_port
-            ]
-            self.remote_port_send_num[meta.remote_engine_id] = get_remote_port_send_num(
-                local_remote_block_port_mappings
-            )
+            mappings, counts = self._get_cp_source_ports(meta, prefill_tp_size, r_blk)
+            self.local_remote_block_port_mapping[meta.remote_engine_id] = mappings[self.handshake_port]
+            self.remote_port_send_num[meta.remote_engine_id] = counts
 
         local_remote_block_port_mapping = copy.deepcopy(self.local_remote_block_port_mapping[meta.remote_engine_id])
 
@@ -4499,6 +4416,10 @@ class MooncakeConnectorWorker:
     ):
         """Start loading KV blocks from remote engine."""
         if isinstance(metadata, DsaConnectorMetadata):
+            scheduled_ids = {command.request_id for command in metadata.requests}
+            for request_id in metadata.cancelled_requests:
+                if request_id in self._dsa_active_commands or request_id in scheduled_ids:
+                    self._dsa_cancel_events.setdefault(request_id, threading.Event()).set()
             self._dispatch_dsa_commands(metadata.requests)
             return
         for req_id in metadata.reqs_in_batch:
@@ -4596,15 +4517,7 @@ class MooncakeConnectorWorker:
 
         if self.kv_send_thread is not None and self.pcp_size * self.dcp_size == 1:
             for req_id, delay_start_time in metadata.requests_to_send.items():
-                source_ranks = (
-                    range(
-                        0,
-                        self._prefill_tp_size,
-                        self._prefill_tp_size // self._decode_tp_size,
-                    )
-                    if self._dsa_pd_offload
-                    else self._prefill_get_remote_rank(req_id)
-                )
+                source_ranks = self._prefill_get_remote_rank(req_id)
                 if self.tp_rank in source_ranks:
                     self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
                 else:
@@ -4614,43 +4527,101 @@ class MooncakeConnectorWorker:
             for req_id, delay_start_time in metadata.requests_to_send.items():
                 self.kv_send_thread.add_delayed_request(req_id, delay_start_time)
 
-    def _dispatch_dsa_commands(
-        self,
-        commands: tuple[DsaStepRequest, ...],
-    ) -> None:
-        if not self._dsa_decode:
-            raise RuntimeError(
-                "DSA commands are valid only on the Decode consumer"
+    def shutdown(self) -> None:
+        self._closing = True
+        if self.kv_recv_thread is not None:
+            self.kv_recv_thread.request_queue.join()
+            self.kv_recv_thread.request_queue.put(None)
+            self.kv_recv_thread.join()
+            self.kv_recv_thread.executor.shutdown(wait=True)
+            if self._dsa_decode:
+                get_sparse_kv_offload_manager().get_mooncake_host_pool().unregister()
+
+    def _plan_dsa_endpoints(self, command: DsaStepRequest):
+        """Adapt ordinary source participants; writer filtering cannot remove tasks."""
+        source = command.source
+        cp_size = source.remote_pcp_size * source.remote_dcp_size
+        endpoints = source.endpoints_by_prefill_rank
+        expected_endpoints = source.remote_ptp_size * source.remote_pcp_size * source.remote_pp_size
+        if len(endpoints) != expected_endpoints:
+            raise ValueError("DSA endpoint coverage does not match Prefill topology")
+        if source.remote_pp_size != self._prefill_pp_size:
+            raise ValueError("DSA Prefill PP metadata does not match configured topology")
+        base = endpoints[0].remote_port
+        if cp_size > 1:
+            meta = ReqMeta(
+                (),
+                source.num_external_tokens,
+                source.num_computed_tokens,
+                (),
+                endpoints[0].remote_host,
+                base,
+                endpoints[0].remote_engine_id,
+                source.remote_request_id,
+                source.remote_pcp_size,
+                source.remote_dcp_size,
+                source.remote_ptp_size,
+                {},
+                0,
+                source.remote_block_size,
             )
+            mappings, counts = self._get_cp_source_ports(meta, source.remote_ptp_size, 1)
+            # Source planner's virtual offsets retain CP shard identity. Actual
+            # host/port translation happens after planning, as in ordinary pulls.
+            all_ranks = [
+                [port - base for group in mappings[self.side_channel_port + rank] for port in group]
+                for rank in range(self.tp_size)
+            ]
+            expected = {rank: counts[base + rank]["num"] for rank in range(len(endpoints))}
+        else:
+            all_ranks = self._get_remote_ranks_for_req(source.remote_request_id, source.remote_ptp_size)
+            expected = {rank: sum(ranks.count(rank) for ranks in all_ranks) for rank in range(len(endpoints))}
+        selected = all_ranks[self.tp_rank]
+        tasks = []
+        indexer_stages = set()
+        for task_index, rank in enumerate(selected):
+            pp_rank = rank // source.remote_ptp_size if cp_size == 1 else 0
+            cp_rank = (
+                (rank // source.remote_ptp_size * source.remote_dcp_size + rank % source.remote_dcp_size)
+                if cp_size > 1
+                else 0
+            )
+            include_indexer = pp_rank not in indexer_stages
+            indexer_stages.add(pp_rank)
+            tasks.append((rank, cp_rank, pp_rank, include_indexer, expected[rank], task_index))
+        # Ordinary zero-reader cleanup belongs to the designated D worker.
+        if self.tp_rank == 0:
+            tasks.extend((rank, 0, 0, False, 0, len(selected) + rank) for rank, count in expected.items() if count == 0)
+        if not tasks:
+            raise ValueError("DSA source plan must retain a logical completion task")
+        return tasks
+
+    def _dispatch_dsa_commands(self, commands: tuple[DsaStepRequest, ...]) -> None:
+        if not self._dsa_decode or getattr(self, "_closing", False):
+            raise RuntimeError("DSA commands require an active Decode consumer")
         for command in commands:
-            existing = self._dsa_active_commands.get(
-                command.request_id
-            )
+            existing = self._dsa_active_commands.get(command.request_id)
             if existing is not None:
                 if existing != command:
-                    raise ValueError(
-                        "conflicting blockwise DSA receive for "
-                        f"{command.request_id!r}"
-                    )
+                    raise ValueError(f"conflicting DSA receive for {command.request_id!r}")
                 continue
-            leader_rank = self.tp_rank * (
-                self._prefill_tp_size // self._decode_tp_size
-            )
-            endpoints = command.source.endpoints_by_prefill_rank
-            if len(endpoints) != self._prefill_tp_size:
-                raise ValueError(
-                    "DSA endpoint tuple must contain "
-                    f"{self._prefill_tp_size} Prefill ranks"
-                )
+            plan = self._plan_dsa_endpoints(command)
+            logger.debug("DSA plan request=%s rank=%s endpoint_tasks=%s", command.request_id, self.tp_rank, len(plan))
             self._dsa_active_commands[command.request_id] = command
-            assert self.kv_recv_thread is not None
-            self.kv_recv_thread.add_dsa_request(
-                command,
-                endpoints[leader_rank],
-                lambda result, request=command: (
-                    self._finish_dsa_receive(request, result)
-                ),
-            )
+            cancelled = self._dsa_cancel_events.setdefault(command.request_id, threading.Event())
+            for index, (rank, cp_rank, pp_rank, indexer, expected, task_index) in enumerate(plan):
+                self.kv_recv_thread.add_dsa_request(
+                    command,
+                    command.source.endpoints_by_prefill_rank[rank],
+                    lambda result, request=command: self._finish_dsa_receive(request, result),
+                    cp_rank=cp_rank,
+                    pp_rank=pp_rank,
+                    include_indexer=indexer,
+                    expected=expected,
+                    participant=f"{self.engine_id}:{self.handshake_port}:{task_index}",
+                    cancelled=cancelled,
+                    all_task_done=index == len(plan) - 1,
+                )
 
     def _finish_dsa_receive(
         self,
@@ -4660,7 +4631,9 @@ class MooncakeConnectorWorker:
         if self._dsa_active_commands.get(command.request_id) != command:
             return
         self._dsa_active_commands.pop(command.request_id, None)
-        self._dsa_results.put(result)
+        self._dsa_cancel_events.pop(command.request_id, None)
+        if not command.notify_only:
+            self._dsa_results.put(result)
 
     def build_connector_worker_meta(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_metadata.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metadata for one-shot blockwise DSA Mooncake receives."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorWorkerMetadata,
+)
+
+MAX_TCP_PORT = 65535
+
+
+class DsaLocalResultKind(str, Enum):
+    RECEIVE_COMPLETE = "receive_complete"
+    TRANSFER_FAILED = "transfer_failed"
+
+
+class DsaTransferPhase(str, Enum):
+    INDEXER_D2D = "indexer_d2d"
+    MAIN_D2RH = "main_d2rh"
+
+
+def _require_nonempty_string(name: str, value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+
+
+def _require_nonnegative_integer(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{name} must be nonnegative")
+
+
+def _normalize_block_ids(name: str, values: object) -> tuple[int, ...]:
+    if not isinstance(values, (tuple, list)):
+        raise TypeError(f"{name} must be a tuple or list")
+    block_ids = tuple(values)
+    for block_id in block_ids:
+        _require_nonnegative_integer(name, block_id)
+    if not block_ids:
+        raise ValueError(f"{name} must not be empty")
+    if len(set(block_ids)) != len(block_ids):
+        raise ValueError(f"{name} must not contain duplicates")
+    return block_ids
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteEndpoint:
+    remote_host: str
+    remote_port: int
+    remote_engine_id: str
+
+    def __post_init__(self) -> None:
+        _require_nonempty_string("remote_host", self.remote_host)
+        _require_nonnegative_integer("remote_port", self.remote_port)
+        if self.remote_port == 0 or self.remote_port > MAX_TCP_PORT:
+            raise ValueError("remote_port must be in range 1..65535")
+        _require_nonempty_string("remote_engine_id", self.remote_engine_id)
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteSource:
+    remote_request_id: str
+    endpoints_by_prefill_rank: tuple[RemoteEndpoint, ...]
+    indexer_block_ids: tuple[int, ...]
+    main_block_ids: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        _require_nonempty_string(
+            "remote_request_id",
+            self.remote_request_id,
+        )
+        endpoints = tuple(self.endpoints_by_prefill_rank)
+        if not endpoints:
+            raise ValueError("endpoints_by_prefill_rank must not be empty")
+        if not all(
+            isinstance(endpoint, RemoteEndpoint) for endpoint in endpoints
+        ):
+            raise TypeError(
+                "endpoints_by_prefill_rank must contain RemoteEndpoint values"
+            )
+        object.__setattr__(self, "endpoints_by_prefill_rank", endpoints)
+        object.__setattr__(
+            self,
+            "indexer_block_ids",
+            _normalize_block_ids(
+                "indexer_block_ids",
+                self.indexer_block_ids,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "main_block_ids",
+            _normalize_block_ids("main_block_ids", self.main_block_ids),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DsaStepRequest:
+    """One PD receive into vLLM-owned Decode blocks."""
+
+    request_id: str
+    source: RemoteSource
+    main_host_block_ids: tuple[int, ...]
+    indexer_hbm_block_ids: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        _require_nonempty_string("request_id", self.request_id)
+        if not isinstance(self.source, RemoteSource):
+            raise TypeError("source must be RemoteSource")
+        object.__setattr__(
+            self,
+            "main_host_block_ids",
+            _normalize_block_ids(
+                "main_host_block_ids",
+                self.main_host_block_ids,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "indexer_hbm_block_ids",
+            _normalize_block_ids(
+                "indexer_hbm_block_ids",
+                self.indexer_hbm_block_ids,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DsaConnectorMetadata(KVConnectorMetadata):
+    """One-shot receive requests issued to Decode workers."""
+
+    requests: tuple[DsaStepRequest, ...] = ()
+
+    def __post_init__(self) -> None:
+        requests_by_id: dict[str, DsaStepRequest] = {}
+        for request in self.requests:
+            if not isinstance(request, DsaStepRequest):
+                raise TypeError(
+                    "requests must contain DsaStepRequest values"
+                )
+            existing = requests_by_id.get(request.request_id)
+            if existing is not None and existing != request:
+                raise ValueError(
+                    f"conflicting DSA requests for {request.request_id!r}"
+                )
+            requests_by_id[request.request_id] = request
+        object.__setattr__(
+            self,
+            "requests",
+            tuple(
+                requests_by_id[key] for key in sorted(requests_by_id)
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DsaLocalResult:
+    request_id: str
+    tp_rank: int
+    kind: DsaLocalResultKind
+    failure_phase: DsaTransferPhase | None = None
+
+    def __post_init__(self) -> None:
+        _require_nonempty_string("request_id", self.request_id)
+        _require_nonnegative_integer("tp_rank", self.tp_rank)
+        if not isinstance(self.kind, DsaLocalResultKind):
+            raise TypeError("kind must be DsaLocalResultKind")
+        if self.failure_phase is not None and not isinstance(
+            self.failure_phase,
+            DsaTransferPhase,
+        ):
+            raise TypeError("failure_phase must be DsaTransferPhase")
+        if (
+            self.kind is DsaLocalResultKind.TRANSFER_FAILED
+            and self.failure_phase is None
+        ):
+            raise ValueError("TRANSFER_FAILED requires a failure phase")
+        if (
+            self.kind is DsaLocalResultKind.RECEIVE_COMPLETE
+            and self.failure_phase is not None
+        ):
+            raise ValueError(
+                "RECEIVE_COMPLETE must not carry a failure phase"
+            )
+
+    @property
+    def identity(self) -> tuple[str, int]:
+        return self.request_id, self.tp_rank
+
+
+def _merge_results(
+    groups: Iterable[Iterable[DsaLocalResult]],
+) -> tuple[DsaLocalResult, ...]:
+    merged: dict[tuple[str, int], DsaLocalResult] = {}
+    for results in groups:
+        for result in results:
+            if not isinstance(result, DsaLocalResult):
+                raise TypeError(
+                    "results must contain DsaLocalResult values"
+                )
+            existing = merged.get(result.identity)
+            if existing is not None and existing != result:
+                raise ValueError(
+                    f"conflicting DSA local results for {result.identity}"
+                )
+            merged[result.identity] = result
+    return tuple(merged[key] for key in sorted(merged))
+
+
+@dataclass(frozen=True, slots=True)
+class DsaWorkerResultMetadata(KVConnectorWorkerMetadata):
+    """Rank-aware completion results for one-shot PD receives."""
+
+    results: tuple[DsaLocalResult, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "results",
+            _merge_results((self.results,)),
+        )
+
+    def aggregate(
+        self,
+        other: KVConnectorWorkerMetadata,
+    ) -> DsaWorkerResultMetadata:
+        if not isinstance(other, DsaWorkerResultMetadata):
+            raise TypeError(
+                "aggregate expects DsaWorkerResultMetadata"
+            )
+        return DsaWorkerResultMetadata(
+            _merge_results((self.results, other.results))
+        )

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_metadata.py
@@ -46,8 +46,6 @@ def _normalize_block_ids(name: str, values: object) -> tuple[int, ...]:
     block_ids = tuple(values)
     for block_id in block_ids:
         _require_nonnegative_integer(name, block_id)
-    if not block_ids:
-        raise ValueError(f"{name} must not be empty")
     if len(set(block_ids)) != len(block_ids):
         raise ValueError(f"{name} must not contain duplicates")
     return block_ids
@@ -73,8 +71,35 @@ class RemoteSource:
     endpoints_by_prefill_rank: tuple[RemoteEndpoint, ...]
     indexer_block_ids: tuple[int, ...]
     main_block_ids: tuple[int, ...]
+    remote_dcp_size: int = 1
+    remote_pcp_size: int = 1
+    remote_ptp_size: int = 1
+    remote_pp_size: int = 1
+    remote_block_size: int = 1
+    num_prompt_blocks: int = 0
+    remote_main_group_id: int | None = None
+    remote_indexer_group_id: int | None = None
+    remote_main_block_size: int = 0
+    remote_indexer_block_size: int = 0
+    num_computed_tokens: int = 0
+    num_external_tokens: int = 0
 
     def __post_init__(self) -> None:
+        for name in ("remote_dcp_size", "remote_pcp_size", "remote_ptp_size", "remote_pp_size", "remote_block_size"):
+            _require_nonnegative_integer(name, getattr(self, name))
+            if getattr(self, name) == 0:
+                raise ValueError(f"{name} must be positive")
+        for name in (
+            "num_computed_tokens",
+            "num_external_tokens",
+            "remote_main_block_size",
+            "num_prompt_blocks",
+            "remote_indexer_block_size",
+        ):
+            _require_nonnegative_integer(name, getattr(self, name))
+        for name in ("remote_main_group_id", "remote_indexer_group_id"):
+            if getattr(self, name) is not None:
+                _require_nonnegative_integer(name, getattr(self, name))
         _require_nonempty_string(
             "remote_request_id",
             self.remote_request_id,
@@ -82,12 +107,8 @@ class RemoteSource:
         endpoints = tuple(self.endpoints_by_prefill_rank)
         if not endpoints:
             raise ValueError("endpoints_by_prefill_rank must not be empty")
-        if not all(
-            isinstance(endpoint, RemoteEndpoint) for endpoint in endpoints
-        ):
-            raise TypeError(
-                "endpoints_by_prefill_rank must contain RemoteEndpoint values"
-            )
+        if not all(isinstance(endpoint, RemoteEndpoint) for endpoint in endpoints):
+            raise TypeError("endpoints_by_prefill_rank must contain RemoteEndpoint values")
         object.__setattr__(self, "endpoints_by_prefill_rank", endpoints)
         object.__setattr__(
             self,
@@ -112,11 +133,16 @@ class DsaStepRequest:
     source: RemoteSource
     main_host_block_ids: tuple[int, ...]
     indexer_hbm_block_ids: tuple[int, ...]
+    invalid_block_ids: tuple[int, ...] = ()
+    notify_only: bool = False
 
     def __post_init__(self) -> None:
         _require_nonempty_string("request_id", self.request_id)
         if not isinstance(self.source, RemoteSource):
             raise TypeError("source must be RemoteSource")
+        if not isinstance(self.notify_only, bool):
+            raise TypeError("notify_only must be bool")
+        object.__setattr__(self, "invalid_block_ids", _normalize_block_ids("invalid_block_ids", self.invalid_block_ids))
         object.__setattr__(
             self,
             "main_host_block_ids",
@@ -140,26 +166,21 @@ class DsaConnectorMetadata(KVConnectorMetadata):
     """One-shot receive requests issued to Decode workers."""
 
     requests: tuple[DsaStepRequest, ...] = ()
+    cancelled_requests: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         requests_by_id: dict[str, DsaStepRequest] = {}
         for request in self.requests:
             if not isinstance(request, DsaStepRequest):
-                raise TypeError(
-                    "requests must contain DsaStepRequest values"
-                )
+                raise TypeError("requests must contain DsaStepRequest values")
             existing = requests_by_id.get(request.request_id)
             if existing is not None and existing != request:
-                raise ValueError(
-                    f"conflicting DSA requests for {request.request_id!r}"
-                )
+                raise ValueError(f"conflicting DSA requests for {request.request_id!r}")
             requests_by_id[request.request_id] = request
         object.__setattr__(
             self,
             "requests",
-            tuple(
-                requests_by_id[key] for key in sorted(requests_by_id)
-            ),
+            tuple(requests_by_id[key] for key in sorted(requests_by_id)),
         )
 
 
@@ -180,18 +201,10 @@ class DsaLocalResult:
             DsaTransferPhase,
         ):
             raise TypeError("failure_phase must be DsaTransferPhase")
-        if (
-            self.kind is DsaLocalResultKind.TRANSFER_FAILED
-            and self.failure_phase is None
-        ):
+        if self.kind is DsaLocalResultKind.TRANSFER_FAILED and self.failure_phase is None:
             raise ValueError("TRANSFER_FAILED requires a failure phase")
-        if (
-            self.kind is DsaLocalResultKind.RECEIVE_COMPLETE
-            and self.failure_phase is not None
-        ):
-            raise ValueError(
-                "RECEIVE_COMPLETE must not carry a failure phase"
-            )
+        if self.kind is DsaLocalResultKind.RECEIVE_COMPLETE and self.failure_phase is not None:
+            raise ValueError("RECEIVE_COMPLETE must not carry a failure phase")
 
     @property
     def identity(self) -> tuple[str, int]:
@@ -205,14 +218,10 @@ def _merge_results(
     for results in groups:
         for result in results:
             if not isinstance(result, DsaLocalResult):
-                raise TypeError(
-                    "results must contain DsaLocalResult values"
-                )
+                raise TypeError("results must contain DsaLocalResult values")
             existing = merged.get(result.identity)
             if existing is not None and existing != result:
-                raise ValueError(
-                    f"conflicting DSA local results for {result.identity}"
-                )
+                raise ValueError(f"conflicting DSA local results for {result.identity}")
             merged[result.identity] = result
     return tuple(merged[key] for key in sorted(merged))
 
@@ -235,9 +244,5 @@ class DsaWorkerResultMetadata(KVConnectorWorkerMetadata):
         other: KVConnectorWorkerMetadata,
     ) -> DsaWorkerResultMetadata:
         if not isinstance(other, DsaWorkerResultMetadata):
-            raise TypeError(
-                "aggregate expects DsaWorkerResultMetadata"
-            )
-        return DsaWorkerResultMetadata(
-            _merge_results((self.results, other.results))
-        )
+            raise TypeError("aggregate expects DsaWorkerResultMetadata")
+        return DsaWorkerResultMetadata(_merge_results((self.results, other.results)))

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_transfer.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host destination geometry layered on Mooncake's source endpoint plan."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DsaCacheLayout:
+    layer_name: str
+    position: int
+    base: int
+    block_bytes: int
+    stride: int
+    scale: int
+    block_tokens: int
+    dtype: str
+    capacity: int = 0
+
+
+def build_component_read(
+    local: DsaCacheLayout,
+    remote: DsaCacheLayout,
+    source_ids: tuple[int, ...],
+    destination_ids: tuple[int, ...],
+    start_token: int,
+    end_token: int,
+    *,
+    cp_size: int,
+    cp_rank: int,
+    writer_rank: int,
+    writer_size: int,
+    indexer: bool,
+    statistics: dict[str, int] | None = None,
+) -> tuple[list[int], list[int], list[int]]:
+    """Map token intervals, retaining full-request ordinals and page offsets.
+
+    Main source blocks are CP-sharded. Replicated Indexer stores all CP pages
+    inside each source manager block. Its destination is never writer-filtered.
+    Tensor pages and manager blocks have distinct IDs; packing is determined
+    from token geometry, then checked against bytes and dtype.
+    """
+    if cp_size <= 0 or not 0 <= cp_rank < cp_size:
+        raise ValueError("invalid source CP geometry")
+    if writer_size <= 0 or not 0 <= writer_rank < writer_size:
+        raise ValueError("invalid Main writer geometry")
+    if start_token < 0 or end_token < start_token:
+        raise ValueError("invalid request token interval")
+    remote_span = remote.block_tokens * (cp_size if indexer else 1)
+    if (
+        local.scale <= 0
+        or remote.scale <= 0
+        or local.block_tokens <= 0
+        or remote.block_tokens <= 0
+        or local.block_tokens % local.scale
+        or remote_span % remote.scale
+    ):
+        raise ValueError("cache pages must divide manager token geometry")
+    local_page = local.block_tokens // local.scale
+    remote_page = remote_span // remote.scale
+    if (
+        local.block_bytes % local_page
+        or remote.block_bytes % remote_page
+        or local.block_bytes // local_page != remote.block_bytes // remote_page
+        or local.dtype != remote.dtype
+    ):
+        raise ValueError("incompatible DSA component dtype/token bytes")
+    if local.stride < local.block_bytes or remote.stride < remote.block_bytes:
+        raise ValueError("overlapping component page stride")
+    token_bytes = local.block_bytes // local_page
+    result: tuple[list[int], list[int], list[int]] = ([], [], [])
+    token = start_token
+    while token < end_token:
+        global_source_block, source_offset = divmod(token, remote.block_tokens)
+        destination_ordinal, destination_offset = divmod(token, local.block_tokens)
+        source_ordinal = global_source_block // cp_size
+        if indexer:
+            source_offset += global_source_block % cp_size * remote.block_tokens
+        local_slot, local_offset = divmod(destination_offset, local_page)
+        remote_slot, remote_offset = divmod(source_offset, remote_page)
+        count = min(
+            end_token - token,
+            local_page - local_offset,
+            remote_page - remote_offset,
+            remote.block_tokens - token % remote.block_tokens,
+        )
+        selected = indexer or (
+            global_source_block % cp_size == cp_rank and destination_ordinal % writer_size == writer_rank
+        )
+        if selected:
+            if source_ordinal >= len(source_ids) or destination_ordinal >= len(destination_ids):
+                raise ValueError("incomplete DSA source/destination block coverage")
+            if (local.capacity and destination_ids[destination_ordinal] >= local.capacity) or (
+                remote.capacity and source_ids[source_ordinal] >= remote.capacity
+            ):
+                raise ValueError("DSA physical block ID exceeds registered capacity")
+            local_id = destination_ids[destination_ordinal] * local.scale + local_slot
+            remote_id = source_ids[source_ordinal] * remote.scale + remote_slot
+            result[0].append(local.base + local_id * local.stride + local_offset * token_bytes)
+            result[1].append(remote.base + remote_id * remote.stride + remote_offset * token_bytes)
+            result[2].append(count * token_bytes)
+        token += count
+    merged = coalesce_transfer_lists(*result)
+    if statistics is not None:
+        statistics["entries_before"] = statistics.get("entries_before", 0) + len(result[0])
+        statistics["entries_after"] = statistics.get("entries_after", 0) + len(merged[0])
+    return merged
+
+
+def coalesce_transfer_lists(local, remote, lengths):
+    """Merge only byte ranges contiguous at both ends of one endpoint read."""
+    if len(local) != len(remote) or len(local) != len(lengths):
+        raise ValueError("transfer list coverage mismatch")
+    result = ([], [], [])
+    for dst, src, size in zip(local, remote, lengths):
+        if size <= 0:
+            raise ValueError("transfer length must be positive")
+        if result[2] and dst == result[0][-1] + result[2][-1] and src == result[1][-1] + result[2][-1]:
+            result[2][-1] += size
+        else:
+            result[0].append(dst)
+            result[1].append(src)
+            result[2].append(size)
+    return result

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_dsa_transfer.py
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Host destination geometry layered on Mooncake's source endpoint plan."""
 
+from collections import OrderedDict
+from collections.abc import Hashable
 from dataclasses import dataclass
+
+MAX_REGISTER_MEMORY_BYTES = 64 * 1024**3
 
 
 @dataclass(frozen=True)
@@ -16,6 +20,127 @@ class DsaCacheLayout:
     block_tokens: int
     dtype: str
     capacity: int = 0
+
+
+@dataclass(frozen=True)
+class DsaRegisterAtom:
+    """One transfer component that must not straddle registered regions."""
+
+    start: int
+    end: int
+    location: str
+    allocation: Hashable
+
+
+@dataclass(frozen=True)
+class DsaRegisterRegions:
+    ptrs: list[int]
+    lengths: list[int]
+    locations: list[str]
+
+
+def layout_span_bytes(layout: DsaCacheLayout) -> int:
+    """Return the address span touched by all physical pages in a layout."""
+    physical_pages = layout.capacity * layout.scale
+    if physical_pages <= 0 or layout.block_bytes <= 0 or layout.stride < layout.block_bytes:
+        raise ValueError("invalid DSA registration layout")
+    return (physical_pages - 1) * layout.stride + layout.block_bytes
+
+
+def collect_bounded_register_regions(
+    atoms: list[DsaRegisterAtom],
+    *,
+    max_region_bytes: int = MAX_REGISTER_MEMORY_BYTES,
+) -> DsaRegisterRegions:
+    """Merge atoms per allocation without cutting an atom at a region edge.
+
+    An atom larger than Mooncake's per-call limit is registered in deterministic
+    chunks anchored at the atom base. Transfer entries use the same anchor.
+    """
+    if max_region_bytes <= 0:
+        raise ValueError("max_region_bytes must be positive")
+    grouped: OrderedDict[tuple[Hashable, str], list[DsaRegisterAtom]] = OrderedDict()
+    for atom in atoms:
+        if atom.start < 0 or atom.end <= atom.start:
+            raise ValueError("invalid DSA register atom")
+        grouped.setdefault((atom.allocation, atom.location), []).append(atom)
+
+    ptrs: list[int] = []
+    lengths: list[int] = []
+    locations: list[str] = []
+
+    def append_region(start: int, end: int, location: str) -> None:
+        ptrs.append(start)
+        lengths.append(end - start)
+        locations.append(location)
+
+    for (_, location), allocation_atoms in grouped.items():
+        allocation_atoms.sort(key=lambda atom: (atom.start, atom.end))
+        # Shared layers can expose the exact same tensor more than once. Drop
+        # exact aliases first, including oversized atoms whose chunks would
+        # otherwise be registered twice. Partially overlapping atoms are safe
+        # only when their whole union fits in one registered region.
+        unique_atoms: list[DsaRegisterAtom] = []
+        for atom in allocation_atoms:
+            if unique_atoms and (atom.start, atom.end) == (unique_atoms[-1].start, unique_atoms[-1].end):
+                continue
+            unique_atoms.append(atom)
+        overlap_clusters: list[list[DsaRegisterAtom]] = []
+        for atom in unique_atoms:
+            if not overlap_clusters or atom.start >= max(item.end for item in overlap_clusters[-1]):
+                overlap_clusters.append([atom])
+            else:
+                overlap_clusters[-1].append(atom)
+
+        normalized_atoms: list[DsaRegisterAtom] = []
+        for cluster in overlap_clusters:
+            cluster_start = cluster[0].start
+            cluster_end = max(atom.end for atom in cluster)
+            if cluster_end - cluster_start > max_region_bytes:
+                for atom in cluster:
+                    offset = atom.start - cluster_start
+                    atom_size = atom.end - atom.start
+                    boundary_aligned = atom_size > max_region_bytes and offset % max_region_bytes == 0
+                    within_one_chunk = atom_size <= max_region_bytes and (
+                        offset // max_region_bytes == (offset + atom_size - 1) // max_region_bytes
+                    )
+                    if not (boundary_aligned or within_one_chunk):
+                        raise ValueError("overlapping DSA register atoms cross a registration boundary")
+            normalized_atoms.append(
+                DsaRegisterAtom(
+                    cluster_start,
+                    cluster_end,
+                    location,
+                    cluster[0].allocation,
+                )
+            )
+
+        current_start: int | None = None
+        current_end = 0
+        for atom in normalized_atoms:
+            atom_size = atom.end - atom.start
+            if atom_size > max_region_bytes:
+                if current_start is not None:
+                    append_region(current_start, current_end, location)
+                    current_start = None
+                chunk_start = atom.start
+                while chunk_start < atom.end:
+                    chunk_end = min(chunk_start + max_region_bytes, atom.end)
+                    append_region(chunk_start, chunk_end, location)
+                    chunk_start = chunk_end
+                continue
+            if current_start is None:
+                current_start, current_end = atom.start, atom.end
+            elif atom.end - current_start <= max_region_bytes:
+                # The allocation key proves that any alignment gap is backed
+                # by the same allocation and can safely be registered.
+                current_end = atom.end
+            else:
+                append_region(current_start, current_end, location)
+                current_start, current_end = atom.start, atom.end
+        if current_start is not None:
+            append_region(current_start, current_end, location)
+    return DsaRegisterRegions(ptrs, lengths, locations)
 
 
 def build_component_read(
@@ -101,6 +226,19 @@ def build_component_read(
             result[2].append(count * token_bytes)
         token += count
     merged = coalesce_transfer_lists(*result)
+    if (
+        local.capacity
+        and remote.capacity
+        and (
+            layout_span_bytes(local) > MAX_REGISTER_MEMORY_BYTES
+            or layout_span_bytes(remote) > MAX_REGISTER_MEMORY_BYTES
+        )
+    ):
+        merged = split_transfer_lists_at_region_boundaries(
+            *merged,
+            local_base=local.base,
+            remote_base=remote.base,
+        )
     if statistics is not None:
         statistics["entries_before"] = statistics.get("entries_before", 0) + len(result[0])
         statistics["entries_after"] = statistics.get("entries_after", 0) + len(merged[0])
@@ -121,4 +259,36 @@ def coalesce_transfer_lists(local, remote, lengths):
             result[0].append(dst)
             result[1].append(src)
             result[2].append(size)
+    return result
+
+
+def split_transfer_lists_at_region_boundaries(
+    local,
+    remote,
+    lengths,
+    *,
+    local_base: int,
+    remote_base: int,
+    max_region_bytes: int = MAX_REGISTER_MEMORY_BYTES,
+):
+    """Split reads at both endpoints' deterministic registration edges."""
+    if len(local) != len(remote) or len(local) != len(lengths):
+        raise ValueError("transfer list coverage mismatch")
+    if max_region_bytes <= 0:
+        raise ValueError("max_region_bytes must be positive")
+    result = ([], [], [])
+    for dst, src, size in zip(local, remote, lengths):
+        if size <= 0 or dst < local_base or src < remote_base:
+            raise ValueError("invalid transfer range for registered layout")
+        remaining = size
+        while remaining:
+            local_available = max_region_bytes - (dst - local_base) % max_region_bytes
+            remote_available = max_region_bytes - (src - remote_base) % max_region_bytes
+            part = min(remaining, local_available, remote_available)
+            result[0].append(dst)
+            result[1].append(src)
+            result[2].append(part)
+            dst += part
+            src += part
+            remaining -= part
     return result

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mooncake shared Host-memory pool for sparse KV offload."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+@dataclass(frozen=True)
+class HostPoolTopology:
+    """Tensor-parallel ownership of one shared Host-memory pool."""
+
+    tp_rank: int
+    tp_size: int
+    owner_rank: int = 0
+    device_id: int = 0
+    dp_rank: int = 0
+    tp_group: Any = None
+
+    def __post_init__(self) -> None:
+        if self.tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {self.tp_size}")
+        if not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError(
+                f"tp_rank out of range: rank={self.tp_rank}, "
+                f"size={self.tp_size}"
+            )
+        if not 0 <= self.owner_rank < self.tp_size:
+            raise ValueError(
+                f"owner_rank out of range: owner={self.owner_rank}, "
+                f"size={self.tp_size}"
+            )
+
+
+@dataclass
+class HostMemoryRegion:
+    """One shared allocation and its local NPU-addressable tensor view."""
+
+    tensor: torch.Tensor
+    handle: Any = None
+    register_location: str | None = None
+    release_callback: Callable[[Any], None] | None = None
+    _released: bool = field(default=False, init=False)
+
+    def release(self) -> None:
+        if self._released:
+            return
+        if self.release_callback is not None:
+            self.release_callback(self.handle)
+        self.handle = None
+        self._released = True
+
+
+def _select_shared_segment_mode() -> tuple[bool, bool]:
+    """Select a Mooncake mode that exposes an NPU-addressable Host VA."""
+    try:
+        from mooncake.shared_segment import shared_segment_supported
+    except ImportError as exc:
+        raise RuntimeError(
+            "Mooncake shared_segment support is required for sparse KV "
+            "offload with the Mooncake Host backend"
+        ) from exc
+
+    if shared_segment_supported(mmap=False):
+        return False, False
+    if shared_segment_supported(mmap=True, host_register=True):
+        return True, True
+    raise RuntimeError(
+        "Mooncake shared_segment cannot expose an NPU-addressable address"
+    )
+
+
+def allocate_mooncake_host_region(
+    *,
+    size_bytes: int,
+    alignment: int,
+    topology: HostPoolTopology,
+    name: str = "sparse_kv_offload_host_pool",
+) -> HostMemoryRegion:
+    """Create or map one shared segment for a Decode DP group's Host KV."""
+    try:
+        from mooncake.shared_segment import create_shared_segment
+    except ImportError as exc:
+        raise RuntimeError(
+            "Mooncake shared_segment support is required for sparse KV "
+            "offload with the Mooncake Host backend"
+        ) from exc
+
+    if size_bytes <= 0:
+        raise ValueError(f"size_bytes must be positive, got {size_bytes}")
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    allocation_size_bytes = int(size_bytes) + int(alignment) - 1
+    if topology.tp_size > 1 and topology.tp_group is None:
+        raise RuntimeError(
+            "create_shared_segment requires tp_group when tp_size > 1: "
+            f"tp={topology.tp_rank}/{topology.tp_size}"
+        )
+
+    mmap, host_register = _select_shared_segment_mode()
+    segment_name = f"{name}_dp{topology.dp_rank}"
+    logger.info(
+        "Creating sparse KV Mooncake Host pool name=%s tp=%s/%s owner=%s "
+        "device=%s mmap=%s host_register=%s size_bytes=%s allocated=%s",
+        segment_name,
+        topology.tp_rank,
+        topology.tp_size,
+        topology.owner_rank,
+        topology.device_id,
+        mmap,
+        host_register,
+        size_bytes,
+        allocation_size_bytes,
+    )
+    segment = create_shared_segment(
+        segment_name,
+        blocks={
+            "pool": {
+                "count": 1,
+                "shape": (allocation_size_bytes,),
+                "dtype": torch.int8,
+            }
+        },
+        world_size=topology.tp_size,
+        rank_id=topology.tp_rank,
+        owner_rank=topology.owner_rank,
+        device_id=topology.device_id,
+        tp_group=topology.tp_group,
+        mmap=mmap,
+        host_register=host_register,
+    )
+    if host_register and os.getenv(
+        "VLLM_ASCEND_SKIP_MIGRATEPAGES"
+    ) is None:
+        os.environ["VLLM_ASCEND_SKIP_MIGRATEPAGES"] = "1"
+
+    raw = segment.tensors("pool")[0].reshape(-1)
+    base_offset = _align_up(raw.data_ptr(), alignment) - raw.data_ptr()
+    aligned = raw.narrow(0, base_offset, int(size_bytes))
+    device = getattr(aligned, "device", None)
+    if device is None or getattr(device, "type", None) == "cpu":
+        raise RuntimeError(
+            "Mooncake shared segment did not expose an NPU tensor: "
+            f"device={device}, mmap={mmap}, host_register={host_register}"
+        )
+    return HostMemoryRegion(
+        tensor=aligned,
+        handle=segment,
+        register_location=f"npu:{topology.device_id}",
+    )
+
+
+class MooncakeHostPool:
+    """Aligned bump allocator over one Mooncake shared segment."""
+
+    def __init__(
+        self,
+        region: HostMemoryRegion,
+        topology: HostPoolTopology,
+    ) -> None:
+        if region.tensor.dtype != torch.int8:
+            raise TypeError(
+                "Mooncake Host pool must use an int8 byte tensor, got "
+                f"{region.tensor.dtype}"
+            )
+        if not region.tensor.is_contiguous():
+            raise ValueError("Mooncake Host pool allocation must be contiguous")
+        self.region = region
+        self.topology = topology
+        self._offset = 0
+        self._registered_engine: Any = None
+        self._closed = False
+
+    @classmethod
+    def allocate(
+        cls,
+        *,
+        size_bytes: int,
+        alignment: int,
+        topology: HostPoolTopology,
+    ) -> MooncakeHostPool:
+        region = allocate_mooncake_host_region(
+            size_bytes=size_bytes,
+            alignment=alignment,
+            topology=topology,
+        )
+        try:
+            return cls(region, topology)
+        except Exception:
+            region.release()
+            raise
+
+    @property
+    def data_ptr(self) -> int:
+        return int(self.region.tensor.data_ptr())
+
+    @property
+    def nbytes(self) -> int:
+        return self.region.tensor.numel()
+
+    @property
+    def is_owner(self) -> bool:
+        return self.topology.tp_rank == self.topology.owner_rank
+
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor]:
+        if self._closed:
+            raise RuntimeError("cannot allocate from a closed Mooncake Host pool")
+        tensors: list[torch.Tensor] = []
+        for size in sizes:
+            if size < 0:
+                raise ValueError(f"allocation size must be non-negative, got {size}")
+            start = _align_up(self.data_ptr + self._offset, alignment) - self.data_ptr
+            end = start + int(size)
+            if end > self.nbytes:
+                raise MemoryError(
+                    "Mooncake Host pool is exhausted: "
+                    f"requested={size}, offset={start}, capacity={self.nbytes}"
+                )
+            tensors.append(self.region.tensor.narrow(0, start, int(size)))
+            self._offset = end
+        return tensors
+
+    def register(self, engine: Any) -> None:
+        if self._closed:
+            raise RuntimeError("cannot register a closed Mooncake Host pool")
+        if not self.is_owner:
+            raise RuntimeError(
+                "only the owner rank may register the Mooncake Host pool: "
+                f"rank={self.topology.tp_rank}, owner={self.topology.owner_rank}"
+            )
+        if self._registered_engine is engine:
+            return
+        if self._registered_engine is not None:
+            raise RuntimeError("Mooncake Host pool is already registered")
+        location = self.region.register_location
+        if location is None:
+            result = engine.register_memory(self.data_ptr, self.nbytes)
+        else:
+            try:
+                result = engine.register_memory(
+                    self.data_ptr,
+                    self.nbytes,
+                    location=location,
+                )
+            except TypeError:
+                result = engine.register_memory(
+                    self.data_ptr,
+                    self.nbytes,
+                    location,
+                )
+        if result not in (0, None):
+            raise RuntimeError(
+                "Mooncake register_memory failed for sparse KV Host pool: "
+                f"result={result}, ptr=0x{self.data_ptr:x}, size={self.nbytes}"
+            )
+        self._registered_engine = engine
+
+    def unregister(self) -> None:
+        if self._registered_engine is None:
+            return
+        unregister_memory = getattr(
+            self._registered_engine,
+            "unregister_memory",
+            None,
+        )
+        if unregister_memory is None:
+            raise RuntimeError(
+                "Mooncake engine must unregister the Host pool before release"
+            )
+        try:
+            result = unregister_memory(self.data_ptr)
+        except TypeError:
+            result = unregister_memory(self.data_ptr, self.nbytes)
+        if result not in (0, None):
+            raise RuntimeError(
+                "Mooncake unregister_memory failed for sparse KV Host pool: "
+                f"result={result}, ptr=0x{self.data_ptr:x}"
+            )
+        self._registered_engine = None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.unregister()
+        self.region.release()
+        self._closed = True

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -35,15 +35,9 @@ class HostPoolTopology:
         if self.tp_size <= 0:
             raise ValueError(f"tp_size must be positive, got {self.tp_size}")
         if not 0 <= self.tp_rank < self.tp_size:
-            raise ValueError(
-                f"tp_rank out of range: rank={self.tp_rank}, "
-                f"size={self.tp_size}"
-            )
+            raise ValueError(f"tp_rank out of range: rank={self.tp_rank}, size={self.tp_size}")
         if not 0 <= self.owner_rank < self.tp_size:
-            raise ValueError(
-                f"owner_rank out of range: owner={self.owner_rank}, "
-                f"size={self.tp_size}"
-            )
+            raise ValueError(f"owner_rank out of range: owner={self.owner_rank}, size={self.tp_size}")
 
 
 @dataclass
@@ -71,17 +65,14 @@ def _select_shared_segment_mode() -> tuple[bool, bool]:
         from mooncake.shared_segment import shared_segment_supported
     except ImportError as exc:
         raise RuntimeError(
-            "Mooncake shared_segment support is required for sparse KV "
-            "offload with the Mooncake Host backend"
+            "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
     if shared_segment_supported(mmap=False):
         return False, False
     if shared_segment_supported(mmap=True, host_register=True):
         return True, True
-    raise RuntimeError(
-        "Mooncake shared_segment cannot expose an NPU-addressable address"
-    )
+    raise RuntimeError("Mooncake shared_segment cannot expose an NPU-addressable address")
 
 
 def allocate_mooncake_host_region(
@@ -96,8 +87,7 @@ def allocate_mooncake_host_region(
         from mooncake.shared_segment import create_shared_segment
     except ImportError as exc:
         raise RuntimeError(
-            "Mooncake shared_segment support is required for sparse KV "
-            "offload with the Mooncake Host backend"
+            "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
     if size_bytes <= 0:
@@ -107,8 +97,7 @@ def allocate_mooncake_host_region(
     allocation_size_bytes = int(size_bytes) + int(alignment) - 1
     if topology.tp_size > 1 and topology.tp_group is None:
         raise RuntimeError(
-            "create_shared_segment requires tp_group when tp_size > 1: "
-            f"tp={topology.tp_rank}/{topology.tp_size}"
+            f"create_shared_segment requires tp_group when tp_size > 1: tp={topology.tp_rank}/{topology.tp_size}"
         )
 
     mmap, host_register = _select_shared_segment_mode()
@@ -143,9 +132,7 @@ def allocate_mooncake_host_region(
         mmap=mmap,
         host_register=host_register,
     )
-    if host_register and os.getenv(
-        "VLLM_ASCEND_SKIP_MIGRATEPAGES"
-    ) is None:
+    if host_register and os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES") is None:
         os.environ["VLLM_ASCEND_SKIP_MIGRATEPAGES"] = "1"
 
     raw = segment.tensors("pool")[0].reshape(-1)
@@ -173,10 +160,7 @@ class MooncakeHostPool:
         topology: HostPoolTopology,
     ) -> None:
         if region.tensor.dtype != torch.int8:
-            raise TypeError(
-                "Mooncake Host pool must use an int8 byte tensor, got "
-                f"{region.tensor.dtype}"
-            )
+            raise TypeError(f"Mooncake Host pool must use an int8 byte tensor, got {region.tensor.dtype}")
         if not region.tensor.is_contiguous():
             raise ValueError("Mooncake Host pool allocation must be contiguous")
         self.region = region
@@ -231,8 +215,7 @@ class MooncakeHostPool:
             end = start + int(size)
             if end > self.nbytes:
                 raise MemoryError(
-                    "Mooncake Host pool is exhausted: "
-                    f"requested={size}, offset={start}, capacity={self.nbytes}"
+                    f"Mooncake Host pool is exhausted: requested={size}, offset={start}, capacity={self.nbytes}"
                 )
             tensors.append(self.region.tensor.narrow(0, start, int(size)))
             self._offset = end
@@ -282,17 +265,14 @@ class MooncakeHostPool:
             None,
         )
         if unregister_memory is None:
-            raise RuntimeError(
-                "Mooncake engine must unregister the Host pool before release"
-            )
+            raise RuntimeError("Mooncake engine must unregister the Host pool before release")
         try:
             result = unregister_memory(self.data_ptr)
         except TypeError:
             result = unregister_memory(self.data_ptr, self.nbytes)
         if result not in (0, None):
             raise RuntimeError(
-                "Mooncake unregister_memory failed for sparse KV Host pool: "
-                f"result={result}, ptr=0x{self.data_ptr:x}"
+                f"Mooncake unregister_memory failed for sparse KV Host pool: result={result}, ptr=0x{self.data_ptr:x}"
             )
         self._registered_engine = None
 

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -46,7 +46,6 @@ class HostMemoryRegion:
 
     tensor: torch.Tensor
     handle: Any = None
-    register_location: str | None = None
     release_callback: Callable[[Any], None] | None = None
     _released: bool = field(default=False, init=False)
 
@@ -68,8 +67,6 @@ def _select_shared_segment_mode() -> tuple[bool, bool]:
             "Mooncake shared_segment support is required for sparse KV offload with the Mooncake Host backend"
         ) from exc
 
-    if shared_segment_supported(mmap=False):
-        return False, False
     if shared_segment_supported(mmap=True, host_register=True):
         return True, True
     raise RuntimeError("Mooncake shared_segment cannot expose an NPU-addressable address")
@@ -147,7 +144,6 @@ def allocate_mooncake_host_region(
     return HostMemoryRegion(
         tensor=aligned,
         handle=segment,
-        register_location=f"npu:{topology.device_id}",
     )
 
 
@@ -166,7 +162,6 @@ class MooncakeHostPool:
         self.region = region
         self.topology = topology
         self._offset = 0
-        self._registered_engine: Any = None
         self._closed = False
 
     @classmethod
@@ -196,10 +191,6 @@ class MooncakeHostPool:
     def nbytes(self) -> int:
         return self.region.tensor.numel()
 
-    @property
-    def is_owner(self) -> bool:
-        return self.topology.tp_rank == self.topology.owner_rank
-
     def allocate_tensors(
         self,
         sizes: list[int],
@@ -221,64 +212,8 @@ class MooncakeHostPool:
             self._offset = end
         return tensors
 
-    def register(self, engine: Any) -> None:
-        if self._closed:
-            raise RuntimeError("cannot register a closed Mooncake Host pool")
-        if not self.is_owner:
-            raise RuntimeError(
-                "only the owner rank may register the Mooncake Host pool: "
-                f"rank={self.topology.tp_rank}, owner={self.topology.owner_rank}"
-            )
-        if self._registered_engine is engine:
-            return
-        if self._registered_engine is not None:
-            raise RuntimeError("Mooncake Host pool is already registered")
-        location = self.region.register_location
-        if location is None:
-            result = engine.register_memory(self.data_ptr, self.nbytes)
-        else:
-            try:
-                result = engine.register_memory(
-                    self.data_ptr,
-                    self.nbytes,
-                    location=location,
-                )
-            except TypeError:
-                result = engine.register_memory(
-                    self.data_ptr,
-                    self.nbytes,
-                    location,
-                )
-        if result not in (0, None):
-            raise RuntimeError(
-                "Mooncake register_memory failed for sparse KV Host pool: "
-                f"result={result}, ptr=0x{self.data_ptr:x}, size={self.nbytes}"
-            )
-        self._registered_engine = engine
-
-    def unregister(self) -> None:
-        if self._registered_engine is None:
-            return
-        unregister_memory = getattr(
-            self._registered_engine,
-            "unregister_memory",
-            None,
-        )
-        if unregister_memory is None:
-            raise RuntimeError("Mooncake engine must unregister the Host pool before release")
-        try:
-            result = unregister_memory(self.data_ptr)
-        except TypeError:
-            result = unregister_memory(self.data_ptr, self.nbytes)
-        if result not in (0, None):
-            raise RuntimeError(
-                f"Mooncake unregister_memory failed for sparse KV Host pool: result={result}, ptr=0x{self.data_ptr:x}"
-            )
-        self._registered_engine = None
-
     def close(self) -> None:
         if self._closed:
             return
-        self.unregister()
         self.region.release()
         self._closed = True

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
 import torch
-
-logger = logging.getLogger(__name__)
+from vllm.logger import logger
 
 
 def _align_up(value: int, alignment: int) -> int:
@@ -212,6 +210,15 @@ class MooncakeHostPool:
                 )
             tensors.append(self.region.tensor.narrow(0, start, int(size)))
             self._offset = end
+        logger.debug(
+            "Mooncake HostPool allocated views rank=%s/%s views=%s requested_bytes=%s used_bytes=%s capacity_bytes=%s",
+            self.topology.tp_rank,
+            self.topology.tp_size,
+            len(tensors),
+            sum(sizes),
+            self._offset,
+            self.nbytes,
+        )
         return tensors
 
     def describe_local_views(self, views, num_blocks: int) -> tuple:
@@ -237,6 +244,14 @@ class MooncakeHostPool:
         ranges.sort()
         if any(a[1] > b[0] for a, b in zip(ranges, ranges[1:])):
             raise ValueError("overlapping Host views")
+        logger.debug(
+            "Mooncake HostPool described local views rank=%s/%s components=%s blocks=%s capacity_bytes=%s",
+            self.topology.tp_rank,
+            self.topology.tp_size,
+            len(entries),
+            num_blocks,
+            self.nbytes,
+        )
         return self.region.segment_offset, self.nbytes, tuple(entries)
 
     def close(self) -> None:
@@ -244,3 +259,8 @@ class MooncakeHostPool:
             return
         self.region.release()
         self._closed = True
+        logger.debug(
+            "Mooncake HostPool closed rank=%s/%s",
+            self.topology.tp_rank,
+            self.topology.tp_size,
+        )

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -48,7 +48,6 @@ class HostMemoryRegion:
     handle: Any = None
     release_callback: Callable[[Any], None] | None = None
     segment_offset: int = 0
-    segment_offset: int = 0
     _released: bool = field(default=False, init=False)
 
     def release(self) -> None:
@@ -239,6 +238,7 @@ class MooncakeHostPool:
         if any(a[1] > b[0] for a, b in zip(ranges, ranges[1:])):
             raise ValueError("overlapping Host views")
         return self.region.segment_offset, self.nbytes, tuple(entries)
+
     def close(self) -> None:
         if self._closed:
             return

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/mooncake_host_pool.py
@@ -47,6 +47,8 @@ class HostMemoryRegion:
     tensor: torch.Tensor
     handle: Any = None
     release_callback: Callable[[Any], None] | None = None
+    segment_offset: int = 0
+    segment_offset: int = 0
     _released: bool = field(default=False, init=False)
 
     def release(self) -> None:
@@ -144,6 +146,7 @@ def allocate_mooncake_host_region(
     return HostMemoryRegion(
         tensor=aligned,
         handle=segment,
+        segment_offset=base_offset,
     )
 
 
@@ -212,6 +215,30 @@ class MooncakeHostPool:
             self._offset = end
         return tensors
 
+    def describe_local_views(self, views, num_blocks: int) -> tuple:
+        """Validate typed views and describe shared offsets, not absolute virtual addresses."""
+        entries, ranges = [], []
+        identities = set()
+        for name, component, tensor in views:
+            if (name, component) in identities:
+                raise ValueError("duplicate Host component")
+            identities.add((name, component))
+            if tensor.ndim not in (3, 4) or tensor.shape[0] != num_blocks or num_blocks <= 0:
+                raise ValueError("invalid Host block capacity/shape")
+            if not tensor.is_contiguous():
+                raise ValueError("Host views must be contiguous for zero-copy fused consumption")
+            if tensor.data_ptr() % tensor.element_size():
+                raise ValueError("Host view is not dtype aligned")
+            offset = tensor.data_ptr() - self.data_ptr
+            size = tensor.numel() * tensor.element_size()
+            if offset < 0 or size <= 0 or offset + size > self.nbytes:
+                raise ValueError("Host view outside shared pool")
+            ranges.append((offset, offset + size))
+            entries.append((name, component, offset, tuple(tensor.shape), str(tensor.dtype), tuple(tensor.stride())))
+        ranges.sort()
+        if any(a[1] > b[0] for a, b in zip(ranges, ranges[1:])):
+            raise ValueError("overlapping Host views")
+        return self.region.segment_offset, self.nbytes, tuple(entries)
     def close(self) -> None:
         if self._closed:
             return

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -45,6 +45,17 @@ OFFLOAD_V_CACHE_CPU_INDEX = 3
 OFFLOAD_TOPK_BUFFER_K_INDEX = 4
 OFFLOAD_TOPK_BUFFER_V_INDEX = 5
 
+
+class HostKVAllocator(typing.Protocol):
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor]: ...
+
+    def close(self) -> None: ...
+
+
 FSA_EXTERNAL_PLAN_READY_MARKER = 0x5A45
 FSA_PAIRED_SELECTION_COPY_MARKER = 0x5A56
 FSA_SELECTION_MEMBERSHIP_MAP_INT16_COUNT = 16376
@@ -320,8 +331,17 @@ def allocate_kv_cache_tensors_for_sparse_kv_offload(
     tp_rank: int,
     keep_device_kv_cache: bool,
     npu_kv_cache_allocate_func: typing.Callable,
+    host_kv_cache_allocate_func: typing.Callable[
+        [list[int], int], list[torch.Tensor | None]
+    ]
+    | None = None,
 ):
-    if tp_rank == 0:
+    if host_kv_cache_allocate_func is not None:
+        [k_tensor_cpu, v_tensor_cpu] = host_kv_cache_allocate_func(
+            [k_tensor_size, v_tensor_size],
+            alignment,
+        )
+    elif tp_rank == 0:
         [k_tensor_cpu, v_tensor_cpu] = empty_aligned_int8_cpu_tensors(
             [k_tensor_size, v_tensor_size],
             alignment,
@@ -383,7 +403,7 @@ def reshape_kv_cache_tensors_for_sparse_kv_offload(
     k_cache = raw_k_tensor.view(k_cache_dtype).view(k_shape) if raw_k_tensor is not None else None
     v_cache = raw_v_tensor.view(v_cache_dtype).view(v_shape) if raw_v_tensor is not None else None
 
-    if tp_rank == 0:
+    if raw_k_tensor_cpu is not None and raw_v_tensor_cpu is not None:
         k_cache_cpu = raw_k_tensor_cpu.view(k_cache_dtype).view(k_shape)
         v_cache_cpu = raw_v_tensor_cpu.view(v_cache_dtype).view(v_shape)
     else:
@@ -535,23 +555,70 @@ class SparseKVOffloadManager:
                 f"limit={sparse_kv_offload_config.dram_size_per_dp_GB} GiB, "
                 f"num_blocks={kv_cache_config.num_blocks}"
             )
-        actual_pool_size_bytes = min(planned_pool_size_bytes, dram_limit_bytes)
+        self.host_pool_size_bytes = min(
+            planned_pool_size_bytes,
+            dram_limit_bytes,
+        )
+        self._host_kv_allocator: HostKVAllocator | None = None
+        self._host_allocation_prepared = False
         logger.info(
             "SparseKVOffloadManager starts CPU KV pool initialization: "
             "planned=%.2f GiB, configured_limit=%s GiB, num_blocks=%s.",
-            actual_pool_size_bytes / (1 << 30),
+            self.host_pool_size_bytes / (1 << 30),
             sparse_kv_offload_config.dram_size_per_dp_GB,
             kv_cache_config.num_blocks,
         )
+
+    def prepare_host_kv_allocation(
+        self,
+        *,
+        device_id: int,
+        dp_rank: int,
+    ) -> None:
+        """Prepare Host KV allocation before per-layer cache allocation."""
+        if self._host_allocation_prepared:
+            return
+
+        # dp_rank is part of the backend-neutral contract. The existing
+        # MemFabric allocator does not need it.
+        del dp_rank
         config = offload.OffloadConfig()
-        config.device_id = torch_npu.npu.current_device()
-        config.reserve_size = actual_pool_size_bytes
-        config.alloc_size = actual_pool_size_bytes if self.tp_rank == 0 else 0
+        config.device_id = device_id
+        config.reserve_size = self.host_pool_size_bytes
+        config.alloc_size = (
+            self.host_pool_size_bytes if self.tp_rank == 0 else 0
+        )
         config.world_size = self.tp_size
         config.rank_id = self.tp_rank
         config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
+        assert offload.initialize(config) == 0, (
+            "Sparse KV offload offload.initialize failed."
+        )
         self.tp_group.barrier()
+        self._host_allocation_prepared = True
+
+    def allocate_host_kv_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor | None]:
+        """Allocate one layer's Host K/V through the prepared allocator."""
+        if not self._host_allocation_prepared:
+            raise RuntimeError(
+                "prepare_host_kv_allocation must run before Host KV allocation"
+            )
+        if self._host_kv_allocator is not None:
+            return self._host_kv_allocator.allocate_tensors(sizes, alignment)
+        if self.tp_rank == 0:
+            return empty_aligned_int8_cpu_tensors(sizes, alignment)
+        return [None for _ in sizes]
+
+    def close(self) -> None:
+        """Release backend-owned Host KV resources."""
+        allocator = self._host_kv_allocator
+        if allocator is not None:
+            allocator.close()
+            self._host_kv_allocator = None
 
     def _warmup_external_lru_planner_threads(self) -> int:
         if not (self.use_fused_overlap and self.tp_rank == 0):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -797,6 +797,10 @@ class SparseKVOffloadManager:
     ):
         self._register_offload_layers(kv_caches)
 
+        # HostKVAllocator-backed pools give every TP rank local Host KV views,
+        # while the legacy MemFabric path only allocates on tp_rank == 0.
+        uses_host_allocator = self._host_kv_allocator is not None
+
         # register topk_buffer and cpu kv_cache
         self.topk_buffers_k: list[torch.Tensor] = []
         self.topk_buffers_v: list[torch.Tensor] = []
@@ -812,7 +816,7 @@ class SparseKVOffloadManager:
                 )
             self.topk_buffers_k.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_K_INDEX])
             self.topk_buffers_v.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_V_INDEX])
-            if self.tp_rank == 0:
+            if uses_host_allocator or self.tp_rank == 0:
                 self.k_caches_cpu.append(cache_or_caches[OFFLOAD_K_CACHE_CPU_INDEX])
                 self.v_caches_cpu.append(cache_or_caches[OFFLOAD_V_CACHE_CPU_INDEX])
 
@@ -881,53 +885,74 @@ class SparseKVOffloadManager:
         self.gvas_k_bases: list[int] = []
         self.gvas_v_bases: list[int] = []
         self.cpu_block_lens: list[tuple[int, int]] = []
-        gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
-        gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
-        cpu_block_lens_tensor = torch.zeros([self.num_layers, 2], dtype=torch.int64, device="npu")
-        shape_k_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
-        shape_v_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
-        if self.tp_rank == 0:
+        if uses_host_allocator:
+            # HostKVAllocator gave every rank local Host KV views: use them
+            # directly instead of broadcasting the tp0 pointers.
             for layer_id in range(self.num_layers):
                 k_cpu = self.k_caches_cpu[layer_id]
                 v_cpu = self.v_caches_cpu[layer_id]
-                gvas_k_tensor[layer_id] = k_cpu.data_ptr()
-                gvas_v_tensor[layer_id] = v_cpu.data_ptr()
-                cpu_block_lens_tensor[layer_id, 0] = (
-                    k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks
+                self.gvas_k_bases.append(k_cpu.data_ptr())
+                self.gvas_v_bases.append(v_cpu.data_ptr())
+                self.cpu_block_lens.append(
+                    (
+                        k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks,
+                        v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks,
+                    )
                 )
-                cpu_block_lens_tensor[layer_id, 1] = (
-                    v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks
-                )
-            shape_k_tensor.copy_(torch.tensor(self.k_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
-            shape_v_tensor.copy_(torch.tensor(self.v_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
-        self.tp_group.broadcast(gvas_k_tensor, src=0)
-        self.tp_group.broadcast(gvas_v_tensor, src=0)
-        self.tp_group.broadcast(cpu_block_lens_tensor, src=0)
-        self.tp_group.broadcast(shape_k_tensor, src=0)
-        self.tp_group.broadcast(shape_v_tensor, src=0)
-        for layer_id in range(self.num_layers):
-            self.gvas_k_bases.append(gvas_k_tensor[layer_id].item())
-            self.gvas_v_bases.append(gvas_v_tensor[layer_id].item())
-            self.cpu_block_lens.append(
-                (
-                    cpu_block_lens_tensor[layer_id, 0].item(),
-                    cpu_block_lens_tensor[layer_id, 1].item(),
-                )
-            )
-
-        if self.use_fused_overlap and self.tp_rank != 0:
-            cpu_k_shape = [int(x) for x in shape_k_tensor.tolist()]
-            cpu_v_shape = [int(x) for x in shape_v_tensor.tolist()]
-            self.k_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_k_shape) for ptr in self.gvas_k_bases]
-            self.v_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_v_shape) for ptr in self.gvas_v_bases]
             logger.info(
-                "[fused_overlap_offload][init] restored shared CPU KV views on "
-                "tp_rank=%s layer_count=%s k_shape=%s v_shape=%s",
+                "Registered local Host KV views: tp=%s/%s layers=%s",
                 self.tp_rank,
+                self.tp_size,
                 self.num_layers,
-                cpu_k_shape,
-                cpu_v_shape,
             )
+        else:
+            gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+            gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
+            cpu_block_lens_tensor = torch.zeros([self.num_layers, 2], dtype=torch.int64, device="npu")
+            shape_k_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
+            shape_v_tensor = torch.zeros([4], dtype=torch.int64, device="npu")
+            if self.tp_rank == 0:
+                for layer_id in range(self.num_layers):
+                    k_cpu = self.k_caches_cpu[layer_id]
+                    v_cpu = self.v_caches_cpu[layer_id]
+                    gvas_k_tensor[layer_id] = k_cpu.data_ptr()
+                    gvas_v_tensor[layer_id] = v_cpu.data_ptr()
+                    cpu_block_lens_tensor[layer_id, 0] = (
+                        k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks
+                    )
+                    cpu_block_lens_tensor[layer_id, 1] = (
+                        v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks
+                    )
+                shape_k_tensor.copy_(torch.tensor(self.k_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
+                shape_v_tensor.copy_(torch.tensor(self.v_caches_cpu[0].shape, dtype=torch.int64, device="npu"))
+            self.tp_group.broadcast(gvas_k_tensor, src=0)
+            self.tp_group.broadcast(gvas_v_tensor, src=0)
+            self.tp_group.broadcast(cpu_block_lens_tensor, src=0)
+            self.tp_group.broadcast(shape_k_tensor, src=0)
+            self.tp_group.broadcast(shape_v_tensor, src=0)
+            for layer_id in range(self.num_layers):
+                self.gvas_k_bases.append(gvas_k_tensor[layer_id].item())
+                self.gvas_v_bases.append(gvas_v_tensor[layer_id].item())
+                self.cpu_block_lens.append(
+                    (
+                        cpu_block_lens_tensor[layer_id, 0].item(),
+                        cpu_block_lens_tensor[layer_id, 1].item(),
+                    )
+                )
+
+            if self.use_fused_overlap and self.tp_rank != 0:
+                cpu_k_shape = [int(x) for x in shape_k_tensor.tolist()]
+                cpu_v_shape = [int(x) for x in shape_v_tensor.tolist()]
+                self.k_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_k_shape) for ptr in self.gvas_k_bases]
+                self.v_caches_cpu = [self._restore_bfloat16_tensor(ptr, cpu_v_shape) for ptr in self.gvas_v_bases]
+                logger.info(
+                    "[fused_overlap_offload][init] restored shared CPU KV views on "
+                    "tp_rank=%s layer_count=%s k_shape=%s v_shape=%s",
+                    self.tp_rank,
+                    self.num_layers,
+                    cpu_k_shape,
+                    cpu_v_shape,
+                )
 
         gvas_buffer_offset = 0
         gvas_buffer_size_bytes = self.max_num_topk_rows * self.topk * 2 * 8  # 2: k+v, 8: int64

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -31,6 +31,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostPoolTopology,
+    MooncakeHostPool,
+)
 from vllm_ascend.utils import AscendDeviceType, enable_custom_op, get_ascend_device_type
 
 # Main BF16 cache:
@@ -51,7 +55,7 @@ class HostKVAllocator(typing.Protocol):
         self,
         sizes: list[int],
         alignment: int,
-    ) -> list[torch.Tensor]: ...
+    ) -> list[torch.Tensor | None]: ...
 
     def close(self) -> None: ...
 
@@ -206,6 +210,33 @@ def empty_aligned_int8_cpu_tensors(
         allocate_tensors.append(raw_tensor[base_offset : base_offset + size])
         base_offset += chunk_num * alignment
     return allocate_tensors
+
+
+class MemFabricHostKVAllocator:
+    """HostKVAllocator implementation over the legacy MemFabric backend.
+
+    The MemFabric pool is prepared once by `offload.initialize` in
+    prepare_host_kv_allocation and only tp_rank 0 allocates per-layer
+    tensors; other ranks receive None and rely on the tp0 pointer
+    broadcast in register_kv_caches.
+    """
+
+    def __init__(self, tp_rank: int) -> None:
+        self._tp_rank = tp_rank
+
+    def allocate_tensors(
+        self,
+        sizes: list[int],
+        alignment: int,
+    ) -> list[torch.Tensor | None]:
+        if self._tp_rank == 0:
+            return empty_aligned_int8_cpu_tensors(sizes, alignment)
+        return [None for _ in sizes]
+
+    def close(self) -> None:
+        # MemFabric pool is process-scoped and owned by the offload
+        # runtime; there is nothing per-allocator to release.
+        return None
 
 
 @dataclass(frozen=True)
@@ -508,6 +539,7 @@ class SparseKVOffloadManager:
         self.topk_buffer_size = sparse_kv_offload_config.topk_buffer_size
         self.topk = sparse_kv_offload_config.topk
         self.use_fused_overlap = sparse_kv_offload_config.use_fused_overlap
+        self.host_backend = sparse_kv_offload_config.host_backend
 
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
@@ -576,19 +608,45 @@ class SparseKVOffloadManager:
         if self._host_allocation_prepared:
             return
 
-        # dp_rank is part of the backend-neutral contract. The existing
-        # MemFabric allocator does not need it.
-        del dp_rank
-        config = offload.OffloadConfig()
-        config.device_id = device_id
-        config.reserve_size = self.host_pool_size_bytes
-        config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
-        config.world_size = self.tp_size
-        config.rank_id = self.tp_rank
-        config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
-        self.tp_group.barrier()
-        self._host_allocation_prepared = True
+        if self.host_backend == "mooncake":
+            topology = HostPoolTopology(
+                tp_rank=self.tp_rank,
+                tp_size=self.tp_size,
+                owner_rank=0,
+                device_id=device_id,
+                dp_rank=dp_rank,
+                tp_group=self.tp_group,
+            )
+            self._host_kv_allocator = MooncakeHostPool.allocate(
+                size_bytes=self.host_pool_size_bytes,
+                alignment=_CPU_CACHE_ALIGNMENT,
+                topology=topology,
+            )
+            self._host_allocation_prepared = True
+            logger.info(
+                "Sparse KV offload selected Mooncake Host backend: pool=%.2f GiB, tp=%s/%s, dp=%s, owner=%s.",
+                self.host_pool_size_bytes / (1 << 30),
+                self.tp_rank,
+                self.tp_size,
+                dp_rank,
+                topology.owner_rank,
+            )
+        elif self.host_backend == "memfabric":
+            # MemFabric: process-wide pool prepared here; dp_rank is part of
+            # the backend-neutral contract but unused by this backend.
+            config = offload.OffloadConfig()
+            config.device_id = device_id
+            config.reserve_size = self.host_pool_size_bytes
+            config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
+            config.world_size = self.tp_size
+            config.rank_id = self.tp_rank
+            config.scene = offload.Scene.SHARED
+            assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
+            self.tp_group.barrier()
+            self._host_kv_allocator = MemFabricHostKVAllocator(self.tp_rank)
+            self._host_allocation_prepared = True
+        else:
+            raise ValueError(f"Unsupported sparse KV offload Host backend: {self.host_backend!r}")
 
     def allocate_host_kv_tensors(
         self,
@@ -596,13 +654,10 @@ class SparseKVOffloadManager:
         alignment: int,
     ) -> list[torch.Tensor | None]:
         """Allocate one layer's Host K/V through the prepared allocator."""
-        if not self._host_allocation_prepared:
+        allocator = self._host_kv_allocator
+        if allocator is None:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
-        if self._host_kv_allocator is not None:
-            return self._host_kv_allocator.allocate_tensors(sizes, alignment)
-        if self.tp_rank == 0:
-            return empty_aligned_int8_cpu_tensors(sizes, alignment)
-        return [None for _ in sizes]
+        return allocator.allocate_tensors(sizes, alignment)
 
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
@@ -788,9 +843,8 @@ class SparseKVOffloadManager:
     ):
         self._register_offload_layers(kv_caches)
 
-        # HostKVAllocator-backed pools give every TP rank local Host KV views,
-        # while the legacy MemFabric path only allocates on tp_rank == 0.
-        uses_host_allocator = self._host_kv_allocator is not None
+        # Mooncake hands every TP rank local Host KV views; MemFabric uses tp0 allocation + pointer broadcast.
+        uses_local_views = self.host_backend == "mooncake"
 
         # register topk_buffer and cpu kv_cache
         self.topk_buffers_k: list[torch.Tensor] = []
@@ -807,7 +861,7 @@ class SparseKVOffloadManager:
                 )
             self.topk_buffers_k.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_K_INDEX])
             self.topk_buffers_v.append(cache_or_caches[OFFLOAD_TOPK_BUFFER_V_INDEX])
-            if uses_host_allocator or self.tp_rank == 0:
+            if uses_local_views or self.tp_rank == 0:
                 self.k_caches_cpu.append(cache_or_caches[OFFLOAD_K_CACHE_CPU_INDEX])
                 self.v_caches_cpu.append(cache_or_caches[OFFLOAD_V_CACHE_CPU_INDEX])
 
@@ -876,7 +930,7 @@ class SparseKVOffloadManager:
         self.gvas_k_bases: list[int] = []
         self.gvas_v_bases: list[int] = []
         self.cpu_block_lens: list[tuple[int, int]] = []
-        if uses_host_allocator:
+        if uses_local_views:
             # HostKVAllocator gave every rank local Host KV views: use them
             # directly instead of broadcasting the tp0 pointers.
             for layer_id in range(self.num_layers):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -331,10 +331,7 @@ def allocate_kv_cache_tensors_for_sparse_kv_offload(
     tp_rank: int,
     keep_device_kv_cache: bool,
     npu_kv_cache_allocate_func: typing.Callable,
-    host_kv_cache_allocate_func: typing.Callable[
-        [list[int], int], list[torch.Tensor | None]
-    ]
-    | None = None,
+    host_kv_cache_allocate_func: typing.Callable[[list[int], int], list[torch.Tensor | None]] | None = None,
 ):
     if host_kv_cache_allocate_func is not None:
         [k_tensor_cpu, v_tensor_cpu] = host_kv_cache_allocate_func(
@@ -585,15 +582,11 @@ class SparseKVOffloadManager:
         config = offload.OffloadConfig()
         config.device_id = device_id
         config.reserve_size = self.host_pool_size_bytes
-        config.alloc_size = (
-            self.host_pool_size_bytes if self.tp_rank == 0 else 0
-        )
+        config.alloc_size = self.host_pool_size_bytes if self.tp_rank == 0 else 0
         config.world_size = self.tp_size
         config.rank_id = self.tp_rank
         config.scene = offload.Scene.SHARED
-        assert offload.initialize(config) == 0, (
-            "Sparse KV offload offload.initialize failed."
-        )
+        assert offload.initialize(config) == 0, "Sparse KV offload offload.initialize failed."
         self.tp_group.barrier()
         self._host_allocation_prepared = True
 
@@ -604,9 +597,7 @@ class SparseKVOffloadManager:
     ) -> list[torch.Tensor | None]:
         """Allocate one layer's Host K/V through the prepared allocator."""
         if not self._host_allocation_prepared:
-            raise RuntimeError(
-                "prepare_host_kv_allocation must run before Host KV allocation"
-            )
+            raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         if self._host_kv_allocator is not None:
             return self._host_kv_allocator.allocate_tensors(sizes, alignment)
         if self.tp_rank == 0:

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -32,8 +32,10 @@ from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.mooncake_host_pool import (
+    HostMemoryRegion,
     HostPoolTopology,
     MooncakeHostPool,
+    allocate_mooncake_host_region,
 )
 from vllm_ascend.utils import AscendDeviceType, enable_custom_op, get_ascend_device_type
 
@@ -553,6 +555,11 @@ class SparseKVOffloadManager:
         )
         self.fused_overlap_membership_map: torch.Tensor | None = None
         self.fused_overlap_membership_map_rows = 0
+        self.fused_overlap_membership_region: HostMemoryRegion | None = None
+        self.fused_overlap_planner_membership_map: torch.Tensor | None = None
+        self.fused_overlap_membership_plan_device_staging: (
+            torch.Tensor | None
+        ) = None
         self.fused_overlap_plan_owner_layer_id: int | None = None
         self.fused_overlap_plan_topk: int | None = None
         self.fused_overlap_plan_num_tokens = 0
@@ -659,8 +666,22 @@ class SparseKVOffloadManager:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         return allocator.allocate_tensors(sizes, alignment)
 
+    def _requires_fused_membership_staging(self) -> bool:
+        """Whether the active Host allocator needs a CPU planner bridge."""
+        return isinstance(
+            getattr(self, "_host_kv_allocator", None),
+            MooncakeHostPool,
+        )
+
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
+        region = getattr(self, "fused_overlap_membership_region", None)
+        if region is not None:
+            region.release()
+            self.fused_overlap_membership_region = None
+            self.fused_overlap_membership_map = None
+            self.fused_overlap_planner_membership_map = None
+            self.fused_overlap_membership_plan_device_staging = None
         allocator = self._host_kv_allocator
         if allocator is not None:
             allocator.close()
@@ -785,35 +806,120 @@ class SparseKVOffloadManager:
             return self.fused_overlap_membership_map
 
         shape = [row_capacity, FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT]
-        owner_ptr = torch.zeros(1, dtype=torch.int64, device="npu")
-        membership_map = None
-        if self.tp_rank == 0:
-            membership_map = offload.empty(
-                [row_capacity * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT],
-                dtype=torch.int16,
-                pin_memory=True,
-            ).view(shape)
-            membership_map.fill_(-1)
-            control = membership_map[
-                :,
-                FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT : FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
-                + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
-            ]
-            control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
-            control[:, 2] = self.topk
-            control[:, 3] = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
-            control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
-            owner_ptr[0] = membership_map.data_ptr()
-        self.tp_group.broadcast(owner_ptr, src=0)
-        shared_ptr = int(owner_ptr.item())
-        if self.tp_rank != 0:
-            membership_map = self._restore_int16_tensor(shared_ptr, shape)
-        if membership_map is None:
-            raise RuntimeError("mapped membership storage was not initialized")
-        self.tp_group.barrier()
+        if self._requires_fused_membership_staging():
+            allocator = self._host_kv_allocator
+            assert isinstance(allocator, MooncakeHostPool)
+            region = allocate_mooncake_host_region(
+                size_bytes=(
+                    row_capacity
+                    * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
+                    * torch.int16.itemsize
+                ),
+                alignment=_CPU_CACHE_ALIGNMENT,
+                topology=allocator.topology,
+                name="sparse_kv_offload_fused_membership",
+            )
+            membership_map = region.tensor.view(torch.int16).view(shape)
+            planner_map = None
+            if self.tp_rank == 0:
+                plan_width = (
+                    self.topk
+                    + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
+                )
+                plan_shape = [row_capacity, plan_width]
+                planner_map = torch.empty(
+                    plan_shape,
+                    dtype=torch.int16,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.fused_overlap_membership_plan_device_staging = (
+                    torch.empty(
+                        plan_shape,
+                        dtype=torch.int16,
+                        device=membership_map.device,
+                    )
+                )
+                self._init_fused_overlap_plan_staging(planner_map)
+                self._init_fused_overlap_membership_control(membership_map)
+                torch_npu.npu.current_stream().synchronize()
+            self.tp_group.barrier()
+            self.fused_overlap_membership_region = region
+            self.fused_overlap_planner_membership_map = planner_map
+        else:
+            owner_ptr = torch.zeros(1, dtype=torch.int64, device="npu")
+            membership_map = None
+            if self.tp_rank == 0:
+                membership_map = offload.empty(
+                    [
+                        row_capacity
+                        * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
+                    ],
+                    dtype=torch.int16,
+                    pin_memory=True,
+                ).view(shape)
+                self._init_fused_overlap_membership_control(membership_map)
+                owner_ptr[0] = membership_map.data_ptr()
+            self.tp_group.broadcast(owner_ptr, src=0)
+            shared_ptr = int(owner_ptr.item())
+            if self.tp_rank != 0:
+                membership_map = self._restore_int16_tensor(shared_ptr, shape)
+            if membership_map is None:
+                raise RuntimeError(
+                    "mapped membership storage was not initialized"
+                )
+            self.tp_group.barrier()
+            self.fused_overlap_planner_membership_map = membership_map
+
         self.fused_overlap_membership_map = membership_map
         self.fused_overlap_membership_map_rows = row_capacity
         return membership_map
+
+    def _init_fused_overlap_membership_control(
+        self,
+        membership_map: torch.Tensor,
+    ) -> None:
+        membership_map.fill_(-1)
+        control = membership_map[
+            :,
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT:
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
+            + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+        ]
+        control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
+        control[:, 2] = self.topk
+        control[:, 3] = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
+
+    def _init_fused_overlap_plan_staging(
+        self,
+        plan_staging: torch.Tensor,
+    ) -> None:
+        plan_staging.fill_(-1)
+        control = plan_staging[
+            :,
+            self.topk:
+            self.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+        ]
+        control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
+        control[:, 2] = self.topk
+        control[:, 3] = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
+
+    def is_fused_membership_storage(self, tensor: torch.Tensor) -> bool:
+        if tensor.dtype != torch.int16:
+            return False
+        if self._requires_fused_membership_staging():
+            return (
+                self.fused_overlap_membership_map is not None
+                and tensor.data_ptr()
+                == self.fused_overlap_membership_map.data_ptr()
+            )
+        return tensor.device.type == "cpu"
 
     def get_fused_overlap_cpu_kv_inputs(
         self,
@@ -1493,12 +1599,74 @@ class SparseKVOffloadManager:
             selection_membership_map,
         )
         layer_id = self._get_offload_layer_id(layer_name)
-        plan_start = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        plan_start = (
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
+        )
+        plan_width = FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS - plan_start
         plan_storage = selection_membership_map[
             :num_tokens,
             plan_start:FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS,
         ]
-        encoded_plan_stride = selection_membership_map.stride(0)
+        planner_membership_map = self.fused_overlap_planner_membership_map
+        planner_plan_start = plan_start
+        if self.tp_rank == 0:
+            if planner_membership_map is None:
+                planner_membership_map = selection_membership_map
+            elif self._requires_fused_membership_staging():
+                planner_plan_start = 0
+            if (
+                planner_membership_map.dim() != 2
+                or planner_membership_map.shape[0] < num_tokens
+                or planner_membership_map.shape[1]
+                < planner_plan_start + plan_width
+                or planner_membership_map.dtype != torch.int16
+                or planner_membership_map.device.type != "cpu"
+            ):
+                raise ValueError(
+                    "external FSA planner requires CPU int16 storage: "
+                    f"shape={tuple(planner_membership_map.shape)}, "
+                    f"dtype={planner_membership_map.dtype}, "
+                    f"device={planner_membership_map.device}"
+                )
+            planner_storage = planner_membership_map[
+                :num_tokens,
+                planner_plan_start:planner_plan_start + plan_width,
+            ]
+            if (
+                self._requires_fused_membership_staging()
+                and not planner_storage.is_contiguous()
+            ):
+                raise RuntimeError(
+                    "Mooncake external FSA planner staging must be compact "
+                    "and contiguous"
+                )
+            encoded_plan_stride = planner_membership_map.stride(0)
+        else:
+            # Only TP0 owns and runs the CPU planner. Other TP ranks consume
+            # the published plan after the metadata broadcast.
+            planner_storage = plan_storage
+            encoded_plan_stride = selection_membership_map.stride(0)
+
+        def publish_plan(non_blocking: bool) -> None:
+            if planner_storage.data_ptr() == plan_storage.data_ptr():
+                return
+            device_staging = (
+                self.fused_overlap_membership_plan_device_staging
+            )
+            if device_staging is None:
+                raise RuntimeError(
+                    "external FSA plan requires an NPU staging buffer when "
+                    "planner and operator membership storage are separate"
+                )
+            device_plan_storage = device_staging[:num_tokens, :plan_width]
+            device_plan_storage.copy_(
+                planner_storage,
+                non_blocking=non_blocking,
+            )
+            plan_storage.copy_(
+                device_plan_storage,
+                non_blocking=non_blocking,
+            )
 
         owner_layer_id = self.fused_overlap_plan_owner_layer_id
         owner_map = self.fused_overlap_plan_membership_map
@@ -1546,7 +1714,7 @@ class SparseKVOffloadManager:
                 self.lru_epochs_ptr,
                 self.lru_physical_row_workspace_ptr,
                 self.max_num_topk_rows,
-                plan_storage.data_ptr(),
+                planner_storage.data_ptr(),
                 encoded_plan_stride,
                 num_tokens,
                 self.topk,
@@ -1573,7 +1741,11 @@ class SparseKVOffloadManager:
                         ],
                         non_blocking=True,
                     )
+                    publish_plan(non_blocking=True)
                 self.tp_group.broadcast(self.fused_plan_metadata_npu, src=0)
+            torch_npu.npu.current_stream().wait_stream(
+                self.fused_plan_stream
+            )
             self.fused_overlap_plan_owner_layer_id = layer_id
             self.fused_overlap_plan_topk = self.topk
             self.fused_overlap_plan_num_tokens = num_tokens
@@ -1594,6 +1766,7 @@ class SparseKVOffloadManager:
                         self.max_num_topk_rows * 2 : self.max_num_topk_rows * 2 + num_tokens
                     ]
                 )
+                publish_plan(non_blocking=False)
             except Exception as exc:
                 planner_error = exc
                 self.fused_plan_status_npu.fill_(1)
@@ -1657,10 +1830,12 @@ class SparseKVOffloadManager:
             or selection_membership_map.shape[0] < num_tokens
             or selection_membership_map.shape[1] < FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS
             or selection_membership_map.dtype != torch.int16
-            or selection_membership_map.device.type != "cpu"
+            or not self.is_fused_membership_storage(
+                selection_membership_map
+            )
         ):
             raise ValueError(
-                "external FSA plan requires mapped CPU int16 membership storage: "
+                "external FSA plan requires registered int16 membership storage: "
                 f"min_shape=({num_tokens}, {FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS}), "
                 f"actual_shape={tuple(selection_membership_map.shape)}, "
                 f"dtype={selection_membership_map.dtype}, "

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -97,6 +97,8 @@ _SPARSE_KV_OFFLOAD_OP_NAMES = (
     "sparse_kv_compute_lru_resident_addrs",
     "sparse_kv_restore_bfloat16_tensor",
     "sparse_kv_restore_int16_tensor",
+    "sparse_kv_compute_current_kv_index_copy_descriptors",
+    "sparse_kv_enqueue_current_kv_index_copy_descriptors",
 )
 
 
@@ -553,6 +555,7 @@ class SparseKVOffloadManager:
             self.max_num_tokens,
             self.max_num_reqs * decode_width,
         )
+        self.max_d2h_index_copy_tokens = self.max_num_topk_rows
         self.fused_overlap_membership_map: torch.Tensor | None = None
         self.fused_overlap_membership_map_rows = 0
         self.fused_overlap_membership_region: HostMemoryRegion | None = None
@@ -666,12 +669,15 @@ class SparseKVOffloadManager:
             raise RuntimeError("prepare_host_kv_allocation must run before Host KV allocation")
         return allocator.allocate_tensors(sizes, alignment)
 
-    def _requires_fused_membership_staging(self) -> bool:
-        """Whether the active Host allocator needs a CPU planner bridge."""
+    def _uses_mooncake_host_pool(self) -> bool:
         return isinstance(
             getattr(self, "_host_kv_allocator", None),
             MooncakeHostPool,
         )
+
+    def _requires_fused_membership_staging(self) -> bool:
+        """Whether the active Host allocator needs a CPU planner bridge."""
+        return self._uses_mooncake_host_pool()
 
     def close(self) -> None:
         """Release backend-owned Host KV resources."""
@@ -1008,6 +1014,46 @@ class SparseKVOffloadManager:
             self.fused_plan_status_npu = self.fused_plan_metadata_npu[:1]
             self.fused_plan_current_linear_slots_npu = self.fused_plan_metadata_npu[1:]
             self.current_kv_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+            if self._uses_mooncake_host_pool() and self.tp_rank == 0:
+                self.d2h_slot_mapping_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_src_idx_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_dst_idx_cpu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_index_count_cpu = torch.zeros(
+                    1,
+                    dtype=torch.int32,
+                    device="cpu",
+                    pin_memory=True,
+                )
+                self.d2h_src_idx_npu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                self.d2h_dst_idx_npu = torch.zeros(
+                    self.max_d2h_index_copy_tokens,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                self.d2h_index_count_npu = torch.zeros(
+                    1,
+                    dtype=torch.int32,
+                    device=device,
+                )
         self.d2h_size_npu = torch.empty(1, dtype=torch.int32, device=device)
         self.d2h_token_indices_npu = torch.arange(self.max_num_tokens, dtype=torch.int64, device=device)
 
@@ -1330,10 +1376,22 @@ class SparseKVOffloadManager:
         has_prefill: bool = False,
         capturing: bool = False,
     ) -> None:
+        prepare_index_copy_descriptors = True
         if not has_prefill and k is not None and v is not None and self.use_fused_overlap:
             layer_id = self._get_offload_layer_id(layer_name)
             self.current_kv_by_layer[layer_id] = (k, v)
-        use_side_stream = self.tp_rank == 0 and self.use_fused_overlap and capturing and not has_prefill
+            # All decode layers share one slot mapping within a forward step.
+            prepare_index_copy_descriptors = layer_id == 0
+        use_mooncake_index_copy = (
+            self.use_fused_overlap and self._uses_mooncake_host_pool()
+        )
+        use_side_stream = (
+            self.tp_rank == 0
+            and self.use_fused_overlap
+            and capturing
+            and not has_prefill
+            and not use_mooncake_index_copy
+        )
         if not use_side_stream:
             self._offload_new_kv_on_current_stream(
                 slot_mapping,
@@ -1344,6 +1402,8 @@ class SparseKVOffloadManager:
                 k,
                 v,
                 has_prefill,
+                capturing,
+                prepare_index_copy_descriptors,
             )
             return
 
@@ -1359,6 +1419,8 @@ class SparseKVOffloadManager:
                 k,
                 v,
                 has_prefill,
+                capturing,
+                prepare_index_copy_descriptors,
             )
 
     def _offload_new_kv_on_current_stream(
@@ -1372,6 +1434,7 @@ class SparseKVOffloadManager:
         v: torch.Tensor | None,  # decode: k/v -> cache_cpu[slot]
         has_prefill: bool = False,
         capturing: bool = False,
+        prepare_index_copy_descriptors: bool = True,
     ) -> None:
         # the has_prefill path (NPU paged cache -> CPU pool D2H) only exists
         # for single-node PD-colocate debug.
@@ -1397,6 +1460,17 @@ class SparseKVOffloadManager:
             if k is None or v is None:
                 raise ValueError("decode offload requires current-token K/V")
             device = k.device
+            if self.use_fused_overlap and self._uses_mooncake_host_pool():
+                self._offload_new_kv_via_index_copy(
+                    slot_mapping=slot_mapping,
+                    k_cache_cpu=k_cache_cpu,
+                    v_cache_cpu=v_cache_cpu,
+                    k=k,
+                    v=v,
+                    capturing=capturing,
+                    prepare_descriptors=prepare_index_copy_descriptors,
+                )
+                return
 
         slots = slot_mapping.reshape(-1).to(device=device, dtype=torch.int64)
         token_count = slots.numel()
@@ -1454,6 +1528,124 @@ class SparseKVOffloadManager:
         )
         if result not in (None, 0):
             raise RuntimeError(f"memfabric D2H sparse_copy failed with result={result}")
+
+    def _prepare_current_kv_index_copy_descriptors(
+        self,
+        *,
+        slots: torch.Tensor,
+        token_count: int,
+        num_slots: int,
+    ) -> None:
+        self.d2h_slot_mapping_cpu[:token_count].copy_(
+            slots,
+            non_blocking=True,
+        )
+        _sparse_kv_ops().sparse_kv_enqueue_current_kv_index_copy_descriptors(
+            self.d2h_slot_mapping_cpu,
+            token_count,
+            self.max_d2h_index_copy_tokens,
+            num_slots,
+            self.d2h_src_idx_cpu,
+            self.d2h_dst_idx_cpu,
+            self.d2h_index_count_cpu,
+        )
+        self.d2h_src_idx_npu.copy_(
+            self.d2h_src_idx_cpu,
+            non_blocking=True,
+        )
+        self.d2h_dst_idx_npu.copy_(
+            self.d2h_dst_idx_cpu,
+            non_blocking=True,
+        )
+        self.d2h_index_count_npu.copy_(
+            self.d2h_index_count_cpu,
+            non_blocking=True,
+        )
+
+    def _offload_new_kv_via_index_copy(
+        self,
+        *,
+        slot_mapping: torch.Tensor,
+        k_cache_cpu: torch.Tensor,
+        v_cache_cpu: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        capturing: bool,
+        prepare_descriptors: bool = True,
+    ) -> None:
+        """Write current-token K/V into the Mooncake Shared Segment."""
+        token_dim_k = self.token_size_bytes_k // k.element_size()
+        token_dim_v = self.token_size_bytes_v // v.element_size()
+        k_rows = k.reshape(-1, token_dim_k)
+        v_rows = v.reshape(-1, token_dim_v)
+        if not k_rows.is_contiguous():
+            k_rows = k_rows.contiguous()
+        if not v_rows.is_contiguous():
+            v_rows = v_rows.contiguous()
+        flat_host_k = k_cache_cpu.reshape(-1, token_dim_k)
+        flat_host_v = v_cache_cpu.reshape(-1, token_dim_v)
+        slots = slot_mapping.reshape(-1).to(
+            device=k.device,
+            dtype=torch.int64,
+        )
+        token_count = slots.numel()
+        if token_count == 0:
+            return
+        if token_count > self.max_d2h_index_copy_tokens:
+            raise ValueError(
+                "Sparse KV offload rows exceed index_copy capacity, "
+                f"got {token_count}, "
+                f"capacity={self.max_d2h_index_copy_tokens}"
+            )
+        if k_rows.shape[0] != token_count or v_rows.shape[0] != token_count:
+            raise ValueError("decode K/V row counts must match slot_mapping")
+        if flat_host_k.device != k.device or flat_host_v.device != v.device:
+            raise RuntimeError(
+                "Mooncake Host views and current K/V must share one NPU device"
+            )
+        num_slots = flat_host_k.shape[0]
+        if num_slots != flat_host_v.shape[0] or num_slots <= 0:
+            raise ValueError(
+                "Mooncake Host K/V pools have incompatible token capacities"
+            )
+
+        if capturing:
+            if prepare_descriptors:
+                self._prepare_current_kv_index_copy_descriptors(
+                    slots=slots,
+                    token_count=token_count,
+                    num_slots=num_slots,
+                )
+            current_kv_ready = torch_npu.npu.current_stream().record_event()
+            with torch_npu.npu.stream(self.current_kv_save_stream):
+                self.current_kv_save_stream.wait_event(current_kv_ready)
+                flat_host_k.index_copy_(
+                    0,
+                    self.d2h_dst_idx_npu,
+                    k_rows.index_select(0, self.d2h_src_idx_npu),
+                )
+                flat_host_v.index_copy_(
+                    0,
+                    self.d2h_dst_idx_npu,
+                    v_rows.index_select(0, self.d2h_src_idx_npu),
+                )
+            return
+
+        valid = (slots >= 0) & (slots < num_slots)
+        valid_indices = torch.nonzero(valid, as_tuple=False).reshape(-1)
+        if valid_indices.numel() == 0:
+            return
+        destinations = slots.index_select(0, valid_indices)
+        flat_host_k.index_copy_(
+            0,
+            destinations,
+            k_rows.index_select(0, valid_indices),
+        )
+        flat_host_v.index_copy_(
+            0,
+            destinations,
+            v_rows.index_select(0, valid_indices),
+        )
 
     def onload_topk_kv(
         self,
@@ -1867,7 +2059,11 @@ class SparseKVOffloadManager:
         torch_npu.npu_scatter_nd_update_(flat_rope, indices, current_rope)
 
     def wait_for_current_kv_writeback(self, capturing: bool = False) -> None:
-        if self.use_fused_overlap and capturing and self.tp_rank == 0:
+        if (
+            self.use_fused_overlap
+            and capturing
+            and self.tp_rank == 0
+        ):
             torch_npu.npu.current_stream().wait_stream(self.current_kv_save_stream)
 
     def _onload_topk_kv_cpu(self, args):

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -675,6 +675,15 @@ class SparseKVOffloadManager:
             MooncakeHostPool,
         )
 
+    def get_mooncake_host_pool(self) -> MooncakeHostPool:
+        """Return the prepared Mooncake allocator used by Decode Main KV."""
+        allocator = self._host_kv_allocator
+        if not isinstance(allocator, MooncakeHostPool):
+            raise RuntimeError(
+                "Sparse KV offload is not using the Mooncake Host backend"
+            )
+        return allocator
+
     def _requires_fused_membership_staging(self) -> bool:
         """Whether the active Host allocator needs a CPU planner bridge."""
         return self._uses_mooncake_host_pool()

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -560,9 +560,7 @@ class SparseKVOffloadManager:
         self.fused_overlap_membership_map_rows = 0
         self.fused_overlap_membership_region: HostMemoryRegion | None = None
         self.fused_overlap_planner_membership_map: torch.Tensor | None = None
-        self.fused_overlap_membership_plan_device_staging: (
-            torch.Tensor | None
-        ) = None
+        self.fused_overlap_membership_plan_device_staging: torch.Tensor | None = None
         self.fused_overlap_plan_owner_layer_id: int | None = None
         self.fused_overlap_plan_topk: int | None = None
         self.fused_overlap_plan_num_tokens = 0
@@ -679,9 +677,7 @@ class SparseKVOffloadManager:
         """Return the prepared Mooncake allocator used by Decode Main KV."""
         allocator = self._host_kv_allocator
         if not isinstance(allocator, MooncakeHostPool):
-            raise RuntimeError(
-                "Sparse KV offload is not using the Mooncake Host backend"
-            )
+            raise RuntimeError("Sparse KV offload is not using the Mooncake Host backend")
         return allocator
 
     def _requires_fused_membership_staging(self) -> bool:
@@ -825,11 +821,7 @@ class SparseKVOffloadManager:
             allocator = self._host_kv_allocator
             assert isinstance(allocator, MooncakeHostPool)
             region = allocate_mooncake_host_region(
-                size_bytes=(
-                    row_capacity
-                    * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
-                    * torch.int16.itemsize
-                ),
+                size_bytes=(row_capacity * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT * torch.int16.itemsize),
                 alignment=_CPU_CACHE_ALIGNMENT,
                 topology=allocator.topology,
                 name="sparse_kv_offload_fused_membership",
@@ -837,10 +829,7 @@ class SparseKVOffloadManager:
             membership_map = region.tensor.view(torch.int16).view(shape)
             planner_map = None
             if self.tp_rank == 0:
-                plan_width = (
-                    self.topk
-                    + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
-                )
+                plan_width = self.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT
                 plan_shape = [row_capacity, plan_width]
                 planner_map = torch.empty(
                     plan_shape,
@@ -848,12 +837,10 @@ class SparseKVOffloadManager:
                     device="cpu",
                     pin_memory=True,
                 )
-                self.fused_overlap_membership_plan_device_staging = (
-                    torch.empty(
-                        plan_shape,
-                        dtype=torch.int16,
-                        device=membership_map.device,
-                    )
+                self.fused_overlap_membership_plan_device_staging = torch.empty(
+                    plan_shape,
+                    dtype=torch.int16,
+                    device=membership_map.device,
                 )
                 self._init_fused_overlap_plan_staging(planner_map)
                 self._init_fused_overlap_membership_control(membership_map)
@@ -866,10 +853,7 @@ class SparseKVOffloadManager:
             membership_map = None
             if self.tp_rank == 0:
                 membership_map = offload.empty(
-                    [
-                        row_capacity
-                        * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT
-                    ],
+                    [row_capacity * FSA_SELECTION_MEMBERSHIP_STORAGE_INT16_COUNT],
                     dtype=torch.int16,
                     pin_memory=True,
                 ).view(shape)
@@ -880,9 +864,7 @@ class SparseKVOffloadManager:
             if self.tp_rank != 0:
                 membership_map = self._restore_int16_tensor(shared_ptr, shape)
             if membership_map is None:
-                raise RuntimeError(
-                    "mapped membership storage was not initialized"
-                )
+                raise RuntimeError("mapped membership storage was not initialized")
             self.tp_group.barrier()
             self.fused_overlap_planner_membership_map = membership_map
 
@@ -897,15 +879,12 @@ class SparseKVOffloadManager:
         membership_map.fill_(-1)
         control = membership_map[
             :,
-            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT:
-            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
+            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT : FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT
             + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
         ]
         control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
         control[:, 2] = self.topk
-        control[:, 3] = (
-            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
-        )
+        control[:, 3] = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
         control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
 
     def _init_fused_overlap_plan_staging(
@@ -915,14 +894,11 @@ class SparseKVOffloadManager:
         plan_staging.fill_(-1)
         control = plan_staging[
             :,
-            self.topk:
-            self.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
+            self.topk : self.topk + FSA_SELECTION_MEMBERSHIP_CONTROL_INT16_COUNT,
         ]
         control[:, 1] = FSA_EXTERNAL_PLAN_READY_MARKER
         control[:, 2] = self.topk
-        control[:, 3] = (
-            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
-        )
+        control[:, 3] = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
         control[:, 7] = FSA_PAIRED_SELECTION_COPY_MARKER
 
     def is_fused_membership_storage(self, tensor: torch.Tensor) -> bool:
@@ -931,8 +907,7 @@ class SparseKVOffloadManager:
         if self._requires_fused_membership_staging():
             return (
                 self.fused_overlap_membership_map is not None
-                and tensor.data_ptr()
-                == self.fused_overlap_membership_map.data_ptr()
+                and tensor.data_ptr() == self.fused_overlap_membership_map.data_ptr()
             )
         return tensor.device.type == "cpu"
 
@@ -942,13 +917,17 @@ class SparseKVOffloadManager:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Return CPU full KV tensors used by fused_overlap decode.
 
-        On TP0 these are the owned CPU pools; on other ranks they are non-owning
-        GVA views restored after broadcast.
+        Mooncake preserves each rank's local mapping. MemFabric restores GVA
+        views after the existing owner pointer broadcast.
         """
         if not self.use_fused_overlap:
             raise RuntimeError(
                 "get_fused_overlap_cpu_kv_inputs requires kv_offload_decode_config.use_fused_overlap=true"
             )
+        return self.get_local_host_kv_views(layer_name)
+
+    def get_local_host_kv_views(self, layer_name: str) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return this process's original Mooncake or restored MemFabric views."""
         layer_id = self._get_offload_layer_id(layer_name)
         if layer_id >= len(self.k_caches_cpu) or layer_id >= len(self.v_caches_cpu):
             raise RuntimeError(
@@ -957,6 +936,33 @@ class SparseKVOffloadManager:
                 f"v_len={len(self.v_caches_cpu)}"
             )
         return self.k_caches_cpu[layer_id], self.v_caches_cpu[layer_id]
+
+    def _register_local_mooncake_views(self) -> None:
+        pool = self.get_mooncake_host_pool()
+        descriptor, error = None, None
+        try:
+            views = [
+                (name, component, tensor)
+                for name in self.offload_layer_names
+                for component, tensor in zip(("k", "v"), self.get_local_host_kv_views(name))
+            ]
+            descriptor = pool.describe_local_views(views, self.kv_cache_config.num_blocks)
+        except (ValueError, RuntimeError) as exc:
+            error = str(exc)
+        layouts = [(descriptor, error)]
+        if pool.topology.tp_size > 1:
+            # Exchange initialization errors too, avoiding a stranded peer.
+            layouts = [None] * pool.topology.tp_size
+            torch.distributed.all_gather_object(layouts, (descriptor, error), group=self.tp_group.cpu_group)
+        for peer_layout, peer_error in layouts:
+            if peer_error is not None or peer_layout != descriptor:
+                raise ValueError(f"Mooncake Host layout mismatch: {peer_error}")
+        self.gvas_k_bases = [t.data_ptr() for t in self.k_caches_cpu]
+        self.gvas_v_bases = [t.data_ptr() for t in self.v_caches_cpu]
+        self.cpu_block_lens = [
+            (k.stride(0) * k.element_size(), v.stride(0) * v.element_size())
+            for k, v in zip(self.k_caches_cpu, self.v_caches_cpu)
+        ]
 
     def register_kv_caches(
         self,
@@ -1091,26 +1097,8 @@ class SparseKVOffloadManager:
         self.gvas_k_bases: list[int] = []
         self.gvas_v_bases: list[int] = []
         self.cpu_block_lens: list[tuple[int, int]] = []
-        if uses_local_views:
-            # HostKVAllocator gave every rank local Host KV views: use them
-            # directly instead of broadcasting the tp0 pointers.
-            for layer_id in range(self.num_layers):
-                k_cpu = self.k_caches_cpu[layer_id]
-                v_cpu = self.v_caches_cpu[layer_id]
-                self.gvas_k_bases.append(k_cpu.data_ptr())
-                self.gvas_v_bases.append(v_cpu.data_ptr())
-                self.cpu_block_lens.append(
-                    (
-                        k_cpu.numel() * k_cpu.element_size() // self.kv_cache_config.num_blocks,
-                        v_cpu.numel() * v_cpu.element_size() // self.kv_cache_config.num_blocks,
-                    )
-                )
-            logger.info(
-                "Registered local Host KV views: tp=%s/%s layers=%s",
-                self.tp_rank,
-                self.tp_size,
-                self.num_layers,
-            )
+        if self._uses_mooncake_host_pool():
+            self._register_local_mooncake_views()
         else:
             gvas_k_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
             gvas_v_tensor = torch.zeros([self.num_layers], dtype=torch.int64, device="npu")
@@ -1391,9 +1379,7 @@ class SparseKVOffloadManager:
             self.current_kv_by_layer[layer_id] = (k, v)
             # All decode layers share one slot mapping within a forward step.
             prepare_index_copy_descriptors = layer_id == 0
-        use_mooncake_index_copy = (
-            self.use_fused_overlap and self._uses_mooncake_host_pool()
-        )
+        use_mooncake_index_copy = self.use_fused_overlap and self._uses_mooncake_host_pool()
         use_side_stream = (
             self.tp_rank == 0
             and self.use_fused_overlap
@@ -1450,7 +1436,7 @@ class SparseKVOffloadManager:
         if self.tp_rank != 0:
             # Decode-produced K/V is replicated across TP ranks, so TP0 alone
             # writes new decode tokens. PD pull fills disjoint parts of this
-            # shared pool from all TP ranks through the broadcast GVA.
+            # shared pool from all TP ranks through their local mappings.
             return
         if k_cache_cpu is None or v_cache_cpu is None:
             raise RuntimeError("Sparse KV offload TP0 CPU cache is not registered")
@@ -1609,14 +1595,10 @@ class SparseKVOffloadManager:
         if k_rows.shape[0] != token_count or v_rows.shape[0] != token_count:
             raise ValueError("decode K/V row counts must match slot_mapping")
         if flat_host_k.device != k.device or flat_host_v.device != v.device:
-            raise RuntimeError(
-                "Mooncake Host views and current K/V must share one NPU device"
-            )
+            raise RuntimeError("Mooncake Host views and current K/V must share one NPU device")
         num_slots = flat_host_k.shape[0]
         if num_slots != flat_host_v.shape[0] or num_slots <= 0:
-            raise ValueError(
-                "Mooncake Host K/V pools have incompatible token capacities"
-            )
+            raise ValueError("Mooncake Host K/V pools have incompatible token capacities")
 
         if capturing:
             if prepare_descriptors:
@@ -1800,9 +1782,7 @@ class SparseKVOffloadManager:
             selection_membership_map,
         )
         layer_id = self._get_offload_layer_id(layer_name)
-        plan_start = (
-            FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
-        )
+        plan_start = FSA_SELECTION_MEMBERSHIP_CONTROL_OFFSET_INT16_CNT - self.topk
         plan_width = FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS - plan_start
         plan_storage = selection_membership_map[
             :num_tokens,
@@ -1818,8 +1798,7 @@ class SparseKVOffloadManager:
             if (
                 planner_membership_map.dim() != 2
                 or planner_membership_map.shape[0] < num_tokens
-                or planner_membership_map.shape[1]
-                < planner_plan_start + plan_width
+                or planner_membership_map.shape[1] < planner_plan_start + plan_width
                 or planner_membership_map.dtype != torch.int16
                 or planner_membership_map.device.type != "cpu"
             ):
@@ -1831,16 +1810,10 @@ class SparseKVOffloadManager:
                 )
             planner_storage = planner_membership_map[
                 :num_tokens,
-                planner_plan_start:planner_plan_start + plan_width,
+                planner_plan_start : planner_plan_start + plan_width,
             ]
-            if (
-                self._requires_fused_membership_staging()
-                and not planner_storage.is_contiguous()
-            ):
-                raise RuntimeError(
-                    "Mooncake external FSA planner staging must be compact "
-                    "and contiguous"
-                )
+            if self._requires_fused_membership_staging() and not planner_storage.is_contiguous():
+                raise RuntimeError("Mooncake external FSA planner staging must be compact and contiguous")
             encoded_plan_stride = planner_membership_map.stride(0)
         else:
             # Only TP0 owns and runs the CPU planner. Other TP ranks consume
@@ -1851,9 +1824,7 @@ class SparseKVOffloadManager:
         def publish_plan(non_blocking: bool) -> None:
             if planner_storage.data_ptr() == plan_storage.data_ptr():
                 return
-            device_staging = (
-                self.fused_overlap_membership_plan_device_staging
-            )
+            device_staging = self.fused_overlap_membership_plan_device_staging
             if device_staging is None:
                 raise RuntimeError(
                     "external FSA plan requires an NPU staging buffer when "
@@ -1944,9 +1915,7 @@ class SparseKVOffloadManager:
                     )
                     publish_plan(non_blocking=True)
                 self.tp_group.broadcast(self.fused_plan_metadata_npu, src=0)
-            torch_npu.npu.current_stream().wait_stream(
-                self.fused_plan_stream
-            )
+            torch_npu.npu.current_stream().wait_stream(self.fused_plan_stream)
             self.fused_overlap_plan_owner_layer_id = layer_id
             self.fused_overlap_plan_topk = self.topk
             self.fused_overlap_plan_num_tokens = num_tokens
@@ -2031,9 +2000,7 @@ class SparseKVOffloadManager:
             or selection_membership_map.shape[0] < num_tokens
             or selection_membership_map.shape[1] < FSA_SELECTION_MEMBERSHIP_REQUIRER_COLUMNS
             or selection_membership_map.dtype != torch.int16
-            or not self.is_fused_membership_storage(
-                selection_membership_map
-            )
+            or not self.is_fused_membership_storage(selection_membership_map)
         ):
             raise ValueError(
                 "external FSA plan requires registered int16 membership storage: "
@@ -2068,11 +2035,7 @@ class SparseKVOffloadManager:
         torch_npu.npu_scatter_nd_update_(flat_rope, indices, current_rope)
 
     def wait_for_current_kv_writeback(self, capturing: bool = False) -> None:
-        if (
-            self.use_fused_overlap
-            and capturing
-            and self.tp_rank == 0
-        ):
+        if self.use_fused_overlap and capturing and self.tp_rank == 0:
             torch_npu.npu.current_stream().wait_stream(self.current_kv_save_stream)
 
     def _onload_topk_kv_cpu(self, args):

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -1,4 +1,11 @@
 import threading
+from importlib.metadata import version as get_version
+
+from packaging.version import Version
+
+_WILDCARD_LOCATION = "*"
+_LOCATION_API_MIN_VERSION = Version("0.3.12")
+_MOONCAKE_DISTRIBUTION = "mooncake-transfer-engine"
 
 
 class GlobalTE:
@@ -7,6 +14,7 @@ class GlobalTE:
         self.is_register_buffer: bool = False
         self.transfer_engine_lock = threading.Lock()
         self.register_buffer_lock = threading.Lock()
+        self._registered_regions: list[tuple[int, int, str]] = []
 
     def get_transfer_engine(self, hostname: str, device_name: str | None):
         if self.transfer_engine is None:
@@ -28,16 +36,74 @@ class GlobalTE:
                         raise RuntimeError(f"TransferEngine initialization failed with ret_value: {ret_value}")
         return self.transfer_engine
 
-    def register_buffer(self, ptrs: list[int], sizes: list[int]):
+    def _unregister_regions(
+        self,
+        regions: list[tuple[int, int, str]],
+    ) -> tuple[list[tuple[int, int, str]], list[str]]:
+        """Unregister regions in reverse order and return any failures."""
+        assert self.transfer_engine is not None
+        failed_regions: list[tuple[int, int, str]] = []
+        failure_messages: list[str] = []
+        for region in reversed(regions):
+            ptr, _, _ = region
+            try:
+                ret_value = self.transfer_engine.unregister_memory(ptr)
+            except Exception as exc:  # noqa: BLE001
+                failed_regions.append(region)
+                failure_messages.append(f"ptr={ptr}: {exc}")
+                continue
+            if ret_value != 0:
+                failed_regions.append(region)
+                failure_messages.append(f"ptr={ptr}: ret_value={ret_value}")
+
+        failed_regions.reverse()
+        return failed_regions, failure_messages
+
+    def register_buffer(
+        self,
+        ptrs: list[int],
+        sizes: list[int],
+        locations: list[str] | None = None,
+    ) -> None:
+        if locations is not None:
+            mooncake_version = get_version(_MOONCAKE_DISTRIBUTION)
+            if Version(mooncake_version) < _LOCATION_API_MIN_VERSION:
+                raise RuntimeError(
+                    f"Mooncake {mooncake_version} does not support register_memory locations; "
+                    f"{_LOCATION_API_MIN_VERSION} or newer is required"
+                )
+
+        normalized_locations = locations if locations is not None else [_WILDCARD_LOCATION] * len(ptrs)
+        regions = list(zip(ptrs, sizes, normalized_locations))
+
         with self.register_buffer_lock:
             assert self.transfer_engine is not None, "Transfer engine must be initialized"
             if self.is_register_buffer:
                 return
-            for ptr, size in zip(ptrs, sizes):
-                ret_value = self.transfer_engine.register_memory(ptr, size)
+
+            for ptr, size, location in regions:
+                if locations is None:
+                    ret_value = self.transfer_engine.register_memory(ptr, size)
+                else:
+                    ret_value = self.transfer_engine.register_memory(ptr, size, location)
                 if ret_value != 0:
                     raise RuntimeError("Mooncake memory registration failed.")
+            self._registered_regions = regions
             self.is_register_buffer = True
+
+    def unregister_buffer(self) -> None:
+        """Unregister all buffers owned by this wrapper, if any."""
+        with self.register_buffer_lock:
+            if not self._registered_regions:
+                self.is_register_buffer = False
+                return
+            assert self.transfer_engine is not None, "Transfer engine must be initialized"
+
+            failed_regions, failure_messages = self._unregister_regions(self._registered_regions)
+            self._registered_regions = failed_regions
+            self.is_register_buffer = bool(failed_regions)
+            if failure_messages:
+                raise RuntimeError("Mooncake memory unregistration failed for regions: " + "; ".join(failure_messages))
 
 
 global_te = GlobalTE()

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -1,11 +1,6 @@
 import threading
-from importlib.metadata import version as get_version
-
-from packaging.version import Version
 
 _WILDCARD_LOCATION = "*"
-_LOCATION_API_MIN_VERSION = Version("0.3.12")
-_MOONCAKE_DISTRIBUTION = "mooncake-transfer-engine"
 
 
 class GlobalTE:
@@ -65,13 +60,6 @@ class GlobalTE:
         sizes: list[int],
         locations: list[str] | None = None,
     ) -> None:
-        if locations is not None:
-            mooncake_version = get_version(_MOONCAKE_DISTRIBUTION)
-            if Version(mooncake_version) < _LOCATION_API_MIN_VERSION:
-                raise RuntimeError(
-                    f"Mooncake {mooncake_version} does not support register_memory locations; "
-                    f"{_LOCATION_API_MIN_VERSION} or newer is required"
-                )
 
         normalized_locations = locations if locations is not None else [_WILDCARD_LOCATION] * len(ptrs)
         regions = list(zip(ptrs, sizes, normalized_locations))
@@ -82,10 +70,7 @@ class GlobalTE:
                 return
 
             for ptr, size, location in regions:
-                if locations is None:
-                    ret_value = self.transfer_engine.register_memory(ptr, size)
-                else:
-                    ret_value = self.transfer_engine.register_memory(ptr, size, location)
+                ret_value = self.transfer_engine.register_memory(ptr, size, location)
                 if ret_value != 0:
                     raise RuntimeError("Mooncake memory registration failed.")
             self._registered_regions = regions

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -76,6 +76,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # (safe for Ascend 910B/A3). Set to a positive value to override when
     # auto-detection is unavailable or for debugging UB overflow issues.
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
+    # Skip process-wide NUMA page migration when a Mooncake shared segment
+    # falls back to mmap + HostRegister. CPU thread binding remains enabled.
+    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(
+        int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -78,9 +78,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_ROPE_UB_SIZE_KB": lambda: int(os.getenv("VLLM_ASCEND_ROPE_UB_SIZE_KB") or 0),
     # Skip process-wide NUMA page migration when a Mooncake shared segment
     # falls back to mmap + HostRegister. CPU thread binding remains enabled.
-    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(
-        int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))
-    ),
+    "VLLM_ASCEND_SKIP_MIGRATEPAGES": lambda: bool(int(os.getenv("VLLM_ASCEND_SKIP_MIGRATEPAGES", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4203,7 +4203,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.sparse_kv_offload_config,
             )
             self.sparse_kv_offload_manager.prepare_host_kv_allocation(
-                device_id=torch_npu.npu.current_device(),
+                device_id=torch.npu.current_device(),
                 dp_rank=int(self.dp_rank),
             )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4202,6 +4202,7 @@ class NPUModelRunner(GPUModelRunner):
                 kv_cache_config,
                 self.sparse_kv_offload_config,
             )
+            assert self.sparse_kv_offload_manager is not None
             self.sparse_kv_offload_manager.prepare_host_kv_allocation(
                 device_id=torch.npu.current_device(),
                 dp_rank=int(self.dp_rank),
@@ -4786,6 +4787,7 @@ class NPUModelRunner(GPUModelRunner):
                         k_tensor_size = int(kv_cache_tensor_size // k_tensor_split_factor)
                         v_tensor_size = int(kv_cache_tensor_size // v_tensor_split_factor)
                     if self.sparse_kv_offload_enabled:
+                        assert self.sparse_kv_offload_manager is not None
                         assert self.use_sparse, "Sparse KV offload only support sparse attention."
                         assert not current_sparse_sfa_c8, "Sparse KV offload do not support sparse SFA C8."
                         assert v_tensor_size is not None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4202,6 +4202,10 @@ class NPUModelRunner(GPUModelRunner):
                 kv_cache_config,
                 self.sparse_kv_offload_config,
             )
+            self.sparse_kv_offload_manager.prepare_host_kv_allocation(
+                device_id=torch_npu.npu.current_device(),
+                dp_rank=int(self.dp_rank),
+            )
         kv_caches = self.initialize_kv_cache_tensors(kv_cache_config)
         # TODO: refactor the logic of attention
         if (
@@ -4243,6 +4247,16 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+    def shutdown(self) -> None:
+        parent_shutdown = getattr(super(), "shutdown", None)
+        try:
+            if callable(parent_shutdown):
+                parent_shutdown()
+        finally:
+            manager = getattr(self, "sparse_kv_offload_manager", None)
+            if manager is not None:
+                manager.close()
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()
@@ -4785,6 +4799,7 @@ class NPUModelRunner(GPUModelRunner):
                                     self.tp_rank,
                                     self.sparse_kv_offload_config.keep_device_kv_cache,
                                     self._allocate_int8_cache_tensor,
+                                    self.sparse_kv_offload_manager.allocate_host_kv_tensors,
                                 )
                             )
                         else:
@@ -4798,6 +4813,7 @@ class NPUModelRunner(GPUModelRunner):
                                             self.tp_rank,
                                             self.sparse_kv_offload_config.keep_device_kv_cache,
                                             self._allocate_int8_cache_tensor,
+                                            self.sparse_kv_offload_manager.allocate_host_kv_tensors,
                                         )
                                     )
                         continue


### PR DESCRIPTION
### What this PR does / why we need it?

> [!IMPORTANT]
> This PR is stacked on #16219, which provides the Mooncake Host-memory pool and fused-overlap membership/writeback path. Please review this PR as the blockwise P→D transfer follow-up to #16219.
>
> #16219 itself depends on #15883.

This PR adds a blockwise Mooncake DSA transfer path to `MooncakeConnectorV1` for disaggregated prefill deployments using sparse KV offload.

The existing Mooncake connector transfers device KV caches between Prefill and Decode. With fused sparse KV offload, however, Decode stores the two cache components in different memory locations:

- Main KV is transferred directly from Prefill HBM into the Decode-side Mooncake Host pool.
- Indexer KV is transferred from Prefill HBM into Decode HBM.

This PR introduces the metadata, scheduling, memory registration, and transfer planning needed to support those mixed D2RH and D2D destinations safely.

The main changes are:

1. Blockwise DSA protocol and scheduling
   - Add explicit DSA request, endpoint, result, and failure-phase metadata.
   - Build Decode-side transfer commands from the actual allocated Main and Indexer block IDs.
   - Match remote cache components by stable layer name and cache-group identity.
   - Wait for results from all participating Decode TP ranks before releasing the request.
   - Preserve notification-only handling for empty transfers and rejected requests.

2. Multi-TP, PP, and context-parallel transfer planning
   - Support different Prefill and Decode TP sizes.
   - Partition Main Host writes across Decode TP ranks without overlapping destinations.
   - Replicate the required Indexer data to participating Decode ranks.
   - Project remote endpoints across Prefill TP/PP/CP topology and validate complete source coverage.
   - Include the shared MTP cache layer in the final Prefill PP stage.

3. Mixed Host/HBM registration
   - Register Decode Main KV Host-pool regions with their explicit `npu:<device_id>` location.
   - Register Decode Indexer HBM and Prefill source HBM with the wildcard location.
   - Use the location-aware Mooncake `register_memory(ptr, size, location)` API consistently.
   - Track registered regions and unregister them during orderly connector shutdown.

4. Registration and transfer boundary safety
   - Merge compatible aliases without registering the same allocation repeatedly.
   - Limit each Mooncake registration region to 64 GiB.
   - Split transfer entries at both local and remote registration boundaries.
   - Validate cache capacity, block geometry, strides, dtype, and source coverage before submitting a transfer.

5. Cancellation, failure handling, and observability
   - Coordinate cancellation across queued transfer tasks.
   - Report the failed transfer phase and invalidate only the affected Decode blocks.
   - Drain transfer workers before unregistering memory.
   - Add debug tracing for scheduling, endpoint selection, transfers, completion handling, and Host-pool lifecycle.

The path is opt-in through:

```json
{
  "kv_connector_extra_config": {
    "dsa_pd_offload": true,
    "prefill": {
      "dp_size": 1,
      "tp_size": 8
    },
    "decode": {
      "dp_size": 1,
      "tp_size": 4
    }
  }
}
```

The Decode side additionally requires sparse KV offload with:

- `host_backend="mooncake"`
- `use_fused_overlap=true`
- `kv_load_failure_policy="fail"`

The existing non-DSA Mooncake path remains unchanged when `dsa_pd_offload` is disabled.

Refs #16219.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can enable blockwise Mooncake DSA transfers with `kv_connector_extra_config.dsa_pd_offload=true`. When enabled, Main KV is transferred directly into the Decode-side Mooncake Host pool while Indexer KV remains device-to-device.

The existing Mooncake path remains unchanged when `dsa_pd_offload` is disabled.

This PR does not introduce a new environment variable.

### How was this patch tested?

Added focused unit coverage for:

- DSA metadata serialization and validation.
- Scheduler allocation, notification-only requests, cancellation, failure reporting, and all-TP completion.
- Main and Indexer transfer construction across different Prefill/Decode TP sizes, CP sizes, block sizes, and partially cached token ranges.
- PP endpoint selection and MTP-layer ownership.
- Host-pool and HBM mixed-location registration.
- Aliased and oversized registrations, including 64-GiB boundaries.
- Transfer splitting at local and remote registration boundaries.
- Mooncake registration/unregistration lifecycle and shutdown ordering.
- Host-pool topology consistency and sparse-offload integration.

Relevant test commands:

```bash
python -m pytest -sv \
  tests/ut/kv_offload/test_mooncake_dsa_metadata.py \
  tests/ut/kv_offload/test_mooncake_dsa_scheduler.py \
  tests/ut/kv_offload/test_mooncake_dsa_shared_pool.py \
  tests/ut/kv_offload/test_mooncake_dsa_transfer.py

python -m pytest -sv \
  tests/ut/distributed/kv_transfer/test_mooncake_transfer_engine.py \
  tests/ut/distributed/kv_transfer/sparse_kv_offload/test_mooncake_host_pool.py \
  tests/ut/kv_offload/test_mooncake_connector.py \
  tests/ut/kv_offload/test_sparse_kv_offload_external_plan.py

bash format.sh ci
```

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
