### PR TITLE
[Performance][Attention] Cache sink decode query lengths

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -328,6 +328,7 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.layer_no_quant._v_scale_float = 1.0
         self.mock_vllm_config = MagicMock()
         self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
+        self.mock_vllm_config.scheduler_config.max_num_seqs = 64
         self.config_patcher = patch(
             "vllm_ascend.attention.attention_v1.get_current_vllm_config", return_value=self.mock_vllm_config
         )
@@ -700,7 +701,29 @@ class TestAscendAttentionBackendImpl(TestBase):
         output = self.impl_swa.forward(layer, query, key, value, kv_cache, metadata, output)
         print(output.shape)
         mock_fused_infer_attention_score.assert_called_once()
+        self.assertIs(
+            mock_fused_infer_attention_score.call_args.kwargs["actual_seq_lengths"],
+            metadata.actual_seq_lengths_q,
+        )
         assert output.shape == (10, 8, 64)
+
+    def test_decode_sink_actual_seq_qlen_cache_shape_and_values(self):
+        self.assertIsNone(self.impl_swa._decode_sink_actual_seq_qlen)
+        self.assertEqual(
+            self.impl_swa_sink._decode_sink_actual_seq_qlen.numel(),
+            self.mock_vllm_config.scheduler_config.max_num_seqs + 1,
+        )
+
+        for num_reqs in (1, 2, 63, 64, 65):
+            actual_seq_qlen = self.impl_swa_sink._decode_sink_actual_seq_qlen[:num_reqs]
+
+            self.assertEqual(actual_seq_qlen.dtype, torch.int64)
+            self.assertEqual(actual_seq_qlen.device.type, "cpu")
+            self.assertEqual(actual_seq_qlen.shape, (num_reqs,))
+            self.assertTrue(actual_seq_qlen.is_contiguous())
+            self.assertEqual(actual_seq_qlen.storage_offset(), 0)
+            self.assertEqual(actual_seq_qlen.stride(), (1,))
+            torch.testing.assert_close(actual_seq_qlen, torch.arange(1, num_reqs + 1, dtype=torch.int64))
 
     @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
     @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")
@@ -734,6 +757,92 @@ class TestAscendAttentionBackendImpl(TestBase):
         mock_fused_infer_attention_score_v2.return_value = (torch.ones(10, 8, 64), 1)
         output = self.impl_swa_sink.forward(layer, query, key, value, kv_cache, metadata, output)
         mock_fused_infer_attention_score_v2.assert_called_once()
