### PR TITLE
[Performance][Kimi K3] Fuse BF16 O projection and TP ReduceScatter

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -338,6 +338,24 @@ unquantized BF16, even when the other model weights use MXFP quantization.
 Fine-grained O-projection TP, BF16 NZ weights (`weight_nz_mode=2`), and LoRA
 are not supported by this path.
 
+Enabling the option selects fusion only for supported layers. Unsupported
+configurations, including pipeline parallelism (`PP > 1`), retain the original
+O projection and communication path instead of failing model initialization.
+Sequence-parallel layers keep their separate ReduceScatter; layers without
+sequence parallelism retain their original full-token output layout. Existing
+  custom projection operators, quantized or non-BF16 O weights, and projections
+with bias also keep their original implementation.
+
+Selection also requires the V2 Python interface, a TP size in
+`{2, 4, 8, 16, 32, 64}`, and nonempty 2D weights with local `K` in
+`[256, 65535)`. At execution, unsupported activation dtype/shape, weight
+strides, empty batches, or padded communication payloads at or above 4 GiB
+use the original GEMM followed by `sp_reduce_scatter`. This fallback still
+returns the token shard expected by the MLA buffer and decoder. Branches
+depend on tensor metadata shared by the TP ranks, not tensor values or
+rank-local resource availability. The payload ceiling is an upper bound;
+kernel support below it still depends on the installed CANN version and shape.
+
 Each rank keeps its existing TP weight shard. Token padding moves before the
 fused GEMM, the MLA output buffer holds `ceil(num_tokens / TP)` rows, and the
 decoder skips its separate ReduceScatter. Output gates, KDA normalization,

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -66,6 +66,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `mc2_comm_alg`                      | str  | `""`    | set dispatch/combine op's `comm_alg` param, only supports `""/"fullmesh"/"hierarchy"/"fullmesh_v2"`. `"hierarchy"` is only supported by A2/A3, and `"fullmesh_v2"` is only supported by A3 now. |
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. This param will be deprecated and be replaced by mc2_comm_alg = "hierarchy" |
 | `enable_prefill_mc2`                | bool | `False` | Whether to reserve mc2_token_capacity for prefill batches. When enabled, `max_num_batched_tokens` is used to calculate the mc2_token_capacity instead of the decode-only capacity. In this scenario, the recommended maximum value of `max_num_batched_tokens` is `tp_size * 512`. This is a temporary switch; once MC2 operators are complete for all scenarios, this switch will be removed and MC2 will be enabled by default. |
+| `enable_kimi_o_proj_mm_reduce_scatter` | bool | `False` | Fuse Kimi K3 BF16 O-projection GEMM and TP ReduceScatter on A5. Requires sequence parallel attention residuals, the original TP group, ND O weights (`weight_nz_mode` 0 or 1), and no LoRA. Uses `npu_quant_mm_reduce_scatter` without quantization scales and with `comm_mode="ai_cpu"`. See [Kimi O-projection fusion](#kimi-o-projection-fusion). |
 | `mega_moe_max_tokens`               | int  | `65536` | Reference per-rank token capacity after dispatch in the fused MC2/MegaMoe path. It is passed as `dispatch_ffn_combine`'s `max_output_size` and CANN MegaMoe buffer's `max_recv_token_num`. If a rank's actual MoE load exceeds this value, precision degradation may occur. The absolute safe upper bound is `num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank)`, but using it directly can consume very large device memory. Tune this value based on actual expert load distribution. |
 | `msmonitor_use_daemon`              | bool | `False` | Whether to use daemon mode for msmonitor. The legacy `MSMONITOR_USE_DAEMON` environment variable is no longer supported. |
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). The legacy `VLLM_ASCEND_ENABLE_MLAPO` environment variable is no longer supported. |
@@ -322,4 +323,37 @@ An example of additional configuration is as follows:
     },
     "refresh": False
 }
