### PR TITLE
[BugFix][Worker] Snapshot query boundaries and computed-token counts before H2D

### DIFF
--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -96,6 +96,31 @@ class TestGlm5MtpGraphMetadata(unittest.TestCase):
         self.assertTrue(call_kwargs["uniform_decode"])
 
 
+class TestQueryStartLocSnapshot(unittest.TestCase):
+    def test_padding_transfer_survives_cpu_buffer_reuse(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.uniform_decode_query_len = 1
+        runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.NONE)
+        runner.arange_np = np.arange(5, dtype=np.int32)
+        cpu = torch.tensor([0, 2, 5, 0, 0], dtype=torch.int32)
+        pending_sources = []
+        gpu = MagicMock()
+        gpu.copy_.side_effect = lambda source, **kwargs: pending_sources.append(source)
+        buffer = SimpleNamespace(cpu=cpu, np=cpu.numpy(), gpu=gpu)
+
+        # This test controls when the transfer reads its source. Pinning itself
+        # is covered by hardware validation, so CPU-only UT can omit it.
+        with patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor):
+            padded_reqs = runner._pad_query_start_loc_for_fia(buffer, 8, 2, 2)
+            cpu.fill_(99)
+
+        self.assertEqual(padded_reqs, 3)
+        self.assertEqual(len(pending_sources), 1)
+        self.assertTrue(gpu.copy_.call_args.kwargs["non_blocking"])
+        self.assertNotEqual(pending_sources[0].data_ptr(), cpu.data_ptr())
+        torch.testing.assert_close(pending_sources[0], torch.tensor([0, 2, 5, 8, 0], dtype=torch.int32))
+
+
 class TestDummyRunSlotInvalidation(unittest.TestCase):
     def test_backend_metadata_sees_invalidated_dummy_slots(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)
@@ -120,7 +145,7 @@ class TestDummyRunSlotInvalidation(unittest.TestCase):
         runner.optimistic_seq_lens_cpu = torch.zeros(8, dtype=torch.int32)
         runner.seq_lens = MagicMock()
         runner.query_pos = SimpleNamespace(np=np.zeros(8, dtype=np.int32))
-        runner.query_start_loc = SimpleNamespace(np=np.zeros(9, dtype=np.int32), copy_to_gpu=MagicMock())
+        runner.query_start_loc = SimpleNamespace(np=np.zeros(9, dtype=np.int32), cpu=MagicMock(), gpu=MagicMock())
         runner.positions = MagicMock()
         runner._dsa_positions_cpu_buf = MagicMock()
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1422,8 +1422,11 @@ class NPUModelRunner(GPUModelRunner):
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
         valid_sampled_token_count_gpu = self.valid_sampled_token_count_gpu
         if self.use_async_spec_decode:
-            computed_token_tensor_cpu = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-                device=self.device, non_blocking=True
+            computed_token_tensor_cpu = (
+                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+                .clone()
+                .pin_memory()
+                .to(device=self.device, non_blocking=True)
             )
         if (
             self.use_async_spec_decode
@@ -1443,7 +1446,7 @@ class NPUModelRunner(GPUModelRunner):
             )
         else:
             self.num_computed_tokens[:num_reqs].copy_(
-                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
+                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].clone().pin_memory(),
                 non_blocking=True,
             )
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1013,7 +1013,7 @@ class NPUModelRunner(GPUModelRunner):
                 query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
                 num_reqs_padded = num_reqs_padded + 1
 
-        query_start_loc.copy_to_gpu()
+        query_start_loc.gpu.copy_(query_start_loc.cpu.clone().pin_memory(), non_blocking=True)
 
         return num_reqs_padded
 
@@ -1343,7 +1343,8 @@ class NPUModelRunner(GPUModelRunner):
 
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
-        self.query_start_loc.copy_to_gpu()
+        # Keep the H2D source independent of the reusable CPU buffer.
+        self.query_start_loc.gpu.copy_(self.query_start_loc.cpu.clone().pin_memory(), non_blocking=True)
 
         # Now, query_start_loc is padded.
         # But gdn needs an unpadded one.
