### PR TITLE
[BugFix][Sampling] Fix greedy token IDs in mixed batches

### DIFF
--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -24,6 +24,7 @@ from vllm_ascend.sample.rejection_sampler import (
     sample_recovered_tokens_blockwise_pytorch,
     sample_recovered_tokens_pytorch,
 )
+from vllm_ascend.sample.sampler import _apply_top_k_top_p_pytorch
 
 # Global constants
 PLACEHOLDER_TOKEN_ID = -1
@@ -979,6 +980,82 @@ def _replace(obj, **kwargs):
     return SimpleNamespace(**data)
 
 
+@pytest.mark.parametrize("other_temperature", [0.0, 0.7])
+@pytest.mark.parametrize("draft_id", [0, 5])
+@pytest.mark.parametrize("logits_case", ["unique", "masked", "tied", "random-sentinel"])
+def test_forward_preserves_greedy_vocab_id_in_mixed_batch(other_temperature, draft_id, logits_case):
+    logits = torch.tensor([[-8.0, -3.0, -2.0, -1.0, 0.0, 9.0, 1.0, 2.0]]).repeat(4, 1)
+    allowed_token_ids_mask = None
+    expected_id = 5
+    if logits_case == "masked":
+        allowed_token_ids_mask = torch.zeros(2, 8, dtype=torch.bool)
+        allowed_token_ids_mask[0, 5] = True
+        expected_id = 7
+    if logits_case == "tied":
+        logits[0, 6] = logits[0, 5]
+    other_draft_id = 5
+    if logits_case == "random-sentinel":
+        logits[2, 4] = 8.5
+        other_draft_id = 4
+    metadata = SimpleNamespace(
+        max_spec_len=1,
+        bonus_logits_indices=torch.tensor([1, 3]),
+        target_logits_indices=torch.tensor([0, 2]),
+        draft_token_ids=torch.tensor([draft_id, other_draft_id], dtype=torch.int32),
+        num_draft_tokens=[1, 1],
+        cu_num_draft_tokens=torch.tensor([1, 2]),
+    )
+    sampling_metadata = SimpleNamespace(
+        all_greedy=other_temperature == 0.0,
+        all_random=False,
+        temperature=torch.tensor([0.0, other_temperature]),
+        top_k=torch.ones(2, dtype=torch.int32) if logits_case == "tied" else None,
+        top_p=None,
+        generators={},
+        max_num_logprobs=None,
+        no_penalties=True,
+        bad_words_token_ids={},
+        output_token_ids=[[], []],
+        allowed_token_ids_mask=allowed_token_ids_mask,
+        logitsprocs=SimpleNamespace(non_argmax_invariant=[]),
+        thinking_budget_state_holder=None,
+    )
+    rs = AscendRejectionSampler.__new__(AscendRejectionSampler)
+    rs.sampler = MagicMock()
+    rs.sampler.logprobs_mode = "raw_logprobs"
+    rs.sampler.return_value = SimpleNamespace(sampled_token_ids=torch.tensor([[7], [7]], dtype=torch.int32))
+    rs.top_k = 1 if logits_case == "tied" else None
+    rs.synthetic_mode = False
+    rs.synthetic_conditional_rates = None
+    rs.is_processed_logprobs_mode = False
+    config = _ascend_cfg(reduce_sample=True)
+    tp_group = _tp_group()
+
+    with (
+        _pin_memory_stack(),
+        patch("vllm_ascend.sample.rejection_sampler.HAS_TRITON", False),
+        patch("vllm_ascend.sample.rejection_sampler.replace", _replace),
+        patch("vllm_ascend.sample.rejection_sampler.get_ascend_config", return_value=config),
+        patch("vllm_ascend.sample.sampler.get_ascend_config", return_value=config),
+        patch("vllm_ascend.sample.rejection_sampler.get_tp_group", return_value=tp_group),
+        patch("vllm_ascend.sample.sampler.get_tp_group", return_value=tp_group),
+        patch("vllm_ascend.sample.rejection_sampler.apply_top_k_top_p", _apply_top_k_top_p_pytorch),
+        patch("vllm_ascend.sample.rejection_sampler.generate_uniform_probs", return_value=torch.tensor([0.01, 0.01])),
+        patch(
+            "vllm_ascend.sample.rejection_sampler.sample_recovered_tokens",
+            return_value=torch.tensor([5, 5], dtype=torch.int32),
+        ),
+    ):
+        output = rs.forward(metadata, None, logits, sampling_metadata)
+
+    expected = [expected_id, 7] if draft_id == expected_id else [expected_id, PLACEHOLDER_TOKEN_ID]
+    assert output.sampled_token_ids[0].tolist() == expected
+    expected_other = [5, 7]
+    if logits_case == "random-sentinel":
+        expected_other = [4, 7] if other_temperature else [5, PLACEHOLDER_TOKEN_ID]
+    assert output.sampled_token_ids[1].tolist() == expected_other
+
+
 def test_ascend_rejection_sampler_methods():
     logits = torch.tensor([[0.1, 0.8, 0.1]])
     with (
@@ -1068,7 +1145,7 @@ def test_ascend_rejection_sampler_methods():
         num_draft_tokens=[1],
         cu_num_draft_tokens=torch.tensor([1]),
     )
