### PR TITLE
[BugFix][MoE] Support uneven expert distribution across EP ranks

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -120,6 +120,7 @@ def test_ascend_routed_experts_uses_parent_unquantized_method_during_init(monkey
 @pytest.mark.parametrize("quant_config", [None, object()])
 def test_ascend_routed_experts_replaces_only_unquantized_method_after_parent_init(monkeypatch, quant_config):
     moe_config = MagicMock()
+    moe_config.moe_parallel_config.use_ep = False
     parent_method = object()
     ascend_method = object()
     init_methods = []
@@ -145,6 +146,7 @@ def test_ascend_routed_experts_replaces_only_unquantized_method_after_parent_ini
         routed_experts_module,
         "get_ascend_config",
         lambda: SimpleNamespace(
+            eplb_config=SimpleNamespace(dynamic_eplb=False, expert_map_path=None),
             ascend_compilation_config=SimpleNamespace(enable_static_kernel=False),
             enable_shared_expert_dp=False,
         ),
@@ -158,7 +160,9 @@ def test_ascend_routed_experts_replaces_only_unquantized_method_after_parent_ini
         ),
     )
 
-    routed_experts = AscendRoutedExperts(tid2eid="tid2eid")
+    routed_experts = AscendRoutedExperts(
+        "model.layers.0.mlp", torch.float32, moe_config, None, expert_map_manager=None, tid2eid="tid2eid"
+    )
 
     assert init_methods == [parent_method]
     if quant_config is None:
