### PR TITLE
[Ops][Misc] Reuse MRV2 speculative draft token counts

### DIFF
--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -10,6 +10,7 @@ from vllm.config import CUDAGraphMode
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 from vllm_ascend.utils import vllm_version_is
+from vllm_ascend.worker.v2 import model_runner as model_runner_module
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -26,6 +27,172 @@ def _make_runner(need_timing: bool = True):
     runner.execute_model_state = None
     runner.is_last_pp_rank = False
     return runner
+
+
+class _CountingDraftTokens(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.get_calls = []
+
+    def get(self, key, default=None):
+        self.get_calls.append(key)
+        return super().get(key, default)
+
+
+def _make_prepare_inputs_runner(num_bonus_tokens: int = 1):
+    max_num_reqs = 8
+    max_num_tokens = 32
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.max_num_reqs = max_num_reqs
+    runner.decode_query_len = 4
+    runner.vllm_config = SimpleNamespace()
+    runner.model_config = SimpleNamespace(rswa_window=None)
+    runner.model_state = SimpleNamespace(num_new_sampled_tokens_per_step=num_bonus_tokens)
+    runner.use_dcp = False
+    runner.use_pp = False
+    runner.pcp_manager = None
+    runner.eplb = SimpleNamespace(set_batch_phase=lambda _has_prefill: None)
+    runner._update_seq_lens_cpu = lambda _scheduler_output, _req_ids: None
+    runner.input_buffers = SimpleNamespace(
+        input_ids=torch.zeros(max_num_tokens, dtype=torch.int64),
+        positions=torch.zeros(max_num_tokens, dtype=torch.int64),
+        is_padding=torch.zeros(max_num_tokens, dtype=torch.bool),
+        query_start_loc=torch.zeros(max_num_reqs + 2, dtype=torch.int32),
+        seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32),
+        seq_lens_np=np.zeros(max_num_reqs, dtype=np.int32),
+    )
+    runner.req_states = SimpleNamespace(
+        last_sampled_tokens=torch.zeros(max_num_reqs, dtype=torch.int64),
+        draft_tokens=torch.zeros(max_num_tokens, dtype=torch.int64),
+        all_token_ids=SimpleNamespace(gpu=torch.zeros(max_num_tokens, dtype=torch.int64)),
+        prefill_len=SimpleNamespace(gpu=torch.zeros(max_num_reqs, dtype=torch.int32)),
+        num_computed_tokens=SimpleNamespace(gpu=torch.zeros(max_num_reqs, dtype=torch.int32)),
+        num_computed_tokens_np=np.arange(max_num_reqs, dtype=np.int32),
+        prompt_len=SimpleNamespace(gpu=torch.zeros(max_num_reqs, dtype=torch.int32)),
+        max_seq_len=np.zeros(max_num_reqs, dtype=np.int32),
+    )
+    return runner
+
+
+def _patch_prepare_inputs_dependencies(monkeypatch):
+    captures = {}
+
+    def fake_async_copy_to_gpu(src, device=None, out=None):
+        tensor = torch.as_tensor(src, device=device)
+        if out is not None:
+            out[: tensor.numel()].copy_(tensor.reshape(-1))
+            return out
+        return tensor
+
+    def fake_build_attn_state(_config, _seq_lens_np, _num_reqs, _scheduled, num_valid_tokens):
+        captures["num_valid_tokens"] = num_valid_tokens
+        return "attn-state"
+
+    def fake_expand_idx_mapping(idx_mapping, total_num_logits, cu_num_logits, decode_query_len):
+        captures["expand_total_num_logits"] = total_num_logits
+        captures["expand_cu_num_logits"] = cu_num_logits.clone()
+        captures["expand_decode_query_len"] = decode_query_len
+        return idx_mapping.repeat_interleave(1), torch.zeros(total_num_logits, dtype=torch.int32)
+
+    def fake_combine_sampled_and_draft_tokens(*args):
+        total_num_logits = args[8]
+        captures["combine_total_num_logits"] = total_num_logits
+        return torch.arange(total_num_logits, dtype=torch.int64)
+
+    monkeypatch.setattr(model_runner_module, "async_copy_to_gpu", fake_async_copy_to_gpu)
+    monkeypatch.setattr(model_runner_module, "build_attn_state", fake_build_attn_state)
+    monkeypatch.setattr(model_runner_module, "expand_idx_mapping", fake_expand_idx_mapping)
+    monkeypatch.setattr(model_runner_module, "combine_sampled_and_draft_tokens", fake_combine_sampled_and_draft_tokens)
+    monkeypatch.setattr(model_runner_module, "prepare_pos_seq_lens", lambda *args: None)
+    monkeypatch.setattr(model_runner_module, "update_cos_sin", lambda *_args: None)
+    monkeypatch.setattr(
+        model_runner_module.vllm_model_runner.pcp, "maybe_partition_pcp_batch", lambda *args, **kwargs: args[1]
+    )
+    monkeypatch.setattr(model_runner_module, "vllm_version_is", lambda _version: False)
+    return captures
+
+
+def _make_prepare_inputs_args(req_ids, scheduled_tokens, draft_tokens):
+    num_scheduled_tokens = np.array(scheduled_tokens, dtype=np.int32)
+    batch_req_state = SimpleNamespace(
+        num_tokens=int(num_scheduled_tokens.sum()),
+        req_ids=req_ids,
+        num_scheduled_tokens=num_scheduled_tokens,
+        idx_mapping_np=np.arange(len(req_ids), dtype=np.int64),
+        has_prefill=False,
+        prefill_len_np=np.zeros(len(req_ids), dtype=np.int32),
+        num_computed_prefill_tokens_np=np.zeros(len(req_ids), dtype=np.int32),
+        is_prefilling_np=np.zeros(len(req_ids), dtype=bool),
+    )
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens=draft_tokens,
+        has_structured_output_requests=False,
+    )
+    batch_desc = SimpleNamespace(
+        num_tokens=0,
+        num_reqs=0,
+        cg_mode=CUDAGraphMode.NONE,
+    )
+    return scheduler_output, batch_req_state, batch_desc
+
+
+def test_prepare_inputs_reuses_draft_counts_for_valid_tokens_and_logits(monkeypatch):
+    runner = _make_prepare_inputs_runner(num_bonus_tokens=2)
+    captures = _patch_prepare_inputs_dependencies(monkeypatch)
+    req_ids = ["req2", "req0", "missing", "req1"]
+    draft_tokens = _CountingDraftTokens(
+        {
+            "req0": [10],
+            "req1": [20, 21],
+            "req2": [],
+        }
+    )
+    scheduler_output, batch_req_state, batch_desc = _make_prepare_inputs_args(
+        req_ids,
+        [5, 4, 3, 5],
+        draft_tokens,
+    )
+
+    input_batch = runner.prepare_inputs(scheduler_output, batch_req_state, batch_desc)
+
+    expected_draft_counts = np.array([0, 1, 0, 2], dtype=np.int32)
+    np.testing.assert_array_equal(input_batch.num_draft_tokens_per_req, expected_draft_counts)
+    assert input_batch.num_draft_tokens_per_req.dtype == np.int32
+    assert input_batch.num_draft_tokens_per_req.shape == (len(req_ids),)
+    assert draft_tokens.get_calls == req_ids
+    np.testing.assert_array_equal(
+        captures["num_valid_tokens"],
+        np.array([5, 3, 3, 3], dtype=np.int32),
+    )
+    assert input_batch.num_draft_tokens == 3
+    np.testing.assert_array_equal(input_batch.cu_num_logits_np, np.array([0, 2, 5, 7, 11], dtype=np.int32))
+    assert captures["combine_total_num_logits"] == 11
+    assert captures["expand_total_num_logits"] == 11
+    torch.testing.assert_close(captures["expand_cu_num_logits"], torch.tensor([0, 2, 5, 7, 11], dtype=torch.int32))
+
+
+def test_prepare_inputs_no_draft_keeps_valid_alias_and_skips_count_materialization(monkeypatch):
+    runner = _make_prepare_inputs_runner()
+    captures = _patch_prepare_inputs_dependencies(monkeypatch)
+
+    def fail_fromiter(*_args, **_kwargs):
+        raise AssertionError("no-draft path must not materialize draft counts")
+
+    monkeypatch.setattr(model_runner_module.np, "fromiter", fail_fromiter)
+    scheduler_output, batch_req_state, batch_desc = _make_prepare_inputs_args(
+        ["req0", "req1"],
+        [3, 2],
+        {},
+    )
+
+    input_batch = runner.prepare_inputs(scheduler_output, batch_req_state, batch_desc)
+
+    assert captures["num_valid_tokens"] is batch_req_state.num_scheduled_tokens
+    assert input_batch.num_draft_tokens_per_req is None
+    assert input_batch.num_draft_tokens == 0
+    np.testing.assert_array_equal(input_batch.cu_num_logits_np, np.array([0, 1, 2], dtype=np.int32))
+    assert input_batch.expanded_idx_mapping.data_ptr() == input_batch.idx_mapping.data_ptr()
 
 
 def test_execute_model_records_profiling_time():

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -338,15 +338,16 @@ class NPUModelRunner(GPUModelRunner):
         idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
         num_reqs = len(req_ids)
 
