### PR TITLE
[Feature][Ops] Support store_kv_block custom op on Ascend950

### DIFF
--- a/csrc/attention/store_kv_block/op_host/store_kv_block_def.cpp
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_def.cpp
@@ -57,6 +57,7 @@ class StoreKVBlock : public OpDef {
     this->Attr("blockSize").Int();
     this->AICore().AddConfig("ascend910b");
     this->AICore().AddConfig("ascend910_93");
+    this->AICore().AddConfig("ascend950");
   }
 };
 

--- a/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.cpp
+++ b/csrc/attention/store_kv_block/op_host/store_kv_block_tiling.cpp
@@ -108,7 +108,11 @@ static ge::graphStatus StoreKVBlockTilingFunc(gert::TilingContext* context) {
     auto platformInfo = context->GetPlatformInfo();
     OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
-    params.coreNum = ascendcPlatform.GetCoreNum();
+    // Arch35 (Ascend950) runs the kernel on vector cores; fall back to GetCoreNum for 910b/910_93.
+    params.coreNum = ascendcPlatform.GetCoreNumAiv();
+    if (params.coreNum == 0) {
+        params.coreNum = ascendcPlatform.GetCoreNum();
+    }
     if (params.coreNum == 0) {
         OP_LOGE(context->GetNodeName(), "Failed to get core num.");
         return ge::GRAPH_FAILED;

--- a/vllm_ascend/meta_registration.py
+++ b/vllm_ascend/meta_registration.py
@@ -49,6 +49,10 @@ def register_meta_if_necessary(ns: str, op_name: str, fn, overload: str = ""):
     meta_impl_list = torch._C._dispatch_get_registrations_for_dispatch_key("Meta")
     if schema_to_find in meta_impl_list:
         return
+    # The op may not be compiled into the extension for the current SoC
+    # (e.g. direct kernels are excluded on ascend950); skip in that case.
+    if not hasattr(getattr(torch.ops, ns), op_name.split(".")[0]):
+        return
     lib.impl(op_name, fn, "Meta")
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables the `store_kv_block` custom op on Ascend950 (Arch35):

- `store_kv_block_def.cpp`: register the `ascend950` AICore config so the op is built and dispatched on Ascend950.
- `store_kv_block_tiling.cpp`: on Arch35 the kernel runs on vector cores, so use `GetCoreNumAiv()` for the core count, falling back to `GetCoreNum()` for ascend910b/ascend910_93.
- `meta_registration.py`: skip meta registration when the op is not compiled into the extension for the current SoC (e.g. direct kernels are excluded on ascend950), which otherwise raises `AttributeError` at import/registration time.

Without these changes, running `tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py` on Ascend950 fails because the op is not registered (`torch.ops._C_ascend.store_kv_block_metadata` is missing).

### Does this PR introduce _any_ user-facing change?

No API change. The `store_kv_block` / `store_kv_block_metadata` custom ops now work on Ascend950 devices; behavior on ascend910b/ascend910_93 is unchanged.

### How was this patch tested?

Ran the existing e2e op test on an Ascend950 single-card environment:

```
pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/test_store_kv_block.py
# 2 passed, 14 warnings in 5.34s
```

Both cases (`test_myops[1-1773-1-1-52]` and the metadata case) pass on Ascend950 with this patch; before the patch, the test failed with `AttributeError: '_OpNamespace' '_C_ascend' object has no attribute 'store_kv_block_metadata'`.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
