### PR TITLE
[Performance][MRV2] Vectorize seq_lens_cpu host update

### DIFF
--- a/tests/ut/worker/test_seq_lens_cpu_vectorization.py
+++ b/tests/ut/worker/test_seq_lens_cpu_vectorization.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import torch
+
+
+def _load_update_seq_lens_cpu():
+    source_path = Path(__file__).parents[3] / "vllm_ascend" / "worker" / "v2" / "model_runner.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    runner_cls = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "NPUModelRunner"
+    )
+    update_method = next(
+        node for node in runner_cls.body if isinstance(node, ast.FunctionDef) and node.name == "_update_seq_lens_cpu"
+    )
+    method_source = ast.get_source_segment(source_path.read_text(encoding="utf-8"), update_method)
+    namespace: dict[str, object] = {}
+    exec(
+        "from __future__ import annotations\n" + textwrap.dedent(method_source),
+        {"np": np},
+        namespace,
+    )
+    return namespace["_update_seq_lens_cpu"]
+
+
+def test_update_seq_lens_cpu_uses_batch_arrays_for_active_prefix():
+    update_seq_lens_cpu = _load_update_seq_lens_cpu()
+    runner = SimpleNamespace()
+    runner.speculator = None
+    num_computed_tokens_cpu = torch.tensor([100, 11, 22, 33, 44, 55], dtype=torch.int32)
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={},
+        num_computed_tokens_cpu=num_computed_tokens_cpu,
+        num_computed_tokens_np=num_computed_tokens_cpu.numpy(),
+    )
+    seq_lens_cpu = torch.full((6,), 888, dtype=torch.int32)
+    runner.input_buffers = SimpleNamespace(
+        seq_lens_cpu=seq_lens_cpu,
+        seq_lens_np=seq_lens_cpu.numpy(),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={},
+        scheduled_cached_reqs=SimpleNamespace(req_ids=[]),
+    )
+
+    update_seq_lens_cpu(
+        runner,
+        scheduler_output,
+        ["logical_0", "logical_1", "logical_2"],
+        np.array([4, 0, 2], dtype=np.int32),
+        np.array([3, 5, 7], dtype=np.int32),
+    )
+
+    np.testing.assert_array_equal(
+        runner.input_buffers.seq_lens_np,
+        np.array([47, 105, 29, 888, 888, 888], dtype=np.int32),
+    )
+    torch.testing.assert_close(
+        runner.input_buffers.seq_lens_cpu,
+        torch.tensor([47, 105, 29, 888, 888, 888], dtype=torch.int32),
+    )
+    assert runner.input_buffers.seq_lens_np.dtype == np.int32
+    assert np.shares_memory(runner.input_buffers.seq_lens_np, runner.input_buffers.seq_lens_cpu.numpy())
+
+
+def test_update_seq_lens_cpu_consumes_spec_corrected_host_state():
+    update_seq_lens_cpu = _load_update_seq_lens_cpu()
+    runner = SimpleNamespace()
+    runner.speculator = object()
+    runner.num_computed_tokens_event = Mock()
+    num_computed_tokens_cpu = torch.tensor([0, 11, 22, 33, 44, 55], dtype=torch.int32)
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={"a": 3, "c": 4},
+        num_computed_tokens_cpu=num_computed_tokens_cpu,
+        num_computed_tokens_np=num_computed_tokens_cpu.numpy(),
+    )
+    runner.num_computed_tokens_cpu = torch.tensor([0, 101, 202, 303, 404, 505], dtype=torch.int32)
+    seq_lens_cpu = torch.full((6,), -1, dtype=torch.int32)
+    runner.input_buffers = SimpleNamespace(
+        seq_lens_cpu=seq_lens_cpu,
+        seq_lens_np=seq_lens_cpu.numpy(),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={},
+        scheduled_cached_reqs=SimpleNamespace(req_ids=["a", "c"]),
+    )
+
+    update_seq_lens_cpu(
+        runner,
+        scheduler_output,
+        ["a", "b", "c"],
+        np.array([3, 1, 4], dtype=np.int32),
+        np.array([7, 5, 2], dtype=np.int32),
+    )
+
+    runner.num_computed_tokens_event.synchronize.assert_called_once_with()
+    np.testing.assert_array_equal(
+        runner.req_states.num_computed_tokens_np,
+        np.array([0, 11, 22, 303, 404, 55], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        runner.input_buffers.seq_lens_np,
+        np.array([310, 16, 406, -1, -1, -1], dtype=np.int32),
+    )
+    torch.testing.assert_close(
+        runner.input_buffers.seq_lens_cpu,
+        torch.tensor([310, 16, 406, -1, -1, -1], dtype=torch.int32),
+    )

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -331,10 +331,14 @@ class NPUModelRunner(GPUModelRunner):
 
         req_ids = batch_req_state.req_ids
 
-        self._update_seq_lens_cpu(scheduler_output, req_ids)
-
         num_scheduled_tokens_np = batch_req_state.num_scheduled_tokens
         idx_mapping_np = batch_req_state.idx_mapping_np
+        self._update_seq_lens_cpu(
+            scheduler_output,
+            req_ids,
+            idx_mapping_np,
+            num_scheduled_tokens_np,
+        )
         idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
         num_reqs = len(req_ids)
 
@@ -704,6 +708,8 @@ class NPUModelRunner(GPUModelRunner):
         self,
         scheduler_output: SchedulerOutput,
         req_ids: list[str],
+        idx_mapping_np: np.ndarray | None = None,
+        num_scheduled_tokens_np: np.ndarray | None = None,
     ):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
 
