### PR TITLE
[v0.27.1rc][BugFix] fix classify PD recompute requests as decode

### DIFF
--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -924,6 +924,23 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertTrue(torch.all(metadata.slot_mapping == base_inputs["slot_mapping"]))
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
+        # PD recomputes the last prompt token (N-1 computed). Metadata building
+        # runs outside set_current_vllm_config, unlike DCP manager initialization.
+        self.mock_vllm_config.parallel_config.decode_context_parallel_size = 16
+        self.mock_vllm_config.kv_transfer_config = SimpleNamespace(is_kv_consumer=True, is_kv_producer=False)
+        common_attn_metadata.is_prefilling = torch.ones(3, dtype=torch.bool)
+        ascend_config = SimpleNamespace(scheduler_config=SimpleNamespace(recompute_scheduler_enable=True))
+        with (
+            patch("vllm.config.get_current_vllm_config_or_none", return_value=None),
+            patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config),
+        ):
+            metadata = builder.build(0, common_attn_metadata)
+        self.assertEqual(metadata.num_decodes, 3)
+        self.assertEqual(metadata.num_prefills, 0)
+        self.assertEqual(metadata.num_decode_tokens, 3)
+        self.assertIsNone(metadata.prefill)
+        self.assertEqual(metadata.decode.seq_lens_list, [4, 5, 6])
+
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
     def test_build_decode_metadata_without_disable_padded_drafter_batch(self, mock_get_cos_and_sin_mla):
         common_attn_metadata = MagicMock()

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -53,6 +53,7 @@ from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
     ACL_FORMAT_FRACTAL_NZ,
+    is_pd_decode_recompute_scheduler_enabled,
     maybe_trans_nz,
     vllm_version_is,
     weak_ref_tensors,
@@ -467,9 +468,14 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             split_decodes_and_prefills(
                 common_attn_metadata,
                 decode_threshold=self.decode_threshold,
-                treat_short_extends_as_decodes=not (
-                    parallel_config.prefill_context_parallel_size > 1
-                    or parallel_config.decode_context_parallel_size > 1
+                # Metadata building can run outside the current-config context.
+                # Use the builder's config for the PD last-token recompute step.
+                treat_short_extends_as_decodes=(
+                    is_pd_decode_recompute_scheduler_enabled(self.vllm_config)
+                    or not (
+                        parallel_config.prefill_context_parallel_size > 1
+                        or parallel_config.decode_context_parallel_size > 1
+                    )
                 ),
             )
         )


### PR DESCRIPTION
### What this PR does / why we need it?
When performing the calculation, the first request of node d should be considered as decode. This is because the dcp manager does it this way, and the mla backend has not handled it correctly.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
