### PR TITLE
[CI] fix a5 multi resource

### DIFF
--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -253,6 +253,7 @@ jobs:
           BISECT_NO_VERIFY_BAD: ${{ inputs.bisect_no_verify_bad }}
           BISECT_FORCE_INITIAL_BUILD: ${{ inputs.bisect_force_initial_build }}
           BISECT_CONFIG_BASE_PATH: ${{ inputs.bisect_config_base_path }}
+          OPENLIBING_SECRET: ${{ secrets.OPENLIBING_SECRET }}
         run: |
           set -euo pipefail
 
@@ -300,7 +301,7 @@ jobs:
             -D runner="$runner" \
             -D aop_multi_enabled="${{ inputs.aop_multi_enabled }}" \
             -D good_table="/root/.cache/vllm-ascend/${{ inputs.vllm_ascend_branch || 'main' }}/${{ inputs.test_frequency }}/good_table.csv" \
-            -D openlibing_secret="$OPENLIBING_SECRET" \
+            -D openlibing_secret="${OPENLIBING_SECRET:-}" \
             -D vllm_ascend_branch="${{ inputs.vllm_ascend_branch }}" \
             -D soc_version="${{ inputs.soc_version }}" \
             -D npu_resource_name="${npu_resource_name:-}" \

--- a/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
+++ b/tests/e2e/nightly/multi_node/scripts/lws.yaml.jinja2
@@ -78,6 +78,8 @@ spec:
                 bash /root/.cache/tests/run.sh \
                   "{{ soc_version | default("") }}" \
                   "{{ max_good_age_days | default("3") }}"
+{% set soc = soc_version | default("a3") | lower %}
+{% if soc in ["a2","a3"] %}
             resources:
               limits:
                 memory: 512Gi
@@ -87,6 +89,17 @@ spec:
                 ephemeral-storage: 100Gi
                 cpu: 125
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+{% elif soc == "a5" %}
+            resources:
+              limits:
+                {{ npu_resource_name | default("huawei.com/ascend-1980") }}: {{ npu_per_node | default("16") }}
+                memory: 512Gi
+                ephemeral-storage: 100Gi
+              requests:
+                {{ npu_resource_name | default("huawei.com/ascend-1980") }}: {{ npu_per_node | default("16") }}
+                ephemeral-storage: 100Gi
+                cpu: 125
+{% endif %}
             ports:
               - containerPort: 8080
             volumeMounts:
@@ -175,6 +188,8 @@ spec:
                 bash /root/.cache/tests/run.sh \
                   "{{ soc_version | default("") }}" \
                   "{{ max_good_age_days | default("3") }}"
+{% set soc = soc_version | default("a3") | lower %}
+{% if soc in ["a2","a3"] %}
             resources:
               limits:
                 memory: 512Gi
@@ -184,6 +199,17 @@ spec:
                 ephemeral-storage: 100Gi
                 cpu: 125
                 huawei.com/ascend-1980: {{ npu_per_node | default("16") }}
+{% elif soc == "a5" %}
+            resources:
+              limits:
+                {{ npu_resource_name | default("huawei.com/ascend-1980") }}: {{ npu_per_node | default("16") }}
+                memory: 512Gi
+                ephemeral-storage: 100Gi
+              requests:
+                {{ npu_resource_name | default("huawei.com/ascend-1980") }}: {{ npu_per_node | default("16") }}
+                ephemeral-storage: 100Gi
+                cpu: 125
+{% endif %}
             volumeMounts:
               - mountPath: /root/.cache
                 name: shared-volume


### PR DESCRIPTION
### What this PR does / why we need it?
adapt resource got a5 multi nightly,add openlibing.secret parameter to enable a5 multi nightly run

### Does this PR introduce _any_ user-facing change?
eable developer run a5 multi nightly
### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