-    forward_sampling = SimpleNamespace(max_num_logprobs=1)
+    forward_sampling = SimpleNamespace(max_num_logprobs=1, all_greedy=True, all_random=False)
     with (
         patch("vllm_ascend.sample.rejection_sampler.replace", _replace),
         patch(
@@ -1096,7 +1173,10 @@ def test_ascend_rejection_sampler_methods():
         ),
     ):
         processed_output = rs.forward(
-            forward_meta, None, forward_logits.clone(), SimpleNamespace(max_num_logprobs=None)
+            forward_meta,
+            None,
+            forward_logits.clone(),
+            SimpleNamespace(max_num_logprobs=None, all_greedy=True, all_random=False),
         )
     assert processed_output.logprobs_tensors is None
 

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -226,6 +226,13 @@ class AscendRejectionSampler(RejectionSampler):
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
+        greedy_token_ids = None
+        if (
+            not sampling_metadata.all_greedy
+            and not sampling_metadata.all_random
+            and get_ascend_config().enable_reduce_sample
+        ):
+            greedy_token_ids = greedy_sample(target_logits)
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the
         # `apply_sampling_constraints` function.
@@ -245,6 +252,7 @@ class AscendRejectionSampler(RejectionSampler):
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
             ori_target_logits=raw_target_logits,
+            greedy_token_ids=greedy_token_ids,
         )
 
         self._log_rejection_sampler_exit(output_token_ids, metadata)
@@ -439,6 +447,7 @@ def rejection_sample(
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
     ori_target_logits: torch.Tensor | None = None,
+    greedy_token_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Rejection sampling for speculative decoding in distributed setting.
@@ -566,7 +575,9 @@ def rejection_sample(
 
     # For greedy sampling, we need to do allgather first to get global argmax
     if not sampling_metadata.all_random:
-        if get_ascend_config().enable_reduce_sample:
+        if greedy_token_ids is not None:
+            target_argmax = greedy_token_ids
+        elif get_ascend_config().enable_reduce_sample:
             target_argmax = greedy_sample(target_logits)
         else:
             target_argmax = target_logits.argmax(dim=-1).view(-1)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #16396.

With `enable_reduce_sample=True`, the rejection sampler passes reordered logits to `greedy_sample` when greedy and random requests share a speculative batch. `greedy_sample` assumes the columns still follow the local vocabulary order. For logits `[-8, -3, -2, -1, 0, 9, 1, 2]`, the mixed TP1 path returns candidate position 0 instead of vocabulary ID 5. It incorrectly accepts draft token 0 and rejects draft token 5.

Compute greedy IDs after logits processors and before `apply_sampling_constraints`, then pass them to `rejection_sample`. This keeps processor masks effective and preserves the original argmax tie-break before top-k truncation. The two greedy all-gathers now run before candidate gathering.

### Does this PR introduce _any_ user-facing change?

Fixes incorrect tokens and draft acceptance for greedy requests batched with random requests. No serving API or configuration changes.

### How was this patch tested?

Tested on Ascend `9d9b9ed` with its paired vLLM `a97dacb`:

```bash
TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m pytest -sv tests/ut/sample/
```

Applying only the test changes gives **32 passed, 8 failed**. With the fix, **40 passed**. The 16 new cases cover pure-greedy/mixed batches, masks, ties, acceptance/rejection, and a random row whose expected result differs from greedy sampling.

Native TP1 and TP2 checks passed all 16 cases per rank; the original code failed the 8 mixed cases. These use real HCCL and rejection kernels with fixed bonus and random inputs. Python 3.12, Torch 2.10.0+cpu, torch-npu 2.10.0.post4 and triton-ascend 3.2.2. The test environment had pre-existing FastAPI and Transformers dependency conflicts.

Applicable pre-commit hooks passed for both changed Python files, including Typos and Gitleaks.

Greedy argmax now scans the local vocabulary shard. Measured target preprocessing time with vocabulary 131072, draft length 3, batch 256 and top-k=64:

| Target preprocessing | Before | After |
|---|---:|---:|
| TP1 | 4.9284 ms | 5.2203 ms |
| TP2 | 2.6743 ms | 2.7807 ms |

Timings cover target preprocessing (cloning, constraints and greedy reduction) only. Values are medians from 20 alternating AB/BA groups of 10 iterations after warmup.

AI assistance: Codex was used for the patch, tests and PR description.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
