### PR TITLE
[Test][Feature] Add GLM-5.3 multi-node internal DP test case

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -261,7 +261,7 @@ a3:
         size: 2
       - name: GLM5_3-W8A8-A3-dual-nodes
         config_file_path: GLM5_3-W8A8-A3-dual-nodes.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
         size: 2
   single_node:
     test_config:

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -259,6 +259,10 @@ a3:
         config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
+      - name: GLM5_3-W8A8-A3-dual-nodes
+        config_file_path: GLM5_3-W8A8-A3-dual-nodes.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
   single_node:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -573,7 +573,8 @@
             "z-lab/Qwen3-8B-DFlash-b16",
             "zai-org/GLM-4.1V-9B-Thinking",
             "zai-org/GLM-Image",
-            "Eco-Tech/GLM-5.2-w8a8c8"
+            "Eco-Tech/GLM-5.2-w8a8c8",
+            "Eco-Tech/GLM-5.3-w8a8c8"
         ],
         "a5": [
             "Eco-Tech/DeepSeek-V3.1-w4a4c8-mxfp4",

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -302,7 +302,8 @@
             "Eco-Tech/Kimi-K2.6-w4a8",
             "z-lab/Qwen3.6-35B-A3B-DFlash",
             "Ex0bit/Qwen3.6-27B-PRISM-EAGLE3",
-            "zai-org/GLM-Image"
+            "zai-org/GLM-Image",
+            "Eco-Tech/GLM-5.3-w8a8c8"
         ],
         "a3": [
             "AI-ModelScope/AI21-Jamba-1.5-Mini",

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_3-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_3-W8A8-A3-dual-nodes.yaml
@@ -1,0 +1,101 @@
+test_name: "double-node-GLM-5.3-w8a8c8-A3"
+model: "Eco-Tech/GLM-5.3-w8a8c8"
+num_nodes: 2
+npu_per_node: 16
+env_common: &env_common
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  HCCL_TRANSFER_TIMEOUT: "600"
+  HCCL_EXEC_TIMEOUT: "3600"
+  HCCL_CONNECT_TIMEOUT: "3600"
+  OMP_PROC_BIND: false
+  VLLM_USE_MODELSCOPE: true
+  OMP_NUM_THREADS: 1
+  HCCL_BUFFSIZE: 400
+  PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
+  VLLM_ASCEND_ENABLE_MLAPO: 1
+  VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+  VLLM_RPC_TIMEOUT: "600"
+  SERVER_PORT: 8077
+
+deployment:
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      vllm serve Eco-Tech/GLM-5.3-w8a8c8
+      --host 0.0.0.0
+      --port $SERVER_PORT
+      --safetensors-load-strategy prefetch
+      --api-server-count 1
+      --data-parallel-size 8
+      --data-parallel-start-rank 0
+      --data-parallel-size-local 4
+      --data-parallel-address $LOCAL_IP
+      --data-parallel-rpc-port 12980
+      --tensor-parallel-size 4
+      --enable-expert-parallel
+      --seed 1024
+      --tool-call-parser glm47
+      --reasoning-parser glm45
+      --enable-auto-tool-choice
+      --max-num-seqs 6
+      --max-model-len 202752
+      --max-num-batched-tokens 4096
+      --trust-remote-code
+      --gpu-memory-utilization 0.90
+      --quantization ascend
+      --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "enable_fused_mc2": 1, "enable_flashcomm1": true}'
+      --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      vllm serve Eco-Tech/GLM-5.3-w8a8c8
+      --host 0.0.0.0
+      --port $SERVER_PORT
+      --headless
+      --data-parallel-size 8
+      --data-parallel-start-rank 4
+      --data-parallel-size-local 4
+      --data-parallel-address $MASTER_IP
+      --data-parallel-rpc-port 12980
+      --tensor-parallel-size 4
+      --enable-expert-parallel
+      --seed 1024
+      --tool-call-parser glm47
+      --reasoning-parser glm45
+      --enable-auto-tool-choice
+      --max-num-seqs 6
+      --max-model-len 202752
+      --max-num-batched-tokens 4096
+      --trust-remote-code
+      --gpu-memory-utilization 0.92
+      --quantization ascend
+      --enable-chunked-prefill
+      --enable-prefix-caching
+      --async-scheduling
+      --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "enable_fused_mc2": 1, "enable_flashcomm1": true}'
+      --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+
+benchmarks:
+  acc_aime2025:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    max_out_len: 72348
+    batch_size: 32
+    baseline: 90
+    threshold: 10
+
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix90_in131072_bs100_glm
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 12
+    max_out_len: 1024
+    batch_size: 3
+    request_rate: 0
+    baseline: 34.49
+    threshold: 0.97

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM5_3-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM5_3-W8A8-A3-dual-nodes.yaml
@@ -78,15 +78,17 @@ deployment:
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
 
 benchmarks:
-  acc_aime2025:
+  acc_GPQA:
     case_type: accuracy
-    dataset_path: vllm-ascend/aime2025
+    dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
-    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
-    max_out_len: 72348
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    max_out_len: 65536
+    temperature: 1.0
+    top_p: 0.95
     batch_size: 32
-    baseline: 90
-    threshold: 10
+    baseline: 87.6
+    threshold: 5
 
   perf:
     case_type: performance


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds a new multi-node end-to-end nightly test configuration for the `Eco-Tech/GLM-5.3-w8a8c8` model using internal data parallel (DP) on dual nodes (A3). This test case helps validate the correctness and performance of GLM-5.3 under multi-node DP execution.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
This patch adds a new configuration file `tests/e2e/nightly/multi_node/internal_dp/config/GLM5_3-W8A8-A3-dual-nodes.yaml` to be run as part of the nightly multi-node E2E test suite.
- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
