### PR TITLE
[BugFix][Worker] Own CPU sources for asynchronous H2D copies

### DIFF
--- a/tests/ut/worker/test_block_table.py
+++ b/tests/ut/worker/test_block_table.py
@@ -183,6 +183,48 @@ class TestBlockTableComputeSlotMapping(TestBase):
             np.array([7, 11], dtype=np.int32),
         )
 
+    def test_commit_preserves_sources_until_deferred_copies_finish(self):
+        block_table = self.create_block_table(
+            dcp_world_size=1,
+            dcp_rank=0,
+            cp_kv_cache_interleave_size=1,
+        )
+        block_table.pin_memory = True
+
+        class DeferredGpuCopy:
+            def __init__(self):
+                self.sources = []
+
+            def __getitem__(self, key):
+                return self
+
+            def copy_(self, source, non_blocking=False):
+                assert non_blocking
+                self.sources.append(source)
+                return self
+
+        destination = DeferredGpuCopy()
+        block_table.block_table.gpu = destination
+        empty_like = torch.empty_like
+        expected = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]
+        # CPU-only tests model deferred consumption; remote NPU tests cover
+        # pinned allocation and the allocator's asynchronous lifetime tracking.
+        with patch(
+            "vllm_ascend.worker.block_table.torch.empty_like",
+            side_effect=lambda tensor, **kwargs: empty_like(tensor),
+        ) as allocate:
+            for values in expected:
+                block_table.add_row(values, 0)
+                block_table.commit_block_table(1)
+                block_table.clear_row(0)
+
+        self.assertEqual(allocate.call_count, len(expected))
+        self.assertTrue(all(call.kwargs["pin_memory"] for call in allocate.call_args_list))
+        for source, values in zip(destination.sources, expected):
+            self.assertEqual(source.shape[0], 1)
+            self.assertNotEqual(source.data_ptr(), block_table.block_table.cpu.data_ptr())
+            np.testing.assert_array_equal(source[0, :4], np.array(values, dtype=np.int32))
+
     def _test_slot_mapping_for_ranks(self, dcp_world_size, cp_kv_cache_interleave_size, test_configs):
         """Helper method to test slot_mapping across multiple ranks
 

--- a/tests/ut/worker/test_cpu_gpu_buffer.py
+++ b/tests/ut/worker/test_cpu_gpu_buffer.py
@@ -1,0 +1,62 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import pytest
+import torch
+
+from vllm_ascend.worker.cpu_gpu_buffer import AscendCpuGpuBuffer
+
+
+class DeferredCopy:
+    def __init__(self, pending, selection=None):
+        self.pending = pending
+        self.selection = selection
+
+    def __getitem__(self, selection):
+        return DeferredCopy(self.pending, selection)
+
+    def copy_(self, source, non_blocking=False):
+        assert non_blocking
+        self.pending.append((self.selection, source))
+        return self
+
+
+@pytest.mark.parametrize("length", [None, 3, 0])
+def test_copy_preserves_multiple_pending_generations(length):
+    buffer = AscendCpuGpuBuffer(5, dtype=torch.int32, device=torch.device("cpu"), pin_memory=False)
+    pending = []
+    buffer.gpu = DeferredCopy(pending)
+    expected = []
+    for values in ([0, 6, 12, 18, 24], [0, 3, 9, 9, 9], [0, 2, 2, 2, 2]):
+        buffer.np[:] = values
+        expected.append(values if length is None else values[:length])
+        buffer.copy_to_gpu(length)
+    buffer.np.fill(-1)
+    # Consume only after every source generation has been overwritten.
+    assert [source.tolist() for _, source in pending] == expected
+    assert all(source.data_ptr() != buffer.cpu.data_ptr() for _, source in pending if source.numel())
+    assert all(selection == (None if length is None else slice(None, length)) for selection, _ in pending)
+
+
+def test_copy_preserves_destination_identity_and_tail():
+    buffer = AscendCpuGpuBuffer(5, dtype=torch.int64, device=torch.device("cpu"), pin_memory=False)
+    buffer.gpu.fill_(-7)
+    pointer = buffer.gpu.data_ptr()
+    buffer.np[:] = [0, 6, 12, 18, 24]
+    result = buffer.copy_to_gpu(3)
+    assert result.data_ptr() == pointer
+    assert buffer.gpu.tolist() == [0, 6, 12, -7, -7]
+    buffer.np.fill(100)
+    assert buffer.gpu.tolist() == [0, 6, 12, -7, -7]

--- a/tests/ut/worker/test_model_runner_v1.py
+++ b/tests/ut/worker/test_model_runner_v1.py
@@ -30,6 +30,47 @@ from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
+class TestComputedTokenSnapshot(unittest.TestCase):
+    def test_pending_batches_survive_counter_update_and_condense(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        source = torch.tensor([32768, 32768, 32768, -1], dtype=torch.int32)
+        runner.input_batch = SimpleNamespace(num_computed_tokens_cpu_tensor=source)
+
+        # Defer reading each transfer source until later batches have mutated
+        # the persistent array, as an asynchronous H2D is allowed to do.
+        pending = [runner._snapshot_num_computed_tokens(3)]
+        source[2] += 59
+        source[0] = source[2]
+        pending.append(runner._snapshot_num_computed_tokens(2))
+        source.zero_()
+        pending.append(runner._snapshot_num_computed_tokens(1))
+        source.fill_(99)
+
+        self.assertEqual([value.tolist() for value in pending], [[32768, 32768, 32768], [32827, 32768], [0]])
+        self.assertEqual(len({value.data_ptr() for value in pending}), 3)
+        self.assertTrue(all(value.data_ptr() != source.data_ptr() for value in pending))
+
+    def test_snapshot_preserves_pinned_allocation_request(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        source = torch.tensor([12, 24], dtype=torch.int32)
+        runner.input_batch = SimpleNamespace(num_computed_tokens_cpu_tensor=source)
+        empty_like = torch.empty_like
+
+        # CPU-only CI cannot allocate NPU pinned memory. Check the requested
+        # allocation mode while using real CPU storage for the snapshot.
+        with (
+            patch.object(torch.Tensor, "is_pinned", return_value=True),
+            patch(
+                "vllm_ascend.worker.model_runner_v1.torch.empty_like",
+                side_effect=lambda tensor, **kwargs: empty_like(tensor),
+            ) as allocate,
+        ):
+            snapshot = runner._snapshot_num_computed_tokens(1)
+        self.assertTrue(allocate.call_args.kwargs["pin_memory"])
+        source.fill_(0)
+        self.assertEqual(snapshot.tolist(), [12])
+
+
 class TestDummyRunSlotInvalidation(unittest.TestCase):
     def test_backend_metadata_sees_invalidated_dummy_slots(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -277,7 +277,17 @@ class BlockTable:
             self.slot_mapping.cpu[: req_indices.shape[0]] = torch.where(mask, slot_mapping, -1)
 
     def commit_block_table(self, num_reqs: int) -> None:
-        self.block_table.copy_to_gpu(num_reqs)
+        if not self.pin_memory:
+            self.block_table.copy_to_gpu(num_reqs)
+            return
+
+        # The scheduler may mutate the table while this non-blocking H2D is
+        # pending. Give each copy its own pinned source; the host allocator
+        # records its stream and defers reuse until the copy has completed.
+        source = self.block_table.cpu[:num_reqs]
+        snapshot = torch.empty_like(source, pin_memory=True)
+        snapshot.copy_(source)
+        self.block_table.gpu[:num_reqs].copy_(snapshot, non_blocking=True)
 
     def clear(self) -> None:
         self.block_table.fill_(0)

--- a/vllm_ascend/worker/cpu_gpu_buffer.py
+++ b/vllm_ascend/worker/cpu_gpu_buffer.py
@@ -1,0 +1,31 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import torch
+from vllm.v1.utils import CpuGpuBuffer
+
+
+class AscendCpuGpuBuffer(CpuGpuBuffer):
+    """Keep each asynchronous H2D source independent of the next CPU update."""
+
+    def copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
+        source = self.cpu if n is None else self.cpu[:n]
+        target = self.gpu if n is None else self.gpu[:n]
+        # Retaining the reusable CPU buffer does not prevent its next update.
+        # Give this copy its own allocation; the pinned host allocator delays
+        # recycling that allocation until the asynchronous copy completes.
+        snapshot = torch.empty_like(source, pin_memory=source.is_pinned())
+        snapshot.copy_(source)
+        return target.copy_(snapshot, non_blocking=True)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1136,6 +1136,15 @@ class NPUModelRunner(GPUModelRunner):
 
         self.maybe_save_ec_to_connector({mm_hash: output}, mm_hash)
 
+    def _snapshot_num_computed_tokens(self, num_reqs: int) -> torch.Tensor:
+        # The next batch can update or condense the persistent CPU array while
+        # a non-blocking H2D still reads it. An owned pinned source lets the
+        # host allocator defer reuse until the copy completes.
+        source = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+        snapshot = torch.empty_like(source, pin_memory=source.is_pinned())
+        snapshot.copy_(source)
+        return snapshot
+
     def _prepare_inputs(
         self,
         scheduler_output: "SchedulerOutput",
@@ -1370,10 +1379,9 @@ class NPUModelRunner(GPUModelRunner):
         # corrects on GPU using the previous step's
         # valid_sampled_token_count_gpu. Otherwise, just copy from CPU.
         valid_sampled_token_count_gpu = self.valid_sampled_token_count_gpu
+        count_snapshot = self._snapshot_num_computed_tokens(num_reqs)
         if self.use_async_spec_decode:
-            computed_token_tensor_cpu = self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs].to(
-                device=self.device, non_blocking=True
-            )
+            computed_token_tensor_cpu = count_snapshot.to(device=self.device, non_blocking=True)
         if (
             self.use_async_spec_decode
             and valid_sampled_token_count_gpu is not None
@@ -1392,7 +1400,7 @@ class NPUModelRunner(GPUModelRunner):
             )
         else:
             self.num_computed_tokens[:num_reqs].copy_(
-                self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
+                count_snapshot,
                 non_blocking=True,
             )
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -195,6 +195,7 @@ from vllm_ascend.utils import (
     weak_ref_tensor,
     weak_ref_tensors,
 )
+from vllm_ascend.worker.cpu_gpu_buffer import AscendCpuGpuBuffer
 from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
 from vllm_ascend.worker.device_metadata import (
     DeviceMetadataExecutor,
@@ -1135,6 +1136,11 @@ class NPUModelRunner(GPUModelRunner):
             self.tmp_encoder_cache[mm_hash] = output
 
         self.maybe_save_ec_to_connector({mm_hash: output}, mm_hash)
+
+    def _make_buffer(
+        self, *size: int | torch.SymInt, dtype: torch.dtype, numpy: bool = True
+    ) -> AscendCpuGpuBuffer:
+        return AscendCpuGpuBuffer(*size, dtype=dtype, device=self.device, with_numpy=numpy)
 
     def _snapshot_num_computed_tokens(self, num_reqs: int) -> torch.Tensor:
         # The next batch can update or condense the persistent CPU array while


### PR DESCRIPTION
### What this PR does / why we need it?

Give asynchronous H2D copies independently owned CPU sources. The Ascend model runner reuses host arrays for block tables, computed-token counters, token IDs, query boundaries, request indices, and query offsets. In the reproduced failure, CPU preparation of the next batch overwrote those arrays before the preceding batch's transfer consumed them.

With the supplied DeepSeek-V4/DSpark P/D scripts on Ascend A3, snapshots immediately before and after H2D showed five input buffers reading the next batch's contents at the same host addresses. One prefill step had 6 incorrect query boundaries, 6,640 incorrect token IDs, 454 incorrect request indices, 6,669 incorrect query offsets, and 6 incorrect scheduled-token counts. Each transferred prefix exactly matched the next step's source snapshot. Separate experiments traced block-table reuse and a computed-token counter changing from 32768 to 32827 during request update/compaction. The resulting incorrect positions and KV writes precede the decode-side NaNs and DSpark anchor failure.

Introduce an Ascend `CpuGpuBuffer` implementation whose H2D source is an owned snapshot, and use it for buffers created by the model runner. Protect the separate block-table and computed-token copy paths as well. Device destinations and existing async scheduling/speculative correction logic remain unchanged. The pinned host allocator keeps each source allocation unavailable for reuse until the transfer completes; no extra device synchronization is added.

The application-level source ownership failure is directly observed. The lower-level runtime behavior in which event synchronization returns while event query reports pending is documented separately; this change does not claim to repair CANN event internals. PR16153 is not applied.

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. Prevents corrupted model inputs and downstream decode failures caused by reusing CPU copy sources. Adds a CPU memory copy and transient source allocation to these H2D paths.

### How was this patch tested?

- Required focused CPU/mock command: `cd vllm-ascend && uv run pytest -q tests/ut/worker/test_cpu_gpu_buffer.py tests/ut/worker/test_block_table.py tests/ut/worker/test_model_runner_v1.py::TestComputedTokenSnapshot` — 13 passed, 21 subtests passed. Tests defer consuming multiple source generations until after in-place updates, compaction, and clearing. Full/prefix/empty copies and destination identity/tail preservation are covered.
- Broader CPU command: `cd vllm-ascend && uv run pytest -q tests/ut/worker/test_cpu_gpu_buffer.py tests/ut/worker/test_block_table.py tests/ut/worker/test_model_runner_v1.py` — 45 passed, 18 failures. The failure set exactly matches the previously verified unchanged-base failure set (KV spec compatibility and missing CPU pin-memory hooks); no new failing test IDs.
- `bash format.sh ci` — all hooks passed, including the staged-change secret scan.
- Real NPU checks: controlled shared-source copies reproduced corruption (10/10), while owned pinned snapshots remained correct (10/10) under delayed H2D and allocator churn. The expanded buffer implementation passed 100 consecutive full/prefix copies with immediate source overwrite and pinned allocation churn.
- Same-probe A/B with the original scripts and full GSM8K: the original shared-copy path reproduced five corrupted input sources and D-side NaNs; adding the expanded P-side ownership fix completed 1319/1319, accuracy 97.6%. Six buffer types each had 1112 verified copies with zero source/device differences. P attention/metadata checks were clean without dropped snapshots; D had 18049 sampled steps without NaN or invalid draft positions.
- Uninstrumented cold start with the expanded P-side fix and original D code: 1319/1319 completed, accuracy 97.7%, exit code 0, no reported engine exceptions, all 20 endpoints healthy afterward. A second uninstrumented cold start with the full patch on both P and D also completed 1319/1319, accuracy 96.7%, exit code 0, no reported engine exceptions, and all 20 endpoints healthy afterward. The accuracy difference (97.7% versus 96.7%) has not yet been separated from sampling variability; this remains a draft pending that follow-up and review. Earlier block-table/counter-only candidates failed without probes, which prompted the five-buffer investigation; those earlier passes are not treated as final validation.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
