### PR TITLE
[BugFix][Model] Fix Kimi K3 dense MLP sequence parallelism

### DIFF
--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -144,6 +144,35 @@ def test_kimi_model_declares_fused_bfg_checkpoint_mapping():
     ]
 
 
+def test_kimi_dense_mlp_gathers_and_scatters_sequence_shards(monkeypatch):
+    mlp = kimi_k3.AscendKimiMLP.__new__(kimi_k3.AscendKimiMLP)
+    nn.Module.__init__(mlp)
+    mlp.use_sequence_parallel = True
+    calls = []
+
+    def fake_all_gather(hidden_states):
+        calls.append(("gather", hidden_states.clone()))
+        return torch.cat((hidden_states, hidden_states + 10), dim=0)
+
+    def fake_mlp_forward(_self, hidden_states):
+        calls.append(("mlp", hidden_states.clone()))
+        return hidden_states + 1
+
+    def fake_reduce_scatter(hidden_states):
+        calls.append(("reduce_scatter", hidden_states.clone()))
+        return hidden_states.chunk(2, dim=0)[0]
+
+    monkeypatch.setattr(kimi_k3, "sp_all_gather", fake_all_gather)
+    monkeypatch.setattr(kimi_k3, "sp_reduce_scatter", fake_reduce_scatter)
+    monkeypatch.setattr(kimi_k3.KimiMLP, "forward", fake_mlp_forward)
+
+    output = mlp(torch.tensor([[1.0], [2.0]]))
+
+    assert [name for name, _ in calls] == ["gather", "mlp", "reduce_scatter"]
+    torch.testing.assert_close(calls[1][1], torch.tensor([[1.0], [2.0], [11.0], [12.0]]))
+    torch.testing.assert_close(output, torch.tensor([[2.0], [3.0]]))
+
+
 def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):
     class IdentityAttention(nn.Module):
         def forward(self, *, hidden_states, positions):

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -125,6 +125,44 @@ def _apply_ascend_attn_res(
     return torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
 
 
+class AscendKimiMLP(KimiMLP):
+    """Keep TP-sharded dense weights compatible with sequence-sharded tokens."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+        activation_situ_beta: float | None = None,
+        activation_situ_linear_beta: float | None = None,
+        use_sequence_parallel: bool = False,
+    ) -> None:
+        super().__init__(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            hidden_act=hidden_act,
+            quant_config=quant_config,
+            reduce_results=False if use_sequence_parallel else reduce_results,
+            prefix=prefix,
+            activation_situ_beta=activation_situ_beta,
+            activation_situ_linear_beta=activation_situ_linear_beta,
+        )
+        self.use_sequence_parallel = use_sequence_parallel
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.use_sequence_parallel:
+            # All weight shards must operate on the same tokens. Reducing
+            # different sequence shards would mix live and padding rows.
+            x = sp_all_gather(x)
+        x = super().forward(x)
+        if self.use_sequence_parallel:
+            x = sp_reduce_scatter(x)
+        return x
+
+
 class AscendKimiMoE(nn.Module):
     """Kimi K3 MoE assembled from the standard vLLM MoE interfaces."""
 
@@ -416,12 +454,13 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
             )
             self.mlp = self.block_sparse_moe
         else:
-            self.mlp = KimiMLP(
+            self.mlp = AscendKimiMLP(
                 hidden_size=self.hidden_size,
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 prefix=f"{prefix}.mlp",
+                use_sequence_parallel=use_sequence_parallel,
                 activation_situ_beta=config.activation_situ_beta,
                 activation_situ_linear_beta=config.activation_situ_linear_beta,
             )


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes the dense Kimi K3 MLP path when sequence parallelism is enabled.

The dense MLP now gathers sequence-sharded token rows before executing the TP-sharded weights, disables the upstream output reduction for this path, and reduce-scatters the output afterwards. This keeps every TP shard aligned on the same tokens and avoids mixing live and padding rows during reduction.

### Does this PR introduce any user-facing change?

Yes. Kimi K3 workloads that enable sequence parallelism now use the corrected dense-MLP collective sequence.

### How was this patch tested?

- Added `test_kimi_dense_mlp_gathers_and_scatters_sequence_shards`, which verifies the gather → MLP → reduce-scatter sequence and the gathered/sharded tensors using CPU mocks.
- Ran Python syntax compilation for the changed implementation and test files.
- Ran `git diff --check` and `git show --check`.
- The local machine does not have the main branch's vLLM/Ascend test runtime or Ascend NPU hardware, so the targeted pytest and NPU validation are left for project CI.
- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
