### PR TITLE
[0.27.1rc][Platform] Default EP HCCL groups to AIV

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -71,6 +71,7 @@ _SHARED_EXPERTS_CALCULATION_STREAM = None
 _CP_CHUNKEDPREFILL_COMM_STREAM = None
 _ASCEND_CUSTOMOP_IS_REIGISTERED = False
 _DEFAULT_BUFFER_SIZE = 200
+_HCCL_OP_EXPANSION_MODE_AIV = 3
 _MIN_DP_BUFFER_SIZE = 50
 _DYNAMIC_EPLB_BUFFER_SIZE = 100
 _IS_MOE_MODEL = None
@@ -970,6 +971,8 @@ def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):
 def create_hccl_pg_options(group_name: str):
     options = torch_npu._C._distributed_c10d.ProcessGroupHCCL.Options()
     hccl_config = get_hccl_config_for_pg_options(group_name) or {}
+    if group_name == "ep":
+        hccl_config["hccl_op_expansion_mode"] = _HCCL_OP_EXPANSION_MODE_AIV
     hccl_config["group_name"] = group_name
     options.hccl_config = hccl_config
     return options


### PR DESCRIPTION
### What this PR does / why we need it?

Set `hccl_op_expansion_mode` to AIV (`3`) when creating EP HCCL process groups on `releases/v0.27.1rc`, so EP collectives use an explicit mode instead of inheriting the global HCCL expansion setting.

### Does this PR introduce _any_ user-facing change?

Yes. The setting applies to the entire EP group, including metadata AllGather and AllToAllV. Other process-group options and existing buffer sizes are preserved.

### How was this patch tested?

- Existing process-group tests: `python -m pytest --noconftest tests/ut/patch/worker/patch_common/test_patch_distributed.py -q` — 17 passed.
- Isolated configuration smoke check: EP selects mode 3; other groups retain their configured modes and buffer sizes.
- `ruff check vllm_ascend/utils.py` and `ruff format --check vllm_ascend/utils.py` passed.
- `bash format.sh ci` could not complete: pre-commit failed while downloading the Go toolchain for actionlint (`RemoteDisconnected`), before running the hooks.
- NPU end-to-end inference was not rerun for this PR.
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