@@ -3820,7 +3821,7 @@ class NPUModelRunner(GPUModelRunner):
                 cum_num_tokens = self._get_cumsum_and_arange(
                 num_scheduled_tokens, self.query_pos.np)
                 self.query_start_loc.np[1 : num_reqs_padded + 1] = cum_num_tokens
-                self.query_start_loc.copy_to_gpu()
+                self.query_start_loc.gpu.copy_(self.query_start_loc.cpu.clone().pin_memory(), non_blocking=True)
                 if self._has_gdn:
                     if skip_gdn_state_update:
                         self.gdn_query_start_loc.np.fill(0)


### PR DESCRIPTION
### What this PR does / why we need it?

Snapshot reusable CPU input metadata with `clone().pin_memory()` before submitting asynchronous H2D transfers in `NPUModelRunner`. This covers `query_start_loc` in input preparation, FIA padding, and dummy runs, plus both direct transfers of `num_computed_tokens` (the speculative `.to()` path and fallback `.copy_()` path).

All production changes are in `vllm_ascend/worker/model_runner_v1.py`. The existing input-preparation event protocol and non-blocking device transfers remain in place. Device buffer addresses, padding contents, and speculative count correction are preserved. The upstream `CpuGpuBuffer` implementation is unchanged.

In the reproduction workload, CPU/device query boundaries disagreed despite the input-preparation event protocol. Snapshotting gives each submitted copy independent source storage. The precise event-ordering gap has not been isolated; this change does not claim that every observed failure was caused by source reuse.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. The transfers incur additional CPU copies and pinned-memory allocations; their performance impact has not been benchmarked.

### How was this patch tested?

- Ruff lint, Ruff format check, and `git diff --check` passed for the changed files.
- Added `TestQueryStartLocSnapshot.test_padding_transfer_survives_cpu_buffer_reuse` in `tests/ut/worker/test_model_runner_v1.py`. It delays reading the submitted source, overwrites the reusable CPU buffer, and verifies that the padded boundaries remain intact. Updated the existing dummy-run test fixture for the explicit CPU/device transfer.
- On the Ascend reproduction host, ran that exact added test against the extracted production padding method: passed. The method and test were loaded in isolation because the reproduction image has older dependencies than this latest-main PR; the complete test module and full unit suite have not been run.
- Exercised all five production transfer expressions on the host with real torch pinned CPU storage and a simulated delayed transport. All five original-source negative controls observed overwritten values; all five patched expressions retained independent, pinned snapshots. This checks source ownership, not actual DMA timing.
- Earlier end-to-end tests with a broader common-buffer snapshot patch plus the computed-token snapshots completed all 1,319 GSM8K samples. With only the two computed-token snapshots, the workload still failed on D DP2 with `IndexCheck_int64_high_performance_0`; 24 of 1,888 P query-boundary comparisons disagreed. These findings motivated the query-boundary snapshots here; the follow-up validation below still reproduced a failure.
- The repository-wide `format.sh ci` attempt was blocked during markdownlint dependency installation and stopped. No full-suite or CI success is claimed. This PR remains a draft.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d


Follow-up end-to-end validation (chain18): ported the five transfer expressions from commit `b0eacd0` to P in the existing reproduction image and verified AST equality for every expression. D computational code and the existing reproduction/diagnostic baseline were held constant; upstream `CpuGpuBuffer.copy_to_gpu()` remained unmodified. Both services were restarted. The original 256-concurrency, 200-shot GSM8K workload still failed: D DP12 hit `IndexCheck_int64_high_performance_0` (`idx >= 0`), and evaluation was stopped at 280/1,319. All 1,456 P query-boundary comparisons matched, but 24 of 728 P worker steps contained valid-region NaN/Inf in the monitored first two layers. All 16 worker rings were complete, with no dump errors. The current PR is insufficient to resolve the end-to-end failure. The previously successful common-buffer patch snapshots more metadata buffers than the query-boundary changes in this PR; its coverage is not equivalent. The remaining failing buffer and a same-request P-to-D causal chain have not been isolated for this run.