@@ -189,9 +193,20 @@ def test_ascend_routed_experts_accepts_tid2eid_parameter_before_module_init(monk
     tid2eid = nn.Parameter(torch.zeros(2, 2), requires_grad=False)
     parent_init = MagicMock(side_effect=RuntimeError("stop after parent init"))
     monkeypatch.setattr(routed_experts_module.RoutedExperts, "__init__", parent_init)
+    monkeypatch.setattr(
+        routed_experts_module,
+        "get_ascend_config",
+        lambda: SimpleNamespace(eplb_config=SimpleNamespace(dynamic_eplb=False, expert_map_path=None)),
+    )
 
     with pytest.raises(RuntimeError, match="stop after parent init"):
-        AscendRoutedExperts(tid2eid=tid2eid)
+        AscendRoutedExperts(
+            "model.layers.0.mlp",
+            torch.float32,
+            moe_config=SimpleNamespace(moe_parallel_config=SimpleNamespace(use_ep=False)),
+            expert_map_manager=None,
+            tid2eid=tid2eid,
+        )
 
     parent_init.assert_called_once()
 
@@ -215,6 +230,7 @@ def test_ascend_routed_experts_initializes_only_matching_eplb_path(
         routed_experts_module,
         "get_ascend_config",
         lambda: SimpleNamespace(
+            eplb_config=SimpleNamespace(dynamic_eplb=False, expert_map_path=None),
             ascend_compilation_config=SimpleNamespace(enable_static_kernel=False),
             enable_shared_expert_dp=False,
         ),
@@ -228,7 +244,13 @@ def test_ascend_routed_experts_initializes_only_matching_eplb_path(
         ),
     )
 
-    routed_experts = AscendRoutedExperts(n_shared_experts=2)
+    routed_experts = AscendRoutedExperts(
+        "model.layers.0.mlp",
+        torch.float32,
+        moe_config=SimpleNamespace(moe_parallel_config=SimpleNamespace(use_ep=False)),
+        expert_map_manager=None,
+        n_shared_experts=2,
+    )
 
     assert routed_experts._use_v2_model_runner is use_v2_model_runner
     assert init_eplb.call_count == legacy_init_calls

--- a/tests/ut/ops/test_routed_experts.py
+++ b/tests/ut/ops/test_routed_experts.py
@@ -5,8 +5,14 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.model_executor.layers.fused_moe.expert_map_manager import ExpertMapManager
 
-from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts, EplbExpertTensorList
+from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
+from vllm_ascend.ops.fused_moe.routed_experts import (
+    AscendRoutedExperts,
+    EplbExpertTensorList,
+    pad_static_expert_capacity,
+)
 from vllm_ascend.utils import vllm_version_is
 
 
@@ -110,3 +116,85 @@ def test_update_expert_map_preserves_upstream_and_legacy_contracts(monkeypatch):
 
     assert routed_experts.ascend_expert_map is legacy_map
     assert expert_map_manager._expert_map is legacy_map
+
+
+@pytest.mark.parametrize("ep_size", [1, 4, 6, 12])
+def test_static_expert_padding_preserves_checkpoint_and_dispatch_placement(ep_size):
+    logical_count = 128
+    physical_count = ((logical_count + ep_size - 1) // ep_size) * ep_size
+    placement = []
+    for rank in range(ep_size):
+        parallel = SimpleNamespace(
+            use_ep=ep_size > 1,
+            enable_eplb=False,
+            ep_size=ep_size,
+            ep_rank=rank,
+            needs_round_robin_routing_tables=False,
+        )
+        manager = ExpertMapManager(
+            max_num_batched_tokens=16,
+            top_k=8,
+            global_num_experts=logical_count,
+            num_redundant_experts=0,
+            num_expert_group=None,
+            moe_parallel_config=parallel,
+            placement_strategy="linear",
+            enable_eplb=False,
+        )
+        config = SimpleNamespace(
+            num_experts=logical_count,
+            num_logical_experts=logical_count,
+            num_local_experts=manager.local_num_experts,
+            moe_parallel_config=parallel,
+            ep_size=ep_size,
+            ep_rank=rank,
+        )
+        padding = pad_static_expert_capacity(config, manager)
+
+        assert padding == physical_count - logical_count
+        assert config.num_logical_experts == logical_count
+        assert config.num_experts == physical_count
+        assert config.num_local_experts == physical_count // ep_size
+        _, dispatch_map, log2phy, redundancy = init_eplb_config(
+            SimpleNamespace(dynamic_eplb=False, expert_map_path=None, num_redundant_experts=0),
+            0,
+            config,
+        )
+        assert redundancy == 0  # Dummy slots are not EPLB replicas.
+        assert log2phy is None
+        if ep_size == 1:
+            assert manager.expert_map is dispatch_map is None
+            continue
+        torch.testing.assert_close(dispatch_map, manager.expert_map)
+        # A checkpoint expert must land in the same local slot used by dispatch.
+        local_count = config.num_local_experts
+        expected = torch.full((physical_count,), -1, dtype=torch.int32)
+        expected[rank * local_count : (rank + 1) * local_count] = torch.arange(local_count, dtype=torch.int32)
+        torch.testing.assert_close(manager.expert_map, expected)
+        placement.append(manager.expert_map[:logical_count] >= 0)
+    if placement:
+        assert torch.stack(placement).sum(dim=0).tolist() == [1] * logical_count
+
+
+def test_static_padding_leaves_eplb_capacity_unchanged():
+    config = SimpleNamespace(moe_parallel_config=SimpleNamespace(use_ep=True, enable_eplb=True))
+    # EPLB owns its capacity and placement; static padding must not touch either.
+    assert pad_static_expert_capacity(config, None) == 0
+
+
+def test_padded_profile_routes_only_to_logical_experts(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_ascend.ops.fused_moe.routed_experts.get_ascend_config",
+        lambda: SimpleNamespace(enable_force_eplb=False),
+    )
+    weights = torch.ones(16, 8)
+    layer = SimpleNamespace(
+        router=SimpleNamespace(_select_experts=lambda **kwargs: (weights, torch.zeros(16, 8, dtype=torch.int32))),
+        log2phy=None,
+        n_shared_experts=0,
+        moe_config=SimpleNamespace(num_experts=132, num_logical_experts=128),
+        global_redundant_expert_num=0,
+    )
+    _, ids = AscendRoutedExperts._select_experts(layer, torch.ones(16, 4), torch.ones(16, 128), True)
+    assert ids.shape == (16, 8)
+    assert torch.all((ids >= 0) & (ids < 128))

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -26,6 +26,7 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoERouter, RoutedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.expert_map_manager import ExpertMapManager
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 from vllm.model_executor.utils import replace_parameter
 
@@ -316,6 +317,27 @@ def make_eplb_placement_config(eplb_config, num_redundant_experts: int) -> Simpl
     )
 
 
+def pad_static_expert_capacity(moe_config: FusedMoEConfig, expert_map_manager: ExpertMapManager) -> int:
+    """Reserve non-routing slots so Ascend dispatch has equal capacity on every rank."""
+    parallel = moe_config.moe_parallel_config
+    if (
+        not parallel.use_ep
+        or parallel.enable_eplb
+        or moe_config.num_experts != moe_config.num_logical_experts
+        or expert_map_manager.num_fused_shared_experts
+        or expert_map_manager.placement_strategy != "linear"
+    ):
+        return 0
+    padding = -moe_config.num_experts % parallel.ep_size
+    if padding:
+        moe_config.num_experts += padding
+        # Update checkpoint placement before RoutedExperts allocates weights.
+        # Logical router IDs remain unchanged; the trailing slots are never routed to.
+        expert_map_manager.update(parallel, moe_config.num_experts)
+        moe_config.num_local_experts = expert_map_manager.local_num_experts
+    return padding
+
+
 class EplbExpertTensorList(list[torch.Tensor]):
     """Per-expert tensors exposed through the upstream EPLB weight contract."""
 
@@ -342,13 +364,25 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
 
     def __init__(
         self,
+        layer_name: str,
+        params_dtype: torch.dtype,
+        moe_config: FusedMoEConfig,
         *args,
+        expert_map_manager: ExpertMapManager,
         tid2eid=None,
         n_shared_experts: int = 0,
         **kwargs,
     ):
         object.__setattr__(self, "tid2eid", tid2eid)
-        super().__init__(*args, **kwargs)
+        ascend_config = get_ascend_config()
+        eplb_config = ascend_config.eplb_config
+        padding = 0
+        if not (
+            eplb_config.dynamic_eplb or eplb_config.expert_map_path or getattr(ascend_config, "mix_placement", False)
+        ):
+            padding = pad_static_expert_capacity(moe_config, expert_map_manager)
+        object.__setattr__(self, "num_padding_experts", padding)
+        super().__init__(layer_name, params_dtype, moe_config, *args, expert_map_manager=expert_map_manager, **kwargs)
         if self.quant_config is None:
             # Preserve the pre-refactor BF16 lifecycle: let upstream create
             # weights first, then install the Ascend execution method.
@@ -426,10 +460,14 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         # Ascend's placement builder operates on logical expert IDs, so give it
         # a shallow config view with the logical count.
         placement_moe_config = copy(self.moe_config)
-        placement_moe_config.num_experts = self.moe_config.num_logical_experts + (
-            n_shared_experts if self.mix_placement else 0
+        placement_moe_config.num_experts = (
+            self.moe_config.num_logical_experts
+            + self.num_padding_experts
+            + (n_shared_experts if self.mix_placement else 0)
         )
-        allocated_redundancy = self.moe_config.num_experts - self.moe_config.num_logical_experts
+        allocated_redundancy = (
+            self.moe_config.num_experts - self.moe_config.num_logical_experts - self.num_padding_experts
+        )
         if eplb_config.num_redundant_experts not in (0, allocated_redundancy):
             raise ValueError(
                 "Conflicting EPLB redundant expert counts: "


### PR DESCRIPTION
### What this PR does / why we need it?

Previously, vLLM Ascend could not start some MoE expert-parallel configurations when the model's number of routed experts was not divisible by the expert-parallel (EP) group size.

For example, Qwen3-30B-A3B has 128 routed experts. With DP=3 and TP=2, the EP group has six ranks, and 128 experts cannot be divided evenly across them. vLLM Ascend therefore crashed during model initialization with:

```text
ValueError: EPLB local expert capacity mismatch: allocated=22, placement=21.
```

The same configuration is supported by upstream vLLM on GPU. This fix is important as when running a configuration like DP=4, TP=4 and you need some more capacity. You cannot run DP=6, TP=4 right now. You need to go directly to DP=8, TP=4 which is unreasonable in some scenarios.

This change pads the per-rank expert capacity with unused slots so that every EP rank allocates the same capacity. Routing remains limited to the model's real experts. This allows configurations such as DP=3 and TP=2 to initialize and serve successfully. Configurations where the expert count already divides evenly are unchanged.

This fix applies to static linear expert placement. Dynamic EPLB and custom expert maps are unchanged.

Fixes: Did not raise a separate issue.

#### Padding logic

For `N` logical experts and `P` EP ranks:

```text
padding = (-N) % P
physical_capacity = N + padding = ceil(N / P) * P
slots_per_rank = physical_capacity / P
```

The logical expert count remains `N`. Linear placement assigns consecutive physical slots to each rank. Trailing slots beyond the logical count are unused padding, and routing—including profiling—continues to select only logical expert IDs.

For 128 experts and six ranks, this gives 132 physical slots, with 22 slots per rank:

The four padding slots add 3.125% expert-slot capacity relative to 128 real experts, per layer. They are not replicated experts and do not increase the router's output space. `init_eplb` includes padding in placement capacity and explicitly excludes it when calculating redundant expert counts.

The padding path applies to static linear EP placement without pre-existing redundant capacity. Divisible configurations need no padding. Dynamic EPLB, custom expert maps, fused shared experts, mixed placement, and non-linear placement bypass this path.

### Does this PR introduce _any_ user-facing change?

Yes. MoE models can now use static expert-parallel configurations where the number of routed experts is not divisible by the EP group size, such as Qwen3-30B-A3B with DP=3 and TP=2 or DP=6 and TP=2. 

No new flags or configuration changes are introduced.

### How was this patch tested?

Added regression tests covering EP group sizes 1, 4, 6, and 12. The tests verify that:

- every rank receives equal expert capacity;
- checkpoint loading and dispatch use the same expert placement;
- padding slots are not routed to as real experts;
- configurations that already divide evenly remain unchanged.

The following focused test suite passed with 122 tests:

```bash
python3 -m pytest -q \
  tests/ut/ops/test_routed_experts.py \
  tests/ut/eplb/core/test_eplb_utils.py \
  tests/ut/ops/test_fused_moe.py \
  tests/ut/ops/test_force_eplb.py \
  tests/ut/patch/platform/test_patch_fused_moe.py
```

The change was also tested with Qwen3-30B-A3B in BF16 on six Ascend A3 NPUs using TP=2, DP=3, expert parallelism, and eager execution.

- Before the fix: the server crashed during model initialization.
- After the fix: the server became ready and successfully handled completion requests.
- The existing DP=2, TP=2 configuration continued to work.

Hardware environment:

- CANN: 9.1.0
- Driver: 25.5.0
- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
