### PR TITLE
[Ops][Misc] Optimize causal conv1d weight layout for NPU loading in GDN

### DIFF
--- a/tests/ut/ops/test_gdn_weight_loading.py
+++ b/tests/ut/ops/test_gdn_weight_loading.py
@@ -24,9 +24,7 @@ from vllm_ascend.ops.gdn import prepare_causal_conv1d_weight_for_loading
 def test_prepare_causal_conv1d_weight_for_loading() -> None:
     weight = torch.nn.Parameter(torch.empty(6, 1, 4), requires_grad=False)
 
-    def sharded_loader(
-        param: torch.Tensor, loaded_weight: torch.Tensor, offset: int
-    ) -> None:
+    def sharded_loader(param: torch.Tensor, loaded_weight: torch.Tensor, offset: int) -> None:
         param.data.copy_(loaded_weight[offset : offset + param.shape[0]])
 
     weight.weight_loader = sharded_loader

--- a/tests/ut/ops/test_gdn_weight_loading.py
+++ b/tests/ut/ops/test_gdn_weight_loading.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.ops.gdn import prepare_causal_conv1d_weight_for_loading
+
+
+def test_prepare_causal_conv1d_weight_for_loading() -> None:
+    weight = torch.nn.Parameter(torch.empty(6, 1, 4), requires_grad=False)
+
+    def sharded_loader(
+        param: torch.Tensor, loaded_weight: torch.Tensor, offset: int
+    ) -> None:
+        param.data.copy_(loaded_weight[offset : offset + param.shape[0]])
+
+    weight.weight_loader = sharded_loader
+    conv1d = SimpleNamespace(weight=weight)
+    loaded_weight = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 1, 4)
+
+    prepare_causal_conv1d_weight_for_loading(conv1d)
+    weight.weight_loader(weight, loaded_weight, 1)
+
+    expected = loaded_weight[1:7].squeeze(1).transpose(0, 1)
+    torch.testing.assert_close(weight, expected)
+    assert weight.shape == (4, 6)
+    assert weight.is_contiguous()
+
+
+@pytest.mark.parametrize("shape", [(6, 4), (6, 2, 4)])
+def test_prepare_causal_conv1d_weight_rejects_unexpected_shape(
+    shape: tuple[int, ...],
+) -> None:
+    weight = torch.nn.Parameter(torch.empty(shape), requires_grad=False)
+    weight.weight_loader = lambda param, loaded_weight: None
+
+    with pytest.raises(ValueError, match="Expected causal conv1d weight shape"):
+        prepare_causal_conv1d_weight_for_loading(SimpleNamespace(weight=weight))
+
+
+def test_prepare_causal_conv1d_weight_requires_loader() -> None:
+    weight = torch.nn.Parameter(torch.empty(6, 1, 4), requires_grad=False)
+
+    with pytest.raises(AttributeError, match="does not have a weight_loader"):
+        prepare_causal_conv1d_weight_for_loading(SimpleNamespace(weight=weight))

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -52,22 +52,15 @@ def prepare_causal_conv1d_weight_for_loading(conv1d: torch.nn.Module) -> None:
     """
     weight = conv1d.weight
     if weight.ndim != 3 or weight.shape[1] != 1:
-        raise ValueError(
-            "Expected causal conv1d weight shape [channels, 1, width], "
-            f"but got {tuple(weight.shape)}"
-        )
+        raise ValueError(f"Expected causal conv1d weight shape [channels, 1, width], but got {tuple(weight.shape)}")
     if not hasattr(weight, "weight_loader"):
         raise AttributeError("Causal conv1d weight does not have a weight_loader")
 
     original_weight_loader = weight.weight_loader
     channels, _, width = weight.shape
-    weight.data = torch.empty(
-        (width, channels), dtype=weight.dtype, device=weight.device
-    )
+    weight.data = torch.empty((width, channels), dtype=weight.dtype, device=weight.device)
 
-    def width_major_weight_loader(
-        param: torch.Tensor, loaded_weight: torch.Tensor, *args, **kwargs
-    ) -> None:
+    def width_major_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor, *args, **kwargs) -> None:
         checkpoint_layout = param.data.transpose(0, 1).unsqueeze(1)
         original_weight_loader(checkpoint_layout, loaded_weight, *args, **kwargs)
 

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -41,6 +41,39 @@ from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.mamba.causal_conv1d import extract_last_width
 
 
+def prepare_causal_conv1d_weight_for_loading(conv1d: torch.nn.Module) -> None:
+    """Store a causal-conv1d weight in the layout consumed by the NPU op.
+
+    Checkpoints and the upstream loader use [channels, 1, width], while
+    npu_causal_conv1d_custom consumes a contiguous [width, channels] tensor.
+    Allocate the parameter in the latter layout before loading and let the
+    existing loader write through a transposed view. This avoids a persistent
+    copy and a transpose in every forward.
+    """
+    weight = conv1d.weight
+    if weight.ndim != 3 or weight.shape[1] != 1:
+        raise ValueError(
+            "Expected causal conv1d weight shape [channels, 1, width], "
+            f"but got {tuple(weight.shape)}"
+        )
+    if not hasattr(weight, "weight_loader"):
+        raise AttributeError("Causal conv1d weight does not have a weight_loader")
+
+    original_weight_loader = weight.weight_loader
+    channels, _, width = weight.shape
+    weight.data = torch.empty(
+        (width, channels), dtype=weight.dtype, device=weight.device
+    )
+
+    def width_major_weight_loader(
+        param: torch.Tensor, loaded_weight: torch.Tensor, *args, **kwargs
+    ) -> None:
+        checkpoint_layout = param.data.transpose(0, 1).unsqueeze(1)
+        original_weight_loader(checkpoint_layout, loaded_weight, *args, **kwargs)
+
+    weight.weight_loader = width_major_weight_loader
+
+
 class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
     # Cached fused-op availability probe result, shared across all layers so the
     # smoke call runs at most once per process.
@@ -302,7 +335,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         a = a[:num_actual_tokens]
 
         # 1. Convolution sequence transformation
-        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2))
+        conv_weights_T = self.conv1d.weight
         if spec_sequence_masks is not None:
             if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
                 mixed_qkv_spec = mixed_qkv
@@ -316,7 +349,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 1.1: Process the multi-query part
         if spec_sequence_masks is not None:
-            conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0
             spec_causal_conv1d_meta = attn_metadata.spec_decode_metadata.spec_causal_conv1d
             spec_query_start_loc_device = spec_causal_conv1d_meta.query_start_loc
@@ -345,12 +377,11 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 cache_indices_opt = non_spec_causal_conv1d_meta.cache_indices
                 initial_state_mode_opt = non_spec_causal_conv1d_meta.initial_state_mode
                 if get_pcp_group().world_size > 1:
-                    conv_weights_T = conv_weights.transpose(0, 1)
                     activation_num = 1 if self.activation else 0
                     non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
                     assert non_spec_query_start_loc is not None
                     non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
-                    width = conv_weights.shape[1]
+                    width = conv_weights_T.shape[0]
                     state_len = width - 1
                     num_seqs = non_spec_query_start_loc.shape[0] - 1
                     prefill_seq_offset = max(0, num_seqs - attn_metadata.num_prefills)
@@ -388,7 +419,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                             -1, ...
                         ].transpose(-1, -2)
                 else:
-                    conv_weights_T = conv_weights.transpose(0, 1)
                     activation_num = 1 if self.activation else 0
                     mixed_qkv_non_spec_output = torch.empty_like(mixed_qkv_non_spec)
                     torch.ops._C_ascend.npu_causal_conv1d_custom(
@@ -407,7 +437,6 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                     )
                     mixed_qkv_non_spec = mixed_qkv_non_spec_output
         elif attn_metadata.num_decodes > 0:
-            conv_weights_T = conv_weights.transpose(0, 1)
             activation_num = 1 if self.activation else 0
             non_spec_causal_conv1d_meta = attn_metadata.non_spec_decode_metadata.causal_conv1d
             non_spec_query_start_loc_device = non_spec_causal_conv1d_meta.query_start_loc

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -46,7 +46,6 @@ def _ascend_gdn_init(self, *args, **kwargs) -> None:
     prepare_causal_conv1d_weight_for_loading(self.conv1d)
 
 
-
 def _uses_multimodal_rope(attention: Qwen3NextAttention) -> bool:
     """Return whether a Qwen3.5 attention layer exposes multimodal RoPE."""
     return "qwen3_5" in attention.config.model_type and hasattr(attention.rotary_emb, "mrope_section")

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -32,9 +32,19 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
-from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+from vllm_ascend.ops.gdn import (
+    AscendGatedDeltaNetAttention,
+    prepare_causal_conv1d_weight_for_loading,
+)
 
 _GDN_PATCH_TARGET = _GDNBaseCls
+_ORIGINAL_GDN_INIT = _GDN_PATCH_TARGET.__init__
+
+
+def _ascend_gdn_init(self, *args, **kwargs) -> None:
+    _ORIGINAL_GDN_INIT(self, *args, **kwargs)
+    prepare_causal_conv1d_weight_for_loading(self.conv1d)
+
 
 
 def _uses_multimodal_rope(attention: Qwen3NextAttention) -> bool:
@@ -210,6 +220,7 @@ if get_current_hardware_profile().supports(HardwareCapability.GDN_COMPATIBILITY)
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core
     _GDN_PATCH_TARGET.get_state_dtype = AscendGatedDeltaNetAttention310.get_state_dtype
 else:
+    _GDN_PATCH_TARGET.__init__ = _ascend_gdn_init
     _GDN_PATCH_TARGET.forward = AscendGatedDeltaNetAttention.forward
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention._forward_core
     _GDN_PATCH_TARGET._warmup_prefill_kernels = AscendGatedDeltaNetAttention._warmup_prefill_kernels


### PR DESCRIPTION
### What this PR does / why we need it?

This PR optimizes the layout of the causal-conv1d weight in GatedDeltaNet (GDN) for NPU execution. Instead of storing the weight in the upstream `[channels, 1, width]` layout and transposing it during every forward pass, we pre-allocate the weight in the NPU-friendly `[width, channels]` layout during initialization.

A custom `width_major_weight_loader` wrapper adapts standard checkpoints by writing through a transposed view, preserving the existing checkpoint format and loader contract. The prepared contiguous weight is then consumed directly by the non-310P CausalConv1d paths, removing the repeated forward-time transpose/copy overhead. The 310P path remains unchanged.

### Does this PR introduce any user-facing change?

No. There is no new CLI option, configuration switch, API, or checkpoint-format change. The optimization is automatic for the existing Qwen3.5 GDN path.

### How was this patch tested?

- Added `tests/ut/ops/test_gdn_weight_loading.py` to verify:
  - `[channels, 1, width]` → `[width, channels]` conversion;
  - compatibility with the existing sharded loader contract;
  - unexpected-shape validation; and
  - missing-loader validation.
- Static validation/reproduction commands:
  - `python -m compileall -q vllm_ascend/ops/gdn.py vllm_ascend/patch/worker/patch_qwen3_5.py`
  - import check for `vllm_ascend.patch.worker.patch_qwen3_5` and the patched GDN initializer.
- RealWorldQA A/B benchmark on Qwen3.5-35B (`realworldqa`, version `e3713f`, `gen`, 765 requests, concurrency 1). Both runs completed 765/765 requests with zero failures.

#### Precision summary

| Metric | Baseline | Conv1d optimized | Delta |
|---|---:|---:|---:|
| RealWorldQA accuracy | 74.25 | **74.38** | **+0.13 percentage points** |
| Success requests | 765/765 | 765/765 | No change |
| Failed requests | 0 | 0 | No change |

#### Performance summary

| Metric | Baseline | Conv1d optimized | Delta |
|---|---:|---:|---:|
| Average E2EL | 2692.2 ms | **2583.9 ms** | **-108.3 ms (-4.02%)** |
| Median E2EL | 2246.6 ms | **2159.8 ms** | **-86.8 ms (-3.86%)** |
| P90 E2EL | 4726.5 ms | **4435.5 ms** | **-290.9 ms (-6.16%)** |
| P99 E2EL | 6846.6 ms | **6532.5 ms** | **-314.1 ms (-4.59%)** |
| Request throughput | 0.3714 req/s | **0.3869 req/s** | **+4.17%** |
| Input token throughput | 537.9056 token/s | **560.4375 token/s** | **+4.19%** |
| Output token throughput | 61.0436 token/s | **63.5759 token/s** | **+4.15%** |
| Total token throughput | 598.9492 token/s | **624.0134 token/s** | **+4.18%** |
| Benchmark duration | 2,059,969.3852 ms | **1,977,149.9401 ms** | **-4.02%** |

The supplied archives have identical total input tokens (1,108,069); total generated tokens differ by 49 (125,748 vs. 125,699). The final `ANSWER` text differs for 100/765 requests, while aggregate accuracy improves by 0.13 percentage points. The archives do not include `kernel_details.csv`, so the end-to-end improvement is not attributed exclusively to the transpose kernel without a same-run operator-level profile.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