@@ -717,10 +723,24 @@ class NPUModelRunner(GPUModelRunner):
                 self.req_states.num_computed_tokens_cpu[req_index] = self.num_computed_tokens_cpu[req_index]
 
         # update seq_lens_cpu
-        for i, req_id in enumerate(req_ids):  # type: ignore
-            req_index = self.req_states.req_id_to_index[req_id]
-            num_computed_tokens = self.req_states.num_computed_tokens_cpu[req_index]
-            self.input_buffers.seq_lens_cpu[i] = num_computed_tokens + num_scheduled_tokens[req_id]
+        num_reqs = len(req_ids)
+        if idx_mapping_np is None:
+            idx_mapping_np = np.fromiter(
+                (self.req_states.req_id_to_index[req_id] for req_id in req_ids),
+                dtype=np.int32,
+                count=num_reqs,
+            )
+        if num_scheduled_tokens_np is None:
+            num_scheduled_tokens_np = np.fromiter(
+                (num_scheduled_tokens[req_id] for req_id in req_ids),
+                dtype=np.int32,
+                count=num_reqs,
+            )
+        np.add(
+            self.req_states.num_computed_tokens_np[idx_mapping_np],
+            num_scheduled_tokens_np,
+            out=self.input_buffers.seq_lens_np[:num_reqs],
+        )
 
     def _pad_query_start_loc_for_fia(
         self,


### PR DESCRIPTION
### What this PR does

- Reuse the existing batch-aligned `idx_mapping_np` and `num_scheduled_tokens` arrays for the generic V2 `seq_lens_cpu` host update.
- Replace the final per-request Python ID lookup/scalar-write loop with a NumPy active-prefix assignment.
- Preserve speculative D2H correction ordering and the shared Torch/NumPy CPU storage semantics.
- Leave the 310P specialization and adjacent metadata paths unchanged.

### Validation

- `pytest -q --confcutdir=tests/ut/worker tests/ut/worker/test_seq_lens_cpu_vectorization.py` — 2 passed
- `python3 -m py_compile` on both changed Python files
- `python3 -m ruff check` on both changed files
- `python3 -m ruff format --check` on both changed files
- `git diff --check`

The focused tests cover shuffled request-to-storage mapping, speculative corrected host state, active-prefix exactness, inactive-tail preservation, dtype, and shared NumPy/Torch storage. A direct run of the broader `test_model_runner_v2.py` was unavailable in the local executor because the vLLM dependency was not installed; no dependency rebuild or NPU runtime was introduced for this change.

Scope is host-source correctness only; this PR does not claim NPU, TTFT/TPOT, end-to-end, deployment, or production speedup.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