+        actual_seq_qlen = mock_fused_infer_attention_score_v2.call_args.kwargs["actual_seq_qlen"]
+        self.assertEqual(
+            actual_seq_qlen.untyped_storage().data_ptr(),
+            self.impl_swa_sink._decode_sink_actual_seq_qlen.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(actual_seq_qlen.storage_offset(), 0)
+        torch.testing.assert_close(
+            actual_seq_qlen,
+            torch.arange(1, len(metadata.seq_lens_list) + 1, dtype=torch.int64),
+        )
+        mock_reshape_and_cache.assert_called_once()
+        assert output.shape == (10, 8, 64)
+
+    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
+    @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")
+    @patch("vllm_ascend.attention.attention_v1.torch_npu.npu_fused_infer_attention_score_v2")
+    def test_forward_swa_sink_prefill_uses_metadata_actual_seq_qlen(
+        self, mock_fused_infer_attention_score_v2, mock_reshape_and_cache, mock_extra_ctx
+    ):
+        mock_extra_ctx.capturing = False
+
+        query = torch.randn(10, 8 * 64)
+        key = torch.randn(10, 8 * 64)
+        value = torch.randn(10, 8 * 64)
+        kv_cache = torch.empty(2, 5, 128, 8, 64)
+        output = torch.empty(10, 8, 64)
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.PrefillCacheHit
+        metadata.seq_lens = torch.tensor([10])
+        metadata.seq_lens_list = [10]
+        metadata.actual_seq_lengths_q = [10]
+        metadata.attn_mask = torch.randn(1, 1, 10, 10)
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 10
+        metadata.slot_mapping = torch.zeros(10, dtype=torch.long)
+        metadata.num_decodes = 0
+        metadata.num_prefills = 1
+        metadata.causal = True
+        metadata.model_runner_type = None
+        layer = self.layer_no_quant
+        mock_fused_infer_attention_score_v2.return_value = (torch.ones(10, 8, 64), 1)
+
+        output = self.impl_swa_sink.forward(layer, query, key, value, kv_cache, metadata, output)
+
+        mock_fused_infer_attention_score_v2.assert_called_once()
+        self.assertIs(
+            mock_fused_infer_attention_score_v2.call_args.kwargs["actual_seq_qlen"],
+            metadata.actual_seq_lengths_q,
+        )
+        mock_reshape_and_cache.assert_called_once()
+        assert output.shape == (10, 8, 64)
+
+    @patch("vllm_ascend.attention.attention_v1._EXTRA_CTX")
+    @patch("vllm_ascend.attention.attention_v1.DeviceOperator.reshape_and_cache")
+    @patch("vllm_ascend.attention.attention_v1.torch_npu.npu_fused_infer_attention_score_v2")
+    def test_forward_swa_sink_capture_uses_full_graph_fia_v2(
+        self, mock_fused_infer_attention_score_v2, mock_reshape_and_cache, mock_extra_ctx
+    ):
+        mock_extra_ctx.capturing = True
+
+        query = torch.randn(10, 8 * 64)
+        key = torch.randn(10, 8 * 64)
+        value = torch.randn(10, 8 * 64)
+        kv_cache = torch.empty(2, 5, 128, 8, 64)
+        output = torch.empty(10, 8, 64)
+
+        metadata = self.attn_metadata
+        metadata.attn_state = AscendAttentionState.DecodeOnly
+        metadata.seq_lens = torch.tensor([10] * 10)
+        metadata.seq_lens_list = [10] * 10
+        metadata.actual_seq_lengths_q = [10]
+        metadata.block_tables = torch.zeros(1, 5, dtype=torch.long)
+        metadata.num_actual_tokens = 100
+        metadata.slot_mapping = torch.zeros(10, dtype=torch.long)
+        metadata.num_decodes = 10
+        metadata.num_prefills = 0
+        metadata.causal = True
+        metadata.model_runner_type = None
+        layer = self.layer_no_quant
+        self.impl_swa_sink.full_graph_fia_v2 = MagicMock(return_value=(torch.ones(10, 8, 64), 1))
+
+        output = self.impl_swa_sink.forward(layer, query, key, value, kv_cache, metadata, output)
+
+        self.impl_swa_sink.full_graph_fia_v2.assert_called_once_with(query, key, value, metadata, output)
+        mock_fused_infer_attention_score_v2.assert_not_called()
         mock_reshape_and_cache.assert_called_once()
         assert output.shape == (10, 8, 64)
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -548,6 +548,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self._use_layer_aware_fia_graph_replay = needs_layer_aware_fia_graph_replay()
         self._use_max_workspace_for_fia_graph = self._use_layer_aware_fia_graph_replay
         self.sinks = sinks
+        self._decode_sink_actual_seq_qlen: torch.Tensor | None = None
+        if self.sinks is not None:
+            max_decode_reqs = self.vllm_config.scheduler_config.max_num_seqs + 1
+            self._decode_sink_actual_seq_qlen = torch.arange(1, max_decode_reqs + 1, dtype=torch.int64)
         self.layerIndex = 0
         # Some mixed-attention models cannot rely on the iteration order of
         # attn_metadata during graph replay. Record the captured layer name only
@@ -863,7 +867,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         if self.sinks is not None:
             actual_seq_qlen = attn_metadata.actual_seq_lengths_q
             if attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-                actual_seq_qlen = torch.tensor([1] * len(attn_metadata.seq_lens_list), dtype=torch.int32).cumsum(dim=0)
+                actual_seq_qlen = self._decode_sink_actual_seq_qlen[: len(attn_metadata.seq_lens_list)]
             if self.sliding_window is not None:
                 sparse_mode = 4
             else:

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -551,7 +551,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self._decode_sink_actual_seq_qlen: torch.Tensor | None = None
         if self.sinks is not None:
             max_decode_reqs = self.vllm_config.scheduler_config.max_num_seqs + 1
-            self._decode_sink_actual_seq_qlen = torch.arange(1, max_decode_reqs + 1, dtype=torch.int64)
+            self._decode_sink_actual_seq_qlen = torch.arange(
+                1, max_decode_reqs + 1, dtype=torch.int64, device="cpu"
+            )
         self.layerIndex = 0
         # Some mixed-attention models cannot rely on the iteration order of
         # attn_metadata during graph replay. Record the captured layer name only


### PR DESCRIPTION
### What this PR does / why we need it?

The eager non-capture learnable-sink `DecodeOnly` FIA v2 path currently rebuilds cumulative query lengths on every attention-layer invocation with an `int32` tensor allocation followed by `cumsum`, whose result is `int64`.

This PR keeps that path's semantics but removes the repeated construction:
- prebuild a per-`AscendAttentionBackendImpl` CPU `torch.int64` cardinality cache only when `sinks` is enabled;
- size it to `scheduler_config.max_num_seqs + 1`, covering the existing FIA dummy/padded request row;
- for eager sink `DecodeOnly`, pass only the direct contiguous view `cache[:len(seq_lens_list)]` as `actual_seq_qlen`;
- leave non-sink, non-`DecodeOnly`, capture/graph routing, metadata construction, and FIA kernels unchanged.

### Correctness / validation

Focused regression coverage was added for:
- cardinalities 1, 2, 63, 64, and 65;
- CPU device, `torch.int64`, exact `[1..N]` values, shape, contiguity, storage offset, stride, and storage sharing;
- eager sink `DecodeOnly` passing the real cached view to FIA v2;
- no-sink behavior unchanged;
- sink non-`DecodeOnly` preserving metadata `actual_seq_lengths_q`;
- capture path continuing through `full_graph_fia_v2`.

Local validation completed:
- `python3 -m py_compile` on the changed source and test files: PASS;
- `git diff --check`: PASS;
- source/AST direct-slice checks: PASS;
- standalone tensor semantics for N=1/2/63/64/65: PASS.

The local environment does not provide the exact `vllm`/`torch_npu` runtime required by this checkout, so `tests/ut/attention/test_attention_v1.py` stops during test collection with `ModuleNotFoundError: No module named 'vllm'`. This is intentionally a Draft PR; no local pytest PASS or native FIA/full-model correctness claim is made yet.

### Performance evidence

A source-faithful host microbenchmark at batch 64 used 2000 paired AB/BA observations:
- current construction median: 26.110 us/layer;
- cached direct slice median: 6.680 us/layer;
- paired median removable host-construction budget: 20.2605 us/layer;
- candidate faster in 1999/2000 pairs.

This is component-level host construction evidence only. It is **not** a TPOT, E2E, deployment, or production speedup claim.

Signed-off-by: Ruiqiu Zheng <191817791+Ruiqiu-Zheng@users.noreply.github.com>

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