Direct input capture (chain19): added device-only snapshots of four inputs immediately before the `seq_lens` computation, with D2H deferred until after evaluation stopped. Across 712 input groups validated against scheduler request IDs/counts, `num_computed_tokens` matched CPU in every group. Eight groups each showed mismatches in `num_scheduled_tokens`, `req_indices`, and `query_pos`; for all three buffers, the captured device vector exactly matched the next preparation's CPU vector. The corresponding attention `seq_lens` equaled the captured computed-token counts plus the wrong scheduled-token counts, and those owner batches contained valid-region NaN. `query_start_loc` remained consistent (1,456 comparisons). This identifies three additional unprotected input transfers in the current PR; the exact DMA/event timing gap remains unresolved. The final preparation per worker was not included in the direct input comparisons. D DP12 again failed with IndexCheck, and evaluation was stopped at 263/1,319. No additional production protection has been committed by this diagnostic run.


Isolated prefill validation (chain20): with the same P production protections and direct-input probes as chain19, restarted P and sent the original 1,319 GSM8K 200-shot prompts at concurrency 256 through a router targeting only its four P APIs. Requests generated one token, matching the original PD prefill output limit, but omitted remote-decode/KV-transfer parameters and never contacted D. All 1,319 returned HTTP 200; P did not crash. Across 952 retained worker steps, all 1,904 query-boundary comparisons matched and no valid-region NaN/Inf was detected in the first two layers. All four input vectors matched across 936 aligned direct captures (the final preparation per worker is not in these comparisons). All 16 rings were complete. This isolated run did not reproduce the issue; removing D and remote-transfer retention changes request lifetime and batching, so it does not establish D as the root cause or validate the PR as a complete PD fix. Accuracy is not applicable to one-token responses.


Common-buffer plus two direct snapshots recheck (chain21): restored the earlier P-side three-protection configuration: upstream `CpuGpuBuffer.copy_to_gpu()` snapshots its source, plus both direct Ascend computed-token transfers. Removed the Ascend-specific query-boundary call-site snapshots and the later four-input diagnostic capture, retaining the original first-two-layer device-ring probes. D computational code remained unchanged and both services restarted. The full original PD GSM8K workload (1,319 samples, 200-shot, concurrency 256, max output 4,096, thinking enabled) completed with exit code 0 and 97.3% accuracy. All 3,280 query-boundary comparisons across 1,640 P worker steps matched; no valid-region NaN/Inf was observed in the first two layers, and D showed no IndexCheck. All 16 worker rings were complete. This verifies the broader common-buffer configuration for this run, not the current Ascend-only PR by itself.


Synchronization-only diagnostic (chain22): removed all three experimental source snapshot protections (common `CpuGpuBuffer.copy_to_gpu()` and both direct computed-token transfers), leaving the earlier reproduction/diagnostic baseline. Added only `torch.npu.synchronize()` immediately before the final return of P `_prepare_inputs()`, with the original `synchronize_input_prep()` event protocol still present. D computational code remained unchanged and both services restarted. The original full PD workload completed all 1,319 samples with exit code 0 and 97.2% accuracy. All 3,184 query-boundary comparisons across 1,592 P worker steps matched, no valid-region NaN/Inf was detected in the first two layers, and D logs/plog had no IndexCheck. All 16 rings were complete. This device-wide synchronization avoided reproduction in this run; it does not isolate the precise missing event dependency, and its performance cost has not been benchmarked. The synchronization experiment is not committed in this PR.
