### PR TITLE
[Test][Model] Cover Kimi K3 dense MLP sequence parallelism on v0.26

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -13,6 +13,10 @@ from vllm_ascend.ops.linear import (
     AscendRowParallelLinear,
     AscendUnquantizedLinearMethod,
 )
+from vllm_ascend.ops.linear_op import (
+    SequenceColumnParallelOp,
+    SequenceRowParallelOp,
+)
 
 
 class BaseLinearTest(unittest.TestCase):
@@ -255,6 +259,14 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
         self.assertIsNone(self._get_column_op("model.vision_model_proj.indexer_proj"))
         self.assertIsNone(self._get_column_op("model.vision_tower_encoder.qkv_proj"))
 
+    def test_kimi_k3_dense_mlp_uses_sequence_column_parallelism(self):
+        self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
+        self._patches[-1].start()
+
+        op = self._get_column_op("model.layers.0.mlp.gate_up_proj")
+
+        self.assertIsInstance(op, SequenceColumnParallelOp)
+
 
 class TestRowParallelOpDispatch(unittest.TestCase):
     """Tests for _get_row_parallel_op — mtp_block, share_expert."""
@@ -293,6 +305,14 @@ class TestRowParallelOpDispatch(unittest.TestCase):
         self._patches[-1].start()
         self.assertIsNone(self._op("model.multi_modal_projector.down_proj"))
         self.assertIsNone(self._op("model.patch_merge_mlp.out_proj"))
+
+    def test_kimi_k3_dense_mlp_uses_sequence_row_parallelism(self):
+        self._patches.append(patch("vllm_ascend.ops.linear_op.enable_sp", return_value=True))
+        self._patches[-1].start()
+
+        op = self._op("model.layers.0.mlp.down_proj")
+
+        self.assertIsInstance(op, SequenceRowParallelOp)
 
 
 class TestGetParallelOpShareExpert(unittest.TestCase):


### PR DESCRIPTION
### What this PR does / why we need it?

Adds v0.26 regression coverage for the Kimi K3 dense MLP sequence-parallel communication path.

The v0.27 fix in #16354 introduces a model-level wrapper because that branch uses the upstream `KimiMLP` implementation. v0.26 uses the native `KimiK3MLP` together with the plugin's generic linear dispatch instead: when FlashComm1 sequence parallelism is enabled, `gate_up_proj` selects `SequenceColumnParallelOp` (all-gather) and `down_proj` selects `SequenceRowParallelOp` (reduce-scatter). Applying the v0.27 wrapper verbatim here would duplicate the collectives.

This test locks that v0.26 dispatch contract in place so dense MLP weights continue to receive the gathered token rows and return sequence-sharded output.

### Does this PR introduce _any_ user-facing change?

No. It adds regression coverage for an existing communication path.

### How was this patch tested?

- Added checks for Kimi K3 `gate_up_proj` and `down_proj` dispatch under sequence parallelism in `tests/ut/ops/test_linear.py`.
- Ran Python syntax compilation for the changed test file.
- Ran `git diff --check` and `git show --check`.
- The local machine does not have the v0.26 vLLM-Ascend test runtime or Ascend NPU hardware, so the targeted pytest and NPU validation are left for repository CI.
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