+        draft_tokens = scheduler_output.scheduled_spec_decode_tokens
+        num_draft_tokens_per_req = None
         num_valid_tokens = num_scheduled_tokens_np
-        if scheduler_output.scheduled_spec_decode_tokens:
-            num_valid_tokens = np.array(
-                [
-                    num_toks - len(scheduler_output.scheduled_spec_decode_tokens.get(i, []))
-                    for num_toks, i in zip(num_scheduled_tokens_np, req_ids)
-                ],
+        if draft_tokens:
+            num_draft_tokens_per_req = np.fromiter(
+                (len(draft_tokens.get(req_id, ())) for req_id in req_ids),
                 dtype=np.int32,
+                count=num_reqs,
             )
+            num_valid_tokens = num_scheduled_tokens_np - num_draft_tokens_per_req
         attn_state = build_attn_state(
             self.vllm_config,
             self.input_buffers.seq_lens_np,
@@ -355,9 +356,6 @@ class NPUModelRunner(GPUModelRunner):
             num_valid_tokens,
         )
 
-        # Get the number of draft tokens for each request.
-        draft_tokens = scheduler_output.scheduled_spec_decode_tokens
-        num_draft_tokens_per_req = None
         if not draft_tokens:
             # No draft token scheduled (common case).
             total_num_draft_tokens = 0
@@ -367,11 +365,6 @@ class NPUModelRunner(GPUModelRunner):
             expanded_idx_mapping = idx_mapping
             expanded_local_pos = torch.zeros(num_reqs, dtype=torch.int32, device=self.device)
         else:
-            num_draft_tokens_per_req = np.fromiter(
-                (len(draft_tokens.get(req_id, ())) for req_id in req_ids),
-                dtype=np.int32,
-                count=num_reqs,
-            )
             num_bonus_tokens = self.model_state.num_new_sampled_tokens_per_step
             total_num_draft_tokens = int(num_draft_tokens_per_req.sum())
             total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -365,6 +365,7 @@ class NPUModelRunner(GPUModelRunner):
             expanded_idx_mapping = idx_mapping
             expanded_local_pos = torch.zeros(num_reqs, dtype=torch.int32, device=self.device)
         else:
+            assert num_draft_tokens_per_req is not None
             num_bonus_tokens = self.model_state.num_new_sampled_tokens_per_step
             total_num_draft_tokens = int(num_draft_tokens_per_req.sum())
             total_num_logits = num_reqs * num_bonus_tokens + total_num_draft_tokens


### PR DESCRIPTION
### What this PR does / why we need it?

`NPUModelRunner.prepare_inputs` currently traverses `scheduled_spec_decode_tokens` twice when speculative drafts are present: once to derive `num_valid_tokens` and again to build per-request draft counts for logits bookkeeping. This PR materializes the request-ordered draft counts once as `np.int32`, reuses the same array for both consumers, and leaves the common no-draft path without draft-count materialization.

The change also adds focused unit coverage for request ordering, sparse/missing keys, dtype/shape, valid-token subtraction, downstream logits bookkeeping, and the no-draft path.

### Does this PR introduce _any_ user-facing change?

No. This is an internal MRV2 host-bookkeeping optimization and does not change public APIs or intended inference semantics.

### How was this patch tested?

- `ruff check` passed for the touched files.
- `ruff format --check` passed for the touched files.
- `git diff --check` passed.
- A source invariant check confirms a single draft-count materialization/traversal in the draft-present path.
- The two focused pytest cases were invoked locally, but collection in the lightweight local environment is blocked because the `vllm` package is not installed (`ModuleNotFoundError`). No local pytest-pass claim is made; the PR CI environment is used for integrated validation.
- A frozen source-equivalent CPU bookkeeping falsifier passed exact correctness and showed the candidate faster in 2000/2000 paired N=256 observations. This is component-level CPU evidence only, not an NPU or end-to-end performance claim.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