+```
+
+## Kimi O-projection fusion
+
+Add `"enable_kimi_o_proj_mm_reduce_scatter": true` to the existing
+`--additional-config` JSON to enable the fused path. The default is `false`.
+The option applies to the main Kimi K3 model's KDA and MLA O projections;
+DSpark draft projections retain their existing communication.
+
+The supported Kimi path uses attention residuals and sequence parallelism
+(`TP > 1`, `PP = 1`, and expert parallelism enabled). O weights must be
+unquantized BF16, even when the other model weights use MXFP quantization.
+Fine-grained O-projection TP, BF16 NZ weights (`weight_nz_mode=2`), and LoRA
+are not supported by this path.
+
+Each rank keeps its existing TP weight shard. Token padding moves before the
+fused GEMM, the MLA output buffer holds `ceil(num_tokens / TP)` rows, and the
+decoder skips its separate ReduceScatter. Output gates, KDA normalization,
+and residual additions retain their existing order. TP communication uses
+AI CPU; this option does not select the MoE EP communication engine.
+
+The installed `torch_npu.npu_quant_mm_reduce_scatter` must support BF16 inputs
+and the `comm_mode` argument. Kernel errors are propagated. Compare accuracy,
+prefill latency, and decode latency against the default path before enabling
+it for a deployment.
+
+The following test checks rank-distinct BF16 results for padded and unpadded
+batches in eager mode and NPU graph replay, then prints baseline/fused latency
+for each shape. Run it on reserved A5 devices before model-level validation:
+
+```bash
+torchrun --standalone --nproc-per-node=8 -m pytest --noconftest -s \
+  tests/e2e/nightly/single_node/ops/multicard_ops_a5/test_kimi_o_proj_mm_reduce_scatter.py
 ```

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a5/__init__.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a5/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/e2e/nightly/single_node/ops/multicard_ops_a5/test_kimi_o_proj_mm_reduce_scatter.py
+++ b/tests/e2e/nightly/single_node/ops/multicard_ops_a5/test_kimi_o_proj_mm_reduce_scatter.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare the fused Kimi O projection with GEMM + ReduceScatter on A5.
+
+Run on reserved devices with the same CANN environment as inference:
+torchrun --standalone --nproc-per-node=8 -m pytest --noconftest -s <this_file>
+"""
+
+import os
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch_npu  # noqa: F401
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.ops import linear_op
+
+
+@pytest.fixture(scope="module")
+def tp_group():
+    if "RANK" not in os.environ:
+        pytest.skip("Launch with torchrun --nproc-per-node=8 to test TP communication.")
+    if not get_current_hardware_profile().supports(HardwareCapability.MM_REDUCE_SCATTER_AI_CPU_INFERENCE):
+        pytest.skip("This test requires Ascend A5.")
+    torch.npu.set_device(int(os.environ["LOCAL_RANK"]))
+    dist.init_process_group("hccl", timeout=timedelta(seconds=180))
+    yield SimpleNamespace(
+        device_group=dist.group.WORLD,
+        rank_in_group=dist.get_rank(),
+        world_size=dist.get_world_size(),
+    )
+    dist.destroy_process_group()
+
+
+def _latency_ms(fn, iterations=20):
+    for _ in range(5):
+        fn()
+    torch.npu.synchronize()
+    start = torch.npu.Event(enable_timing=True)
+    end = torch.npu.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 8, 17, 128, 8192])
+@pytest.mark.parametrize("use_graph", [False, True])
+@torch.inference_mode()
+def test_kimi_o_proj_mm_reduce_scatter(tp_group, monkeypatch, num_tokens, use_graph):
+    rank = tp_group.rank_in_group
+    world_size = tp_group.world_size
+    # Rank-distinct operands catch missing reductions and incorrect TP groups.
+    torch.manual_seed(2026 + rank)
+    local_k = 12288 // world_size
+    x = torch.randn(num_tokens, local_k, dtype=torch.bfloat16, device="npu") * 0.1
+    weight = torch.randn(7168, local_k, dtype=torch.bfloat16, device="npu") * 0.1
+    layer = SimpleNamespace(
+        weight=weight,
+        bias=None,
+        custom_op=None,
+        quant_method=UnquantizedLinearMethod(),
+        input_is_parallel=True,
+        input_size_per_partition=local_k,
+        reduce_results=False,
+        return_bias=True,
+        skip_bias_add=False,
+        prefix="model.layers.0.self_attn.o_proj",
+    )
+    # Use the real HCCL process group without loading a model or KV caches.
+    monkeypatch.setattr(linear_op, "get_tp_group", lambda: tp_group)
+    fused_op = linear_op.KimiOProjMMReduceScatterOp(layer)
+
+    def baseline():
+        partial = torch.nn.functional.linear(x, weight)
+        padding = (-num_tokens) % world_size
+        if padding:
+            partial = torch.nn.functional.pad(partial, (0, 0, 0, padding))
+        output = torch.empty((partial.shape[0] // world_size, 7168), dtype=x.dtype, device=x.device)
+        dist.reduce_scatter_tensor(output, partial, group=tp_group.device_group)
+        return output
+
+    def fused():
+        return fused_op.apply(x)[0]
+
+    expected = baseline()
+    actual = fused()
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+    if use_graph:
+        baseline_graph, fused_graph = torch.npu.NPUGraph(), torch.npu.NPUGraph()
+        torch.npu.synchronize()
+        with torch.npu.graph(baseline_graph, capture_error_mode="thread_local", auto_dispatch_capture=True):
+            expected = baseline()
+        with torch.npu.graph(fused_graph, capture_error_mode="thread_local", auto_dispatch_capture=True):
+            actual = fused()
+        baseline_graph.replay()
+        fused_graph.replay()
+        torch.npu.synchronize()
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        baseline_fn, fused_fn = baseline_graph.replay, fused_graph.replay
+    else:
+        baseline_fn, fused_fn = baseline, fused
+
+    baseline_ms = _latency_ms(baseline_fn)
+    fused_ms = _latency_ms(fused_fn)
+    if rank == 0:
+        print(
+            f"TP={world_size} M={num_tokens} graph={use_graph} rank=0 "
+            f"baseline_ms={baseline_ms:.4f} fused_ms={fused_ms:.4f}"
+        )

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -69,6 +69,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.LORA_CUSTOM_OPS,
             HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
             HardwareCapability.MLAPO_NATIVE_WEIGHTS,
+            HardwareCapability.MM_REDUCE_SCATTER_AI_CPU_INFERENCE,
             HardwareCapability.NPUGRAPH_EX,
             HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
             HardwareCapability.STANDARD_MAMBA_PATCH,

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -174,20 +174,25 @@ def test_kimi_dense_mlp_gathers_and_scatters_sequence_shards(monkeypatch):
     torch.testing.assert_close(output, torch.tensor([[2.0], [3.0]]))
 
 
-@pytest.mark.parametrize("fuse_o_proj", [False, True])
-def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch, fuse_o_proj):
+@pytest.mark.parametrize(
+    "sequence_parallel,request_fusion,hardware_supported",
+    [(True, False, True), (True, True, True), (True, True, False), (False, True, True)],
+)
+def test_kimi_attention_residual_preserves_layout_and_one_reduction(
+    monkeypatch, sequence_parallel, request_fusion, hardware_supported
+):
     class IdentityAttention(nn.Module):
         def forward(self, *, hidden_states, positions):
             del positions
-            if fuse_o_proj:
+            if layer.fuse_o_proj_mm_reduce_scatter:
                 collective_shapes.append(("mm_reduce_scatter", hidden_states.shape))
                 return hidden_states.chunk(2, dim=0)[0]
             return hidden_states
 
     layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
     nn.Module.__init__(layer)
-    layer.use_sequence_parallel = True
-    layer.fuse_o_proj_mm_reduce_scatter = fuse_o_proj
+    layer.use_sequence_parallel = sequence_parallel
+    layer.use_attn_residuals = True
     layer.prev_valid_blocks = 0
     layer.is_block_write_layer = False
     layer.input_layernorm = nn.Identity()
@@ -198,6 +203,17 @@ def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch, fuse_o_proj
     layer.mlp_res_proj = object()
     layer.mlp_res_norm = object()
     layer.self_attn = IdentityAttention()
+    layer.self_attn.o_proj = nn.Linear(2, 2, bias=False)
+    fused_factory = MagicMock(return_value=object())
+    fused_factory.unsupported_reason.return_value = None
+    monkeypatch.setattr(kimi_k3, "KimiOProjMMReduceScatterOp", fused_factory)
+    monkeypatch.setattr(
+        kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: hardware_supported)
+    )
+    monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=1))
+    layer.fuse_o_proj_mm_reduce_scatter = request_fusion and layer._enable_o_proj_mm_reduce_scatter(
+        SimpleNamespace(lora_config=None)
+    )
 
     collective_shapes = []
 
@@ -217,21 +233,28 @@ def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch, fuse_o_proj
         lambda prefix_sum, *_args, **_kwargs: prefix_sum,
     )
 
-    hidden_states = torch.arange(4, dtype=torch.float32).view(2, 2)
-    block_residual = torch.zeros(2, 1, 2)
+    num_rows = 2 if sequence_parallel else 3
+    hidden_states = torch.arange(num_rows * 2, dtype=torch.float32).view(num_rows, 2)
+    block_residual = torch.zeros(num_rows, 1, 2)
     output, returned_residual = layer.forward_attn_residual(
         positions=torch.arange(3),
         hidden_states=hidden_states,
         block_residual=block_residual,
     )
 
-    assert collective_shapes == [
-        ("gather", torch.Size([2, 2])),
-        ("mm_reduce_scatter" if fuse_o_proj else "reduce_scatter", torch.Size([3, 2])),
-    ]
-    assert output.shape == torch.Size([2, 2])
+    expected_collectives = (
+        [
+            ("gather", torch.Size([2, 2])),
+            ("mm_reduce_scatter" if layer.fuse_o_proj_mm_reduce_scatter else "reduce_scatter", torch.Size([3, 2])),
+        ]
+        if sequence_parallel
+        else []
+    )
+    assert collective_shapes == expected_collectives
+    assert fused_factory.call_count == int(request_fusion and hardware_supported and sequence_parallel)
+    assert output.shape == hidden_states.shape
     torch.testing.assert_close(output, hidden_states * 4)
-    assert returned_residual.shape == torch.Size([2, 1, 2])
+    assert returned_residual.shape == block_residual.shape
 
 
 @pytest.mark.parametrize("is_mla", [False, True])
@@ -253,11 +276,13 @@ def test_kimi_fused_o_proj_preserves_projection_and_sets_mla_output_shard(monkey
     original_weight = attention.o_proj.weight
     original_keys = list(layer.state_dict())
     fused_op = object()
-    monkeypatch.setattr(kimi_k3, "KimiOProjMMReduceScatterOp", lambda _layer: fused_op)
+    fused_factory = MagicMock(return_value=fused_op)
+    fused_factory.unsupported_reason.return_value = None
+    monkeypatch.setattr(kimi_k3, "KimiOProjMMReduceScatterOp", fused_factory)
     monkeypatch.setattr(kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: True))
     monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=1))
 
-    layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=None))
+    assert layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=None)) is True
 
     assert attention.o_proj.custom_op is fused_op
     assert attention.o_proj.weight is original_weight
@@ -267,29 +292,88 @@ def test_kimi_fused_o_proj_preserves_projection_and_sets_mla_output_shard(monkey
 
 
 @pytest.mark.parametrize(
-    "sequence_parallel,attn_residuals,hardware_supported,nz_mode,lora_config,error",
+    "sequence_parallel,attn_residuals,hardware_supported,nz_mode,lora_config",
     [
-        (False, True, True, 1, None, "sequence parallel"),
-        (True, False, True, 1, None, "attention residuals"),
-        (True, True, False, 1, None, "Ascend A5"),
-        (True, True, True, 2, None, "ND weights"),
-        (True, True, True, 1, object(), "LoRA"),
+        (False, True, True, 1, None),
+        (True, False, True, 1, None),
+        (True, True, False, 1, None),
+        (True, True, True, 2, None),
+        (True, True, True, 1, object()),
     ],
 )
-def test_kimi_fused_o_proj_rejects_unsupported_configuration(
-    monkeypatch, sequence_parallel, attn_residuals, hardware_supported, nz_mode, lora_config, error
+def test_kimi_fused_o_proj_keeps_original_operator_for_unsupported_configuration(
+    monkeypatch, sequence_parallel, attn_residuals, hardware_supported, nz_mode, lora_config
 ):
     layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
     nn.Module.__init__(layer)
     layer.use_sequence_parallel = sequence_parallel
     layer.use_attn_residuals = attn_residuals
+    attention = kimi_k3.AscendKimiMLAAttention.__new__(kimi_k3.AscendKimiMLAAttention)
+    nn.Module.__init__(attention)
+    attention.o_proj = nn.Linear(2, 2, bias=False)
+    original_op = object()
+    attention.o_proj.custom_op = original_op
+    attention.o_proj.reduce_results = not sequence_parallel
+    attention.mla_attn = SimpleNamespace(output_token_shard_size=1)
+    layer.self_attn = attention
+    original_keys = list(layer.state_dict())
+    fused_factory = MagicMock(side_effect=AssertionError("unsupported configuration must not initialize fusion"))
+    monkeypatch.setattr(kimi_k3, "KimiOProjMMReduceScatterOp", fused_factory)
     monkeypatch.setattr(
         kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: hardware_supported)
     )
     monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=nz_mode))
 
-    with pytest.raises(ValueError, match=error):
-        layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=lora_config))
+    assert layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=lora_config)) is False
+    fused_factory.assert_not_called()
+    assert attention.o_proj.custom_op is original_op
+    assert attention.o_proj.reduce_results is (not sequence_parallel)
+    assert attention.mla_attn.output_token_shard_size == 1
+    assert list(layer.state_dict()) == original_keys
+
+
+@pytest.mark.parametrize("incompatible", ["fp16", "fp32", "quantized", "custom_op", "bias", "api", "tp", "local_k"])
+def test_kimi_fused_o_proj_keeps_incompatible_projection(monkeypatch, incompatible):
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_ascend.ops import linear_op
+
+    layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = True
+    layer.use_attn_residuals = True
+    attention = kimi_k3.AscendKimiMLAAttention.__new__(kimi_k3.AscendKimiMLAAttention)
+    nn.Module.__init__(attention)
+    dtype = {"fp16": torch.float16, "fp32": torch.float32}.get(incompatible, torch.bfloat16)
+    attention.o_proj = nn.Linear(
+        255 if incompatible == "local_k" else 256, 32, bias=incompatible == "bias", dtype=dtype
+    )
+    attention.o_proj.custom_op = object() if incompatible == "custom_op" else None
+    attention.o_proj.quant_method = object() if incompatible == "quantized" else UnquantizedLinearMethod()
+    attention.o_proj.reduce_results = False
+    attention.mla_attn = SimpleNamespace(output_token_shard_size=1)
+    layer.self_attn = attention
+    original_op = attention.o_proj.custom_op
+    original_weight = attention.o_proj.weight
+    monkeypatch.setattr(kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: True))
+    monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=1))
+    monkeypatch.setattr(linear_op, "get_tp_group", lambda: SimpleNamespace(world_size=3 if incompatible == "tp" else 8))
+    monkeypatch.setattr(
+        linear_op.torch_npu,
+        "npu_quant_mm_reduce_scatter",
+        None if incompatible == "api" else MagicMock(),
+        raising=False,
+    )
+    fused_init = MagicMock(side_effect=AssertionError("unsupported projection must not initialize fusion"))
+    monkeypatch.setattr(kimi_k3.KimiOProjMMReduceScatterOp, "__init__", fused_init)
+
+    assert layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=None)) is False
+
+    fused_init.assert_not_called()
+    assert attention.o_proj.custom_op is original_op
+    assert attention.o_proj.weight is original_weight
+    assert attention.o_proj.reduce_results is False
+    assert attention.mla_attn.output_token_shard_size == 1
 
 
 def test_kimi_model_allocates_attention_residual_after_sp_shard(monkeypatch):

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -4,6 +4,7 @@
 from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
@@ -173,15 +174,20 @@ def test_kimi_dense_mlp_gathers_and_scatters_sequence_shards(monkeypatch):
     torch.testing.assert_close(output, torch.tensor([[2.0], [3.0]]))
 
 
-def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):
+@pytest.mark.parametrize("fuse_o_proj", [False, True])
+def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch, fuse_o_proj):
     class IdentityAttention(nn.Module):
         def forward(self, *, hidden_states, positions):
             del positions
+            if fuse_o_proj:
+                collective_shapes.append(("mm_reduce_scatter", hidden_states.shape))
+                return hidden_states.chunk(2, dim=0)[0]
             return hidden_states
 
     layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
     nn.Module.__init__(layer)
     layer.use_sequence_parallel = True
+    layer.fuse_o_proj_mm_reduce_scatter = fuse_o_proj
     layer.prev_valid_blocks = 0
     layer.is_block_write_layer = False
     layer.input_layernorm = nn.Identity()
@@ -221,10 +227,69 @@ def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):
 
     assert collective_shapes == [
         ("gather", torch.Size([2, 2])),
-        ("reduce_scatter", torch.Size([3, 2])),
+        ("mm_reduce_scatter" if fuse_o_proj else "reduce_scatter", torch.Size([3, 2])),
     ]
     assert output.shape == torch.Size([2, 2])
+    torch.testing.assert_close(output, hidden_states * 4)
     assert returned_residual.shape == torch.Size([2, 1, 2])
+
+
+@pytest.mark.parametrize("is_mla", [False, True])
+def test_kimi_fused_o_proj_preserves_projection_and_sets_mla_output_shard(monkeypatch, is_mla):
+    layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = True
+    layer.use_attn_residuals = True
+    if is_mla:
+        attention = kimi_k3.AscendKimiMLAAttention.__new__(kimi_k3.AscendKimiMLAAttention)
+        nn.Module.__init__(attention)
+        attention.mla_attn = nn.Module()
+        attention.mla_attn.output_token_shard_size = 1
+    else:
+        attention = nn.Module()
+    attention.o_proj = nn.Linear(256, 8, bias=False, dtype=torch.bfloat16)
+    attention.o_proj.tp_size = 8
+    layer.self_attn = attention
+    original_weight = attention.o_proj.weight
+    original_keys = list(layer.state_dict())
+    fused_op = object()
+    monkeypatch.setattr(kimi_k3, "KimiOProjMMReduceScatterOp", lambda _layer: fused_op)
+    monkeypatch.setattr(kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: True))
+    monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=1))
+
+    layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=None))
+
+    assert attention.o_proj.custom_op is fused_op
+    assert attention.o_proj.weight is original_weight
+    assert list(layer.state_dict()) == original_keys
+    if is_mla:
+        assert attention.mla_attn.output_token_shard_size == 8
+
+
+@pytest.mark.parametrize(
+    "sequence_parallel,attn_residuals,hardware_supported,nz_mode,lora_config,error",
+    [
+        (False, True, True, 1, None, "sequence parallel"),
+        (True, False, True, 1, None, "attention residuals"),
+        (True, True, False, 1, None, "Ascend A5"),
+        (True, True, True, 2, None, "ND weights"),
+        (True, True, True, 1, object(), "LoRA"),
+    ],
+)
+def test_kimi_fused_o_proj_rejects_unsupported_configuration(
+    monkeypatch, sequence_parallel, attn_residuals, hardware_supported, nz_mode, lora_config, error
+):
+    layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = sequence_parallel
+    layer.use_attn_residuals = attn_residuals
+    monkeypatch.setattr(
+        kimi_k3, "get_current_hardware_profile", lambda: SimpleNamespace(supports=lambda _: hardware_supported)
+    )
+    monkeypatch.setattr(kimi_k3, "get_ascend_config", lambda: SimpleNamespace(weight_nz_mode=nz_mode))
+
+    with pytest.raises(ValueError, match=error):
+        layer._enable_o_proj_mm_reduce_scatter(SimpleNamespace(lora_config=lora_config))
 
 
 def test_kimi_model_allocates_attention_residual_after_sp_shard(monkeypatch):

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -215,7 +215,8 @@ def test_fused_bfg_projection_preserves_staged_outputs():
     torch.testing.assert_close(output_gate, fused_output[:, 8:].reshape(4, 2, 3))
 
 
-def test_mixed_forward_marks_auxiliary_beta_as_preprocessed():
+@pytest.mark.parametrize("output_tokens", [2, 4])
+def test_mixed_forward_marks_auxiliary_beta_as_preprocessed(output_tokens):
     attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
     nn.Module.__init__(attention)
     attention.uses_mixed_projection = True
@@ -227,7 +228,7 @@ def test_mixed_forward_marks_auxiliary_beta_as_preprocessed():
     beta = torch.rand(1, 4, 2, dtype=torch.float32)
     raw_gate = torch.randn(1, 4, 2, 3)
     output_gate = torch.randn(4, 2, 3)
-    projected = torch.randn(4, 6)
+    projected = torch.randn(output_tokens, 6)
     attention._run_overlapped_qkv_bfg = MagicMock(return_value=(mixed_qkv, beta, raw_gate, output_gate))
     attention._forward = MagicMock()
     attention.o_proj = _RecordingLinear(projected)
@@ -237,6 +238,26 @@ def test_mixed_forward_marks_auxiliary_beta_as_preprocessed():
     assert actual is projected
     assert attention._forward.call_args.kwargs["beta"] is beta
     assert attention._forward.call_args.kwargs["beta_is_preprocessed"] is True
+
+
+def test_unquantized_kda_forward_accepts_fused_o_proj_token_shard():
+    attention = AscendKimiK3DeltaAttention.__new__(AscendKimiK3DeltaAttention)
+    nn.Module.__init__(attention)
+    attention.uses_mixed_projection = False
+    attention.local_num_heads = 2
+    attention.head_dim = 3
+    attention.local_projection_size = 6
+    attention.in_proj_padding = 0
+    attention.in_proj_qkvgfab = _RecordingLinear(torch.randn(4, 29))
+    attention.f_b_proj = _RecordingLinear(torch.randn(4, 6))
+    attention._forward = MagicMock()
+    projected = torch.randn(2, 6)
+    attention.o_proj = _RecordingLinear(projected)
+
+    actual = attention.forward(torch.randn(4, 6), torch.arange(4))
+
+    assert actual is projected
+    assert attention._forward.call_args.kwargs["core_attn_out"].shape == (1, 4, 2, 3)
 
 
 def test_overlapped_qkv_bfg_keeps_two_stage_vector_cube_overlap():

--- a/tests/ut/ops/test_kimi_o_proj_mm_reduce_scatter.py
+++ b/tests/ut/ops/test_kimi_o_proj_mm_reduce_scatter.py
@@ -12,6 +12,17 @@ from vllm_ascend.ops import linear_op
 from vllm_ascend.ops.linear import AscendRowParallelLinear
 
 
+@pytest.fixture(autouse=True)
+def available_fused_api(monkeypatch):
+    # CPU UT stubs do not expose this optional NPU interface by default.
+    monkeypatch.setattr(
+        linear_op.torch_npu,
+        "npu_quant_mm_reduce_scatter",
+        MagicMock(side_effect=AssertionError("test must provide its fused implementation")),
+        raising=False,
+    )
+
+
 def _make_layer(weight):
     return SimpleNamespace(
         weight=weight,
@@ -65,12 +76,20 @@ def test_fused_o_proj_matches_padded_partial_sum(monkeypatch, world_size, num_to
         return torch.stack(contributions).sum(0).chunk(size, dim=0)[rank], torch.empty(0)
 
     monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", fused_mm, raising=False)
+    fallback_rs = MagicMock(return_value=expected)
+    monkeypatch.setattr(linear_op, "sp_reduce_scatter", fallback_rs)
 
     output, bias = op.apply(inputs[rank])
 
     torch.testing.assert_close(output, expected)
     assert bias is None
-    assert calls == [("kimi_tp", world_size, {"reduce_op": "sum", "comm_mode": "ai_cpu"})]
+    if num_tokens:
+        assert calls == [("kimi_tp", world_size, {"reduce_op": "sum", "comm_mode": "ai_cpu"})]
+        fallback_rs.assert_not_called()
+    else:
+        assert calls == []
+        fallback_rs.assert_called_once()
+        torch.testing.assert_close(fallback_rs.call_args.args[0], partials[rank])
     backend.get_hccl_comm_name.assert_called_once_with(rank)
 
 
@@ -117,3 +136,90 @@ def test_row_parallel_linear_dispatches_fused_projection(monkeypatch):
     assert bias is None
     fused.assert_called_once()
     assert fused.call_args.args[0].shape == (4, 256)
+
+
+def test_fused_o_proj_propagates_operator_failure(monkeypatch):
+    device_group = MagicMock()
+    device_group._get_backend.return_value.get_hccl_comm_name.return_value = "kimi_tp"
+    monkeypatch.setattr(
+        linear_op, "get_tp_group", lambda: SimpleNamespace(device_group=device_group, rank_in_group=0, world_size=2)
+    )
+    op = linear_op.KimiOProjMMReduceScatterOp(_make_layer(torch.zeros(32, 256, dtype=torch.bfloat16)))
+    fused = MagicMock(side_effect=RuntimeError("collective failed"))
+    monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", fused, raising=False)
+
+    with pytest.raises(RuntimeError, match="collective failed"):
+        op.apply(torch.ones(3, 256, dtype=torch.bfloat16))
+
+    fused.assert_called_once()
+
+
+@pytest.mark.parametrize("world_size", [1, 3, 128])
+def test_fused_o_proj_rejects_unsupported_tp_before_hccl(monkeypatch, world_size):
+    device_group = MagicMock()
+    monkeypatch.setattr(
+        linear_op, "get_tp_group", lambda: SimpleNamespace(device_group=device_group, world_size=world_size)
+    )
+    layer = _make_layer(torch.zeros(32, 256, dtype=torch.bfloat16))
+    assert "TP size" in linear_op.KimiOProjMMReduceScatterOp.unsupported_reason(layer)
+    device_group._get_backend.assert_not_called()
+
+
+def test_fused_o_proj_rejects_missing_api_before_hccl(monkeypatch):
+    monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", None, raising=False)
+    group = MagicMock()
+    monkeypatch.setattr(linear_op, "get_tp_group", group)
+    layer = _make_layer(torch.zeros(32, 256, dtype=torch.bfloat16))
+    assert "V2 interface" in linear_op.KimiOProjMMReduceScatterOp.unsupported_reason(layer)
+    group.assert_not_called()
+
+
+@pytest.mark.parametrize("shape", [(32, 0), (32, 255), (32, 65535), (0, 256), (2, 32, 256)])
+def test_fused_o_proj_rejects_unsupported_weight_shape(monkeypatch, shape):
+    monkeypatch.setattr(linear_op, "get_tp_group", lambda: SimpleNamespace(world_size=2))
+    layer = _make_layer(torch.zeros(shape, dtype=torch.bfloat16))
+    reason = linear_op.KimiOProjMMReduceScatterOp.unsupported_reason(layer)
+    assert ("local K" if len(shape) == 2 and shape[0] else "2D weights") in reason
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+@pytest.mark.parametrize("case", ["empty", "fp32", "weight_stride", "comm_limit"])
+def test_fused_o_proj_runtime_fallback_preserves_token_shard(monkeypatch, rank, case):
+    device_group = MagicMock()
+    monkeypatch.setattr(
+        linear_op, "get_tp_group", lambda: SimpleNamespace(device_group=device_group, rank_in_group=rank, world_size=2)
+    )
+    num_tokens = 0 if case == "empty" else 3
+    generator = torch.Generator().manual_seed(17)
+    inputs = torch.randint(-2, 3, (2, num_tokens, 256), generator=generator).to(torch.bfloat16)
+    weights = torch.randint(-2, 3, (2, 32, 256), generator=generator).to(torch.bfloat16)
+    layer = _make_layer(weights[rank])
+    op = linear_op.KimiOProjMMReduceScatterOp(layer)
+    if case == "fp32":
+        inputs, weights = inputs.float(), weights.float()
+    elif case == "weight_stride":
+        weights = torch.stack((weights, weights), dim=-1)[..., 0]
+    elif case == "comm_limit":
+        # Exactly at the documented communication ceiling must avoid fusion.
+        monkeypatch.setattr(op, "MAX_COMM_BYTES", 4 * 32 * 2)
+    layer.weight = weights[rank]
+    partials = [torch.nn.functional.linear(x, w) for x, w in zip(inputs, weights)]
+    padded = [torch.nn.functional.pad(p, (0, 0, 0, (-num_tokens) % 2)) for p in partials]
+    expected = torch.stack(padded).sum(0).chunk(2, dim=0)[rank]
+
+    def reduce_scatter(local_partial):
+        torch.testing.assert_close(local_partial, partials[rank])
+        return expected
+
+    fallback_rs = MagicMock(side_effect=reduce_scatter)
+    fused = MagicMock(side_effect=AssertionError("unsupported input must not launch fusion"))
+    monkeypatch.setattr(linear_op, "sp_reduce_scatter", fallback_rs)
+    monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", fused, raising=False)
+
+    output, bias = op.apply(inputs[rank])
+
+    torch.testing.assert_close(output, expected)
+    assert output.shape == ((num_tokens + 1) // 2, 32)
+    assert bias is None
+    fallback_rs.assert_called_once()
+    fused.assert_not_called()

--- a/tests/ut/ops/test_kimi_o_proj_mm_reduce_scatter.py
+++ b/tests/ut/ops/test_kimi_o_proj_mm_reduce_scatter.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+from vllm_ascend.ops import linear_op
+from vllm_ascend.ops.linear import AscendRowParallelLinear
+
+
+def _make_layer(weight):
+    return SimpleNamespace(
+        weight=weight,
+        bias=None,
+        custom_op=None,
+        quant_method=UnquantizedLinearMethod(),
+        input_is_parallel=True,
+        input_size_per_partition=weight.shape[1],
+        reduce_results=False,
+        return_bias=True,
+        skip_bias_add=False,
+        prefix="model.layers.0.self_attn.o_proj",
+    )
+
+
+@pytest.mark.parametrize("world_size", [2, 8])
+@pytest.mark.parametrize("num_tokens", [0, 1, 3, 8, 17])
+@pytest.mark.parametrize("last_rank", [False, True])
+def test_fused_o_proj_matches_padded_partial_sum(monkeypatch, world_size, num_tokens, last_rank):
+    rank = world_size - 1 if last_rank else 0
+    generator = torch.Generator().manual_seed(42)
+    # Strided activations exercise the fused operator's contiguous-input rule.
+    inputs = torch.randint(-2, 3, (world_size, num_tokens, 512), generator=generator).to(torch.bfloat16)[..., ::2]
+    weights = torch.randint(-2, 3, (world_size, 32, 256), generator=generator).to(torch.bfloat16) / 8
+    padding = (-num_tokens) % world_size
+    partials = [
+        torch.nn.functional.pad(torch.nn.functional.linear(x, weight), (0, 0, 0, padding))
+        for x, weight in zip(inputs, weights)
+    ]
+    expected = torch.stack(partials).sum(0).chunk(world_size, dim=0)[rank]
+    backend = MagicMock()
+    backend.get_hccl_comm_name.return_value = "kimi_tp"
+    device_group = MagicMock()
+    device_group._get_backend.return_value = backend
+    tp_group = SimpleNamespace(device_group=device_group, rank_in_group=rank, world_size=world_size)
+    monkeypatch.setattr(linear_op, "get_tp_group", lambda: tp_group)
+    layer = _make_layer(weights[rank])
+    op = linear_op.KimiOProjMMReduceScatterOp(layer)
+    calls = []
+
+    def fused_mm(x, weight, hcom, size, **kwargs):
+        calls.append((hcom, size, kwargs))
+        assert x.is_contiguous()
+        assert x.shape == (num_tokens + padding, 256)
+        assert weight.data_ptr() == layer.weight.data_ptr()
+        torch.testing.assert_close(weight, layer.weight.t())
+        local_partial = x @ weight
+        torch.testing.assert_close(local_partial, partials[rank])
+        contributions = list(partials)
+        contributions[rank] = local_partial
+        return torch.stack(contributions).sum(0).chunk(size, dim=0)[rank], torch.empty(0)
+
+    monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", fused_mm, raising=False)
+
+    output, bias = op.apply(inputs[rank])
+
+    torch.testing.assert_close(output, expected)
+    assert bias is None
+    assert calls == [("kimi_tp", world_size, {"reduce_op": "sum", "comm_mode": "ai_cpu"})]
+    backend.get_hccl_comm_name.assert_called_once_with(rank)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.int8])
+def test_fused_o_proj_rejects_non_bf16_weights(dtype):
+    with pytest.raises(ValueError, match="unquantized BF16"):
+        linear_op.KimiOProjMMReduceScatterOp(_make_layer(torch.zeros(32, 256, dtype=dtype)))
+
+
+@pytest.mark.parametrize(
+    "attribute,value,error",
+    [
+        ("quant_method", object(), "unquantized BF16"),
+        ("custom_op", object(), "original TP group"),
+        ("bias", torch.zeros(32), "bias-free"),
+    ],
+)
+def test_fused_o_proj_rejects_incompatible_projection(attribute, value, error):
+    layer = _make_layer(torch.zeros(32, 256, dtype=torch.bfloat16))
+    setattr(layer, attribute, value)
+    with pytest.raises(ValueError, match=error):
+        linear_op.KimiOProjMMReduceScatterOp(layer)
+
+
+def test_row_parallel_linear_dispatches_fused_projection(monkeypatch):
+    monkeypatch.setattr("vllm_ascend.ops.linear.get_parallel_op", lambda *_: (None, 0, 2))
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", lambda: 2)
+    device_group = MagicMock()
+    device_group._get_backend.return_value.get_hccl_comm_name.return_value = "kimi_tp"
+    tp_group = SimpleNamespace(device_group=device_group, rank_in_group=0, world_size=2)
+    monkeypatch.setattr(linear_op, "get_tp_group", lambda: tp_group)
+    layer = AscendRowParallelLinear(
+        512, 32, bias=False, params_dtype=torch.bfloat16, reduce_results=False, prefix="model.layers.0.self_attn.o_proj"
+    )
+    layer.custom_op = linear_op.KimiOProjMMReduceScatterOp(layer)
+    expected = torch.ones(2, 32, dtype=torch.bfloat16)
+    fused = MagicMock(return_value=(expected, torch.empty(0)))
+    monkeypatch.setattr(linear_op.torch_npu, "npu_quant_mm_reduce_scatter", fused, raising=False)
+
+    output, bias = layer(torch.ones(3, 256, dtype=torch.bfloat16), is_prefill=True)
+
+    assert output is expected
+    assert bias is None
+    fused.assert_called_once()
+    assert fused.call_args.args[0].shape == (4, 256)

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -159,3 +159,23 @@ class TestAscendMultiHeadLatentAttention(TestBase):
         output = attn.forward(positions, hidden_states)
 
         self.assertEqual(output.shape, (3, self.hidden_size))
+
+    @patch("vllm_ascend.ops.mla.torch.ops.vllm.mla_forward")
+    def test_fused_o_proj_allocates_sequence_shard(self, mock_mla_forward):
+        attn = AscendMultiHeadLatentAttention.__new__(AscendMultiHeadLatentAttention)
+        torch.nn.Module.__init__(attn)
+        attn.hidden_size = 32
+        attn.output_token_shard_size = 8
+        attn.prefix = self.prefix
+
+        def write_output(hidden_states, output, prefix):
+            self.assertEqual(output.shape, ((hidden_states.shape[0] + 7) // 8, 32))
+            self.assertEqual(prefix, self.prefix)
+            output.fill_(2)
+
+        mock_mla_forward.side_effect = write_output
+        for num_tokens in (0, 1, 8, 17):
+            with self.subTest(num_tokens=num_tokens):
+                output = attn.forward(torch.arange(num_tokens), torch.empty(num_tokens, 32, dtype=torch.bfloat16))
+                self.assertEqual(output.shape, ((num_tokens + 7) // 8, 32))
+                torch.testing.assert_close(output, torch.full_like(output, 2))

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -189,6 +189,7 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
+        self.assertFalse(ascend_config.enable_kimi_o_proj_mm_reduce_scatter)
         self.assertEqual(ascend_config.weight_nz_mode, 1)
         self.assertEqual(ascend_config.mega_moe_max_tokens, 65536)
 
@@ -198,6 +199,14 @@ class TestAscendConfig(TestBase):
         ascend_fusion_config = ascend_config.ascend_fusion_config
         self.assertTrue(ascend_fusion_config.fusion_ops_gmmswigluquant)
         self.assertFalse(ascend_config.rl_config.enabled)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_enable_kimi_o_proj_mm_reduce_scatter(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"enable_kimi_o_proj_mm_reduce_scatter": True}
+        ascend_config = init_ascend_config(test_vllm_config)
+        self.assertTrue(ascend_config.enable_kimi_o_proj_mm_reduce_scatter)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -386,6 +386,7 @@ class AscendConfig:
     enable_cpu_binding: bool = True
     multistream_dsv4_dsa_overlap: bool = True
     enable_prefill_mc2: bool = False
+    enable_kimi_o_proj_mm_reduce_scatter: bool = False
     multistream_overlap_shared_expert: bool = False
     enable_kv_nz: bool = False
     enable_mc2_hierarchy_comm: bool = False  # deprecated, will be replaced by mc2_comm_alg = "hierarchy"

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -38,6 +38,7 @@ class HardwareCapability(Enum):
     MLAPO_NATIVE_WEIGHTS = auto()
     MC2_FULLMESH_V2_COMM = auto()
     MC2_HIERARCHY_COMM = auto()
+    MM_REDUCE_SCATTER_AI_CPU_INFERENCE = auto()
     NPUGRAPH_EX = auto()
     PAGED_ATTENTION = auto()
     RC_DEVICE_DISCOVERY = auto()
@@ -202,6 +203,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.LORA_CUSTOM_OPS,
                     HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
                     HardwareCapability.MLAPO_NATIVE_WEIGHTS,
+                    HardwareCapability.MM_REDUCE_SCATTER_AI_CPU_INFERENCE,
                     HardwareCapability.NPUGRAPH_EX,
                     HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
                     HardwareCapability.STANDARD_MAMBA_PATCH,

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -509,25 +509,29 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
         if self.use_sequence_parallel:
             self.self_attn.o_proj.reduce_results = False
 
-        self.fuse_o_proj_mm_reduce_scatter = get_ascend_config().enable_kimi_o_proj_mm_reduce_scatter
-        if self.fuse_o_proj_mm_reduce_scatter:
-            self._enable_o_proj_mm_reduce_scatter(vllm_config)
+        self.fuse_o_proj_mm_reduce_scatter = (
+            get_ascend_config().enable_kimi_o_proj_mm_reduce_scatter
+            and self._enable_o_proj_mm_reduce_scatter(vllm_config)
+        )
 
-    def _enable_o_proj_mm_reduce_scatter(self, vllm_config: VllmConfig) -> None:
+    def _enable_o_proj_mm_reduce_scatter(self, vllm_config: VllmConfig) -> bool:
         if not self.use_sequence_parallel or not self.use_attn_residuals:
-            raise ValueError("Kimi O-projection MM ReduceScatter requires sequence parallel attention residuals.")
+            return False
         if not get_current_hardware_profile().supports(HardwareCapability.MM_REDUCE_SCATTER_AI_CPU_INFERENCE):
-            raise ValueError("Kimi O-projection MM ReduceScatter is only supported on Ascend A5.")
+            return False
         if get_ascend_config().weight_nz_mode == 2:
-            raise ValueError("Kimi O-projection MM ReduceScatter requires ND weights; set weight_nz_mode to 0 or 1.")
+            return False
         if vllm_config.lora_config is not None:
-            raise ValueError("Kimi O-projection MM ReduceScatter does not support LoRA.")
+            return False
         o_proj = self.self_attn.o_proj
+        if KimiOProjMMReduceScatterOp.unsupported_reason(o_proj) is not None:
+            return False
         o_proj.custom_op = KimiOProjMMReduceScatterOp(o_proj)
         if isinstance(self.self_attn, AscendKimiMLAAttention):
             # The MLA custom op writes into a caller-owned output buffer. Its
             # token dimension must match the fused projection's TP shard.
             self.self_attn.mla_attn.output_token_shard_size = o_proj.tp_size
+        return True
 
     def _run_self_attn(
         self,

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -78,7 +78,10 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
+from vllm_ascend.ops.linear_op import KimiOProjMMReduceScatterOp
 from vllm_ascend.utils import get_rotation_path
 
 if HAS_TRITON:
@@ -506,6 +509,26 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
         if self.use_sequence_parallel:
             self.self_attn.o_proj.reduce_results = False
 
+        self.fuse_o_proj_mm_reduce_scatter = get_ascend_config().enable_kimi_o_proj_mm_reduce_scatter
+        if self.fuse_o_proj_mm_reduce_scatter:
+            self._enable_o_proj_mm_reduce_scatter(vllm_config)
+
+    def _enable_o_proj_mm_reduce_scatter(self, vllm_config: VllmConfig) -> None:
+        if not self.use_sequence_parallel or not self.use_attn_residuals:
+            raise ValueError("Kimi O-projection MM ReduceScatter requires sequence parallel attention residuals.")
+        if not get_current_hardware_profile().supports(HardwareCapability.MM_REDUCE_SCATTER_AI_CPU_INFERENCE):
+            raise ValueError("Kimi O-projection MM ReduceScatter is only supported on Ascend A5.")
+        if get_ascend_config().weight_nz_mode == 2:
+            raise ValueError("Kimi O-projection MM ReduceScatter requires ND weights; set weight_nz_mode to 0 or 1.")
+        if vllm_config.lora_config is not None:
+            raise ValueError("Kimi O-projection MM ReduceScatter does not support LoRA.")
+        o_proj = self.self_attn.o_proj
+        o_proj.custom_op = KimiOProjMMReduceScatterOp(o_proj)
+        if isinstance(self.self_attn, AscendKimiMLAAttention):
+            # The MLA custom op writes into a caller-owned output buffer. Its
+            # token dimension must match the fused projection's TP shard.
+            self.self_attn.mla_attn.output_token_shard_size = o_proj.tp_size
+
     def _run_self_attn(
         self,
         positions: torch.Tensor,
@@ -542,7 +565,7 @@ class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
             hidden_states=hidden_states,
             positions=positions,
         )
-        if self.use_sequence_parallel:
+        if self.use_sequence_parallel and not self.fuse_o_proj_mm_reduce_scatter:
             hidden_states = sp_reduce_scatter(hidden_states)
 
         prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -47,6 +47,7 @@ from vllm.distributed import split_tensor_along_last_dim
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.models.common.ops.sequence_parallel import sp_reduce_scatter
 
 from vllm_ascend.distributed.parallel_state import (
     get_mlp_tp_group,
@@ -154,14 +155,34 @@ class CustomReplicatedOp(CustomLinearOp):
 class KimiOProjMMReduceScatterOp(CustomRowParallelOp):
     """Return the token shard of Kimi's BF16 TP output projection."""
 
+    SUPPORTED_TP_SIZES = (2, 4, 8, 16, 32, 64)
+    MIN_K = 256
+    MAX_K = 65535
+    MAX_COMM_BYTES = 16 * 256 * 1024 * 1024
+
+    @staticmethod
+    def unsupported_reason(layer) -> str | None:
+        if layer.custom_op is not None:
+            return "Kimi O-projection MM ReduceScatter requires the original TP group."
+        if not isinstance(layer.quant_method, UnquantizedLinearMethod) or layer.weight.dtype != torch.bfloat16:
+            return "Kimi O-projection MM ReduceScatter requires unquantized BF16 O-projection weights."
+        if layer.bias is not None:
+            return "Kimi O-projection MM ReduceScatter requires bias-free O projections."
+        if not callable(getattr(torch_npu, "npu_quant_mm_reduce_scatter", None)):
+            return "Kimi O-projection MM ReduceScatter requires the torch_npu V2 interface."
+        if get_tp_group().world_size not in KimiOProjMMReduceScatterOp.SUPPORTED_TP_SIZES:
+            return "Kimi O-projection MM ReduceScatter requires TP size 2, 4, 8, 16, 32, or 64."
+        weight = layer.weight
+        if weight.ndim != 2 or weight.shape[0] == 0:
+            return "Kimi O-projection MM ReduceScatter requires nonempty 2D weights."
+        if not KimiOProjMMReduceScatterOp.MIN_K <= weight.shape[1] < KimiOProjMMReduceScatterOp.MAX_K:
+            return "Kimi O-projection MM ReduceScatter requires local K in [256, 65535)."
+        return None
+
     def __init__(self, layer):
         super().__init__(layer)
-        if layer.custom_op is not None:
-            raise ValueError("Kimi O-projection MM ReduceScatter requires the original TP group.")
-        if not isinstance(layer.quant_method, UnquantizedLinearMethod) or layer.weight.dtype != torch.bfloat16:
-            raise ValueError("Kimi O-projection MM ReduceScatter requires unquantized BF16 O-projection weights.")
-        if layer.bias is not None:
-            raise ValueError("Kimi O-projection MM ReduceScatter requires bias-free O projections.")
+        if reason := self.unsupported_reason(layer):
+            raise ValueError(reason)
         self.update_attrs()
         device_group = self.comm_group.device_group
         backend = device_group._get_backend(torch.device("npu"))
@@ -169,7 +190,15 @@ class KimiOProjMMReduceScatterOp(CustomRowParallelOp):
         self.world_size = self.tp_size
 
     def apply_impl(self, input_: torch.Tensor) -> tuple[torch.Tensor, None]:
-        input_parallel = self.get_input_parallel(input_).contiguous()
+        input_parallel = self.get_input_parallel(input_)
+        weight = self.layer.weight
+        # Branch only on TP-consistent tensor metadata, before any collective.
+        # The decoder skips its RS and MLA already owns a sharded output buffer,
+        # so the unfused path must return the same token shard as fusion.
+        if not self._can_fuse(input_parallel, weight):
+            output = self.quant_method.apply(self.layer, input_parallel, None)
+            return sp_reduce_scatter(output), None
+        input_parallel = input_parallel.contiguous()
         # sp_reduce_scatter pads the GEMM result. With bias-free O projections,
         # padding the input before the fused GEMM gives the same zero rows.
         sp_pad = (-input_parallel.shape[0]) % self.world_size
@@ -186,6 +215,21 @@ class KimiOProjMMReduceScatterOp(CustomRowParallelOp):
             comm_mode="ai_cpu",
         )
         return output, None
+
+    def _can_fuse(self, input_parallel: torch.Tensor, weight: torch.Tensor) -> bool:
+        if input_parallel.ndim != 2 or weight.ndim != 2:
+            return False
+        if input_parallel.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+            return False
+        if not self.MIN_K <= input_parallel.shape[1] < self.MAX_K or input_parallel.shape[1] != weight.shape[1]:
+            return False
+        if not (weight.is_contiguous() or weight.t().is_contiguous()):
+            return False
+        num_tokens, _ = input_parallel.shape
+        if num_tokens == 0 or weight.shape[0] == 0:
+            return False
+        padded_tokens = num_tokens + (-num_tokens) % self.world_size
+        return padded_tokens * weight.shape[0] * weight.element_size() < self.MAX_COMM_BYTES
 
 
 class MLPColumnParallelOp(CustomColumnParallelOp):

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -41,10 +41,12 @@ from types import SimpleNamespace
 import regex as re
 import torch
 import torch.distributed as dist
+import torch_npu
 from torch.nn.parameter import Parameter
 from vllm.distributed import split_tensor_along_last_dim
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 
 from vllm_ascend.distributed.parallel_state import (
     get_mlp_tp_group,
@@ -147,6 +149,43 @@ class CustomReplicatedOp(CustomLinearOp):
         output_bias = self.bias if self.skip_bias_add else None
 
         return output, output_bias
+
+
+class KimiOProjMMReduceScatterOp(CustomRowParallelOp):
+    """Return the token shard of Kimi's BF16 TP output projection."""
+
+    def __init__(self, layer):
+        super().__init__(layer)
+        if layer.custom_op is not None:
+            raise ValueError("Kimi O-projection MM ReduceScatter requires the original TP group.")
+        if not isinstance(layer.quant_method, UnquantizedLinearMethod) or layer.weight.dtype != torch.bfloat16:
+            raise ValueError("Kimi O-projection MM ReduceScatter requires unquantized BF16 O-projection weights.")
+        if layer.bias is not None:
+            raise ValueError("Kimi O-projection MM ReduceScatter requires bias-free O projections.")
+        self.update_attrs()
+        device_group = self.comm_group.device_group
+        backend = device_group._get_backend(torch.device("npu"))
+        self.hcom = backend.get_hccl_comm_name(self.tp_rank)
+        self.world_size = self.tp_size
+
+    def apply_impl(self, input_: torch.Tensor) -> tuple[torch.Tensor, None]:
+        input_parallel = self.get_input_parallel(input_).contiguous()
+        # sp_reduce_scatter pads the GEMM result. With bias-free O projections,
+        # padding the input before the fused GEMM gives the same zero rows.
+        sp_pad = (-input_parallel.shape[0]) % self.world_size
+        if sp_pad:
+            input_parallel = torch.nn.functional.pad(input_parallel, (0, 0, 0, sp_pad))
+        # The V2 interface supports BF16 inference without quantization scales.
+        # Keep TP communication on AI CPU, independently of the MoE EP engine.
+        output, _ = torch_npu.npu_quant_mm_reduce_scatter(
+            input_parallel,
+            self.layer.weight.t(),
+            self.hcom,
+            self.world_size,
+            reduce_op="sum",
+            comm_mode="ai_cpu",
+        )
+        return output, None
 
 
 class MLPColumnParallelOp(CustomColumnParallelOp):

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -82,6 +82,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
     ) -> None:
         nn.Module.__init__(self)
         self.hidden_size = hidden_size
+        self.output_token_shard_size = 1
         self.kv_lora_rank = kv_lora_rank
         self.qk_rope_head_dim = qk_rope_head_dim
         self.q_lora_rank = q_lora_rank
@@ -156,9 +157,8 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
         hidden_dim = self.hidden_size
-        output = torch.empty(
-            (hidden_states.shape[0], hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
-        )
+        num_output_tokens = (hidden_states.shape[0] + self.output_token_shard_size - 1) // self.output_token_shard_size
+        output = torch.empty((num_output_tokens, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device)
 
         torch.ops.vllm.mla_forward(hidden_states, output, self.prefix)
         output = output.view(-1, hidden_dim)


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 sequence parallelism computes a BF16 O-projection GEMM on each TP rank and then ReduceScatters the full token output. This PR adds an opt-in A5 fused MM + ReduceScatter path for KDA and MLA, preserving checkpoint names, TP weight shards, output gates, normalization, and residual ordering. MLA allocates the resulting token shard, and the decoder skips its separate ReduceScatter.

Fusion is selected only when its configuration and projection requirements are met. For example, enabling the option with PP2 keeps the original full-token O-projection path instead of failing model initialization. Unsupported SP layers retain GEMM + ReduceScatter. After selection, unsupported runtime tensor metadata uses the original GEMM + `sp_reduce_scatter`, preserving the sharded output buffer and exactly one reduction.

This PR targets `releases/v0.27.1rc` and remains a draft pending A5 validation. No performance improvement has been measured yet.

### Does this PR introduce _any_ user-facing change?

Add `"enable_kimi_o_proj_mm_reduce_scatter": true` to the existing `--additional-config` JSON to request fusion. The default is `false`.

Selection requires A5, Kimi sequence-parallel attention residuals (`PP=1`, expert parallelism enabled, `TP>1`), unquantized BF16 bias-free O weights, ND layout (`weight_nz_mode` 0 or 1), the original TP group, and no LoRA. The V2 Python interface must be available, TP size must be in `{2,4,8,16,32,64}`, and local weight K must be in `[256,65535)`. DSpark draft projections retain their existing implementation.

Runtime checks cover activation/weight dtype and shape, weight strides, empty batches, and the padded communication payload ceiling. Fallback decisions use TP-consistent tensor metadata before communication. TP fusion uses `comm_mode="ai_cpu"`. Errors after launching the kernel are propagated; there is no rank-local exception retry. The installed CANN/torch_npu must support BF16 inference and this communication mode; the documented payload ceiling does not guarantee support for every shape below it.

### How was this patch tested?

- **114 targeted CPU unit tests passed**, using repository CPU UT stubs on the authorized server. Coverage includes TP2/TP8, first/last ranks, padding, strided activations, native linear dispatch, KDA/MLA output shapes, configuration fallback, absent API, unsupported TP/K, empty batches, runtime fallback, and kernel-error propagation.
- Changed-file Ruff, formatting, codespell, typos, markdownlint, forbidden-import, boolean-context-manager, and long-function checks passed.
- Full `format.sh ci` previously did not complete on Windows because actionlint toolchain setup stalled and the gitleaks shell hook could not resolve `/bin/bash`; a full local lint pass is not claimed.
- An A5 test is included for BF16 accuracy and latency in eager mode and NPU graph replay. **NPU accuracy, graph replay, and performance validation remain pending.**

```bash
pytest -q \
  tests/ut/ops/test_kimi_o_proj_mm_reduce_scatter.py \
  tests/ut/models/test_kimi_k3_adapter.py \
  tests/ut/ops/test_kimi_kda.py \
  tests/ut/ops/test_mla.py \
  tests/ut/device/test_hardware_profile.py \
  tests/ut/test_ascend_config.py::TestAscendConfig::test_init_ascend_config_without_additional_config \
  tests/ut/test_ascend_config.py::TestAscendConfig::test_enable_kimi_o_proj_mm_reduce_scatter
```

On reserved A5 devices with the inference CANN environment:

```bash
torchrun --standalone --nproc-per-node=8 -m pytest --noconftest -s \
  tests/e2e/nightly/single_node/ops/multicard_ops_a5/test_kimi_o_proj_mm_reduce_scatter.py
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
