### PR TITLE
[BugFix][Attention] Restore device-local DSA-CP QLI max length

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -744,7 +744,7 @@ def test_dsa_cp_defers_device_metadata(
     builder._build_sas_metadata.assert_called_once()
     if compressor_ratio == 4:
         builder._build_qli_metadata.assert_called_once()
-        assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_q"] == 2
+        assert "max_seqlen_q" not in builder._build_qli_metadata.call_args.kwargs
         assert builder._build_qli_metadata.call_args.kwargs["max_seqlen_k"] == 8
     else:
         builder._build_qli_metadata.assert_not_called()
@@ -863,7 +863,7 @@ def test_dsa_cp_device_local_metadata_is_deferred_and_reused():
     )
 
 
-def test_dsa_cp_qli_metadata_uses_host_maxima():
+def test_dsa_cp_qli_metadata_uses_device_query_lengths():
     builder = AscendDSACPMetadataBuilder.__new__(AscendDSACPMetadataBuilder)
     builder.compressor_ratio = 4
     builder.common_ratio_to_sas_metadata = {}
@@ -891,7 +891,6 @@ def test_dsa_cp_qli_metadata_uses_host_maxima():
             query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
             seq_lens=seq_lens,
             num_reqs=2,
-            max_seqlen_q=2,
             max_seqlen_k=8,
         )
 

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -832,7 +832,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 query_start_loc=local_query_start_loc,
                 seq_lens=local_seq_lens,
                 num_reqs=num_reqs,
-                max_seqlen_q=max_local_query_len,
                 max_seqlen_k=max_local_seq_lens,
             )
 
@@ -1139,7 +1138,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         query_start_loc,
         seq_lens,
         num_reqs,
-        max_seqlen_q,
         max_seqlen_k,
     ):
         if self.compressor_ratio != 4:
@@ -1162,6 +1160,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
+            # The cached CPU metadata can diverge from the device-local view
+            # under async scheduling, so derive this limit from the consumer.
+            seq_lens_q = query_start_loc[1 : num_reqs + 1] - query_start_loc[:num_reqs]
+            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
             metadata = torch.ops._C_ascend.npu_quant_lightning_indexer_v2_metadata(
                 num_heads_q=self.model_config.hf_config.index_n_heads,
                 num_heads_k=1,


### PR DESCRIPTION
### What this PR does / why we need it?

Field bisection isolated a high-concurrency DSA-CP hang to `64b30301c85d9600516a678594329403e506017e`, which replaced the QLI metadata builder's device-derived query-length maximum with a host-side value.

Fixes #16416.

Under asynchronous metadata scheduling, the cached host metadata can diverge from the worker's device-local `query_start_loc`. Passing that host maximum to the QLI metadata operator can therefore build metadata with an invalid query-length bound.

This patch restores the previous device-local calculation at the QLI metadata consumer and adds a focused regression assertion. The device synchronization happens only on a QLI metadata cache miss. The rest of the asynchronous metadata construction remains unchanged.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. This fixes a DSA-CP hang under concurrent inference workloads.

### How was this patch tested?

- `bash format.sh ci` passed all hooks.
- Python syntax compilation passed for the changed source and test files.
- Focused unit tests in a real Ascend NPU environment: `5 passed`.
- Real Ascend NPU high-concurrency validation of this fix is pending.
