### PR TITLE
[v0.26.0][Performance][KDA] Drop redundant Kimi KDA padding mask

### DIFF
--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -32,7 +32,6 @@ from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiGatedDeltaNetAttention,
     _load_a_log,
-    _zero_padded_spec_output,
 )
 
 
@@ -133,42 +132,6 @@ def test_load_a_log_preserves_exact_local_4d_checkpoint():
 def test_load_a_log_rejects_unsupported_layout():
     with pytest.raises(ValueError, match="must be 1-D or 4-D"):
         _load_a_log(torch.empty(1, 1, 2, 1), torch.empty(2, 2), num_heads=4)
-
-
-def test_zero_padded_spec_output_clears_uninitialized_tail():
-    output = torch.arange(16 * 2 * 3, dtype=torch.float32).reshape(1, 16, 2, 3)
-    output[:, 8:] = torch.nan
-    query_start_loc = torch.tensor([0, 8, 8], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked[:, :8], output[:, :8])
-    assert torch.equal(masked[:, 8:], torch.zeros_like(masked[:, 8:]))
-    assert torch.isfinite(masked).all()
-
-
-def test_zero_padded_spec_output_preserves_fully_covered_output():
-    output = torch.randn(1, 16, 2, 3)
-    query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked, output)
-
-
-def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
-    output = torch.randn(1, 32, 2, 3)
-    expected = output[:, :16].clone()
-    output[:, 16:] = torch.nan
-    query_start_loc = torch.tensor([0, 8, 16, 16, 16], dtype=torch.int32)
-
-    masked = _zero_padded_spec_output(output, query_start_loc)
-
-    torch.testing.assert_close(masked[:, :16], expected)
-    assert torch.equal(masked[:, 16:], torch.zeros_like(masked[:, 16:]))
-    assert masked.shape == output.shape
-    assert masked.dtype == output.dtype
-    assert masked.device == output.device
 
 
 def test_output_norm_gate_uses_kda_fused_triton_kernel():

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -71,30 +71,6 @@ _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
 _FUSED_QKV_NAME = "fused_qkv"
 
 
-def _zero_padded_spec_output(
-    output: torch.Tensor,
-    query_start_loc: torch.Tensor,
-) -> torch.Tensor:
-    """Zero graph-padding rows skipped by the recurrent KDA kernel.
-
-    ``recurrent_kda`` leaves the output for zero-length sequences
-    uninitialized. FULL graph replay keeps those rows in the static output
-    shape, so explicitly clear the uncovered tail before it reaches the
-    residual and MoE layers.
-    """
-    token_indices = torch.arange(
-        output.shape[1],
-        dtype=query_start_loc.dtype,
-        device=output.device,
-    )
-    valid_tokens = token_indices < query_start_loc[-1]
-    return torch.where(
-        valid_tokens.view(1, -1, 1, 1),
-        output,
-        0.0,
-    )
-
-
 def uses_kimi_k3_global_inputs_embeds(vllm_config: VllmConfig) -> bool:
     model_config = vllm_config.model_config
     if model_config.enable_prompt_embeds:
@@ -534,6 +510,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         forward_context = get_forward_context()
         attn_metadata_raw: AttentionMetadata | None = forward_context.attn_metadata
         if attn_metadata_raw is None:
+            core_attn_out.zero_()
             return
 
         assert isinstance(attn_metadata_raw, dict)
@@ -604,12 +581,6 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                 attn_metadata.spec_query_start_loc,
                 attn_metadata.spec_state_indices_tensor,
                 num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
-            )
-            # Clear only static dummy rows skipped by the kernel. Real query
-            # tokens and their accepted lengths are unchanged.
-            core_spec = _zero_padded_spec_output(
-                core_spec,
-                attn_metadata.spec_query_start_loc,
             )
 
         core_non_spec = None
@@ -698,16 +669,24 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
                     attn_metadata.non_spec_state_indices_tensor,
                 )
 
+        if core_spec is None and core_non_spec is None:
+            # Idle DP dummy runs carry graph-shaped metadata with no live work.
+            # Do not feed a previous replay's output through the norm gate.
+            core_attn_out.zero_()
+            return
+
+        # Reuse the caller-owned result buffer. FULL graphs can leave rows
+        # outside the live spec/non-spec index sets, so define them before the
+        # two index copies rather than allocating a temporary merged tensor.
+        core_attn_out[:, :num_actual_tokens].zero_()
         if core_spec is not None and core_non_spec is not None:
-            merged = torch.empty(
-                (1, num_actual_tokens, self.local_num_heads, self.head_dim),
-                dtype=core_non_spec.dtype,
-                device=core_non_spec.device,
-            )
-            merged.index_copy_(1, spec_token_indices, core_spec)
-            merged.index_copy_(1, non_spec_token_indices, core_non_spec)
-            core_attn_out[:, :num_actual_tokens] = merged
+            assert spec_token_indices is not None
+            assert non_spec_token_indices is not None
+            assert spec_token_indices.numel() + non_spec_token_indices.numel() <= num_actual_tokens
+            core_attn_out[:, :num_actual_tokens].index_copy_(1, spec_token_indices, core_spec)
+            core_attn_out[:, :num_actual_tokens].index_copy_(1, non_spec_token_indices, core_non_spec)
         elif core_spec is not None:
             core_attn_out[:, :num_actual_tokens] = core_spec
         elif core_non_spec is not None:
             core_attn_out[:, :num_actual_tokens] = core_non_spec
+        core_attn_out[:, num_actual_tokens:].zero_()


### PR DESCRIPTION
### What this PR does / why we need it?

Port of the mask-removal commit (006a7323f, "perf(kda): remove redundant output padding masks") from #16046 to `releases/v0.26.0rc`, together with the output-buffer zeroing that commit relies on, migrated from the v0.27.1rc base. The strided-recurrent-inputs commit of #16046 is not part of this pick.

- Drop the redundant `_zero_padded_spec_output` mask (`arange` / compare / `where` chain, profiled as `Range / Less / Fill / SelectV2`) after the spec recurrent call. Padding rows inside the graph-shaped region no longer have a zero-value guarantee; effective-token computation is unchanged.
- Migrate the `core_attn_out` zeroing that the v0.27.1rc base already provides and that the upstream mask removal keeps:
  - zero the caller-owned buffer on the empty-context early return;
  - add an idle-DP-dummy early return with an explicit `zero_()` so a previous replay's output is never fed through the norm gate;
  - define padding rows before the two index copies (pre-merge `zero_()` plus direct `index_copy_` into `core_attn_out` instead of a temporary `merged = torch.empty` tensor);
  - zero the tail beyond `num_actual_tokens`.
- The v0.27.1rc-only hunks of the upstream commit (non-spec recurrent mask, post-norm mask, live-token count) have no counterpart on this branch; the norm gate stays in `forward()`. Dangling UT references to the removed helper are dropped.

### Does this PR introduce _any_ user-facing change?

No. Performance optimization of Kimi K3 KDA postprocessing; effective-token computation and the recurrent KDA operator are unchanged.

### How was this patch tested?

- Upstream #16046 reports accuracy validation (GPQA Avg@5: 93.03) plus spec/decode/mixed framework regression cases with NaN padding on `releases/v0.27.1rc`.
- Local CI replication (pre-commit 18 hooks, mypy 3.10/3.11/3.12) passes for this branch.
- NPU runs on v0.26.0rc are not covered by this pick; the upstream regression tests are not ported.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
