### PR TITLE
[BugFix][Quantization] Fix W4A8 MXFP EPLB runtime

### DIFF
--- a/tests/ut/quantization/methods/test_w4a8_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a8_mxfp4.py
@@ -162,7 +162,7 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
     @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch.npu.empty_cache")
     @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch_npu")
     def test_process_weights_creates_eplb_weight_lists(self, mock_npu, mock_empty_cache):
-        mock_npu.npu_format_cast.side_effect = lambda tensor, *args, **kwargs: tensor
+        mock_npu.float4_e2m1fn_x2 = 296
         self.scheme.use_expert_weight_list = True
         layer = nn.Module()
         layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 256, 64), dtype=torch.uint8), requires_grad=False)
@@ -170,27 +170,82 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
         layer.w13_weight_scale = nn.Parameter(
             torch.randint(0, 255, (8, 256, 4), dtype=torch.uint8), requires_grad=False
         )
-        layer.w2_weight_scale = nn.Parameter(
-            torch.randint(0, 255, (8, 128, 8), dtype=torch.uint8), requires_grad=False
-        )
+        layer.w2_weight_scale = nn.Parameter(torch.randint(0, 255, (8, 128, 8), dtype=torch.uint8), requires_grad=False)
 
         self.scheme.process_weights_after_loading(layer)
 
         weight_views = self.scheme.get_eplb_weight_views(layer)
         self.assertEqual(len(weight_views), 4)
-        self.assertEqual(layer.w13_weight_list[0].shape, (64, 256))
+        self.assertEqual(layer.w13_weight_list[0].shape, (256, 64))
         self.assertEqual(layer.w2_weight_list[0].shape, (128, 128))
         self.assertEqual(layer.w13_weight_scale_list[0].shape, (2, 256, 2))
         self.assertEqual(layer.w2_weight_scale_list[0].shape, (4, 128, 2))
         for expert_list in weight_views:
             self.assertEqual(len(expert_list), self.num_experts)
             self.assertTrue(all(expert.storage_offset() == 0 for expert in expert_list))
-        self.assertEqual(mock_npu.npu_format_cast.call_count, 2 * self.num_experts)
+        self.assertEqual(mock_npu.npu_format_cast_.call_count, 2 * self.num_experts)
+        mock_npu.npu_format_cast.assert_not_called()
         mock_empty_cache.assert_called_once_with()
         self.assertFalse(hasattr(layer, "w13_weight"))
         self.assertFalse(hasattr(layer, "w2_weight"))
         self.assertFalse(hasattr(layer, "w13_weight_scale"))
         self.assertFalse(hasattr(layer, "w2_weight_scale"))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch.npu.empty_cache")
+    @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch_npu")
+    def test_process_situ_eplb_preserves_native_w13_fp4(self, mock_npu, mock_empty_cache):
+        mock_npu.float4_e2m1fn_x2 = 296
+        self.scheme.use_expert_weight_list = True
+        layer = nn.Module()
+        layer.activation = MoEActivation.SITU
+        layer.w13_weight = nn.Parameter(
+            torch.zeros(
+                self.num_experts,
+                self.intermediate_size,
+                self.hidden_size // 2,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.w2_weight = nn.Parameter(
+            torch.zeros(
+                self.num_experts,
+                self.hidden_size,
+                self.intermediate_size // 2,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.w13_weight_scale = nn.Parameter(
+            torch.zeros(
+                self.num_experts,
+                self.intermediate_size,
+                self.hidden_size // 32,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+        layer.w2_weight_scale = nn.Parameter(
+            torch.zeros(
+                self.num_experts,
+                self.hidden_size,
+                self.intermediate_size // 32,
+                dtype=torch.uint8,
+            ),
+            requires_grad=False,
+        )
+
+        self.scheme.process_weights_after_loading(layer)
+
+        format_calls = mock_npu.npu_format_cast_.call_args_list
+        self.assertEqual(len(format_calls), 2 * self.num_experts)
+        for call in format_calls[: self.num_experts]:
+            self.assertEqual(call.args[0].dtype, torch.float4_e2m1fn_x2)
+            self.assertEqual(call.kwargs["input_dtype"], torch.float4_e2m1fn_x2)
+        for call in format_calls[self.num_experts :]:
+            self.assertEqual(call.args[0].dtype, torch.uint8)
+            self.assertEqual(call.kwargs["input_dtype"], mock_npu.float4_e2m1fn_x2)
+        mock_empty_cache.assert_called_once_with()
 
     @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch_npu")
     def test_native_fp4_is_limited_to_gmsq_w13(self, mock_npu):

--- a/tests/ut/quantization/methods/test_w4a8_mxfp4.py
+++ b/tests/ut/quantization/methods/test_w4a8_mxfp4.py
@@ -84,6 +84,44 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
         mock_ascend.return_value = create_mock_ascend_config()
         self.scheme = AscendW4A8MXFPDynamicFusedMoEMethod()
 
+    def test_model_runner_v2_eplb_uses_expert_weight_list(self):
+        vllm_config = create_mock_vllm_config()
+        vllm_config.use_v2_model_runner = True
+        vllm_config.parallel_config.enable_eplb = True
+        with (
+            patch(
+                "vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.get_ascend_config",
+                return_value=create_mock_ascend_config(),
+            ),
+        ):
+            scheme = AscendW4A8MXFPDynamicFusedMoEMethod()
+
+        self.assertTrue(scheme.use_expert_weight_list)
+
+    def test_model_runner_v1_dynamic_eplb_uses_expert_weight_list(self):
+        vllm_config = create_mock_vllm_config()
+        vllm_config.use_v2_model_runner = False
+        ascend_config = create_mock_ascend_config()
+        ascend_config.eplb_config.dynamic_eplb = True
+        with (
+            patch(
+                "vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.get_ascend_config",
+                return_value=ascend_config,
+            ),
+        ):
+            scheme = AscendW4A8MXFPDynamicFusedMoEMethod()
+
+        self.assertTrue(scheme.dynamic_eplb)
+        self.assertTrue(scheme.use_expert_weight_list)
+
     def test_get_weight_static_method(self):
         result = self.scheme.get_weight(self.num_experts, self.intermediate_size, self.hidden_size, torch.bfloat16)
         self.assertEqual(result["w13_weight"].dtype, torch.uint8)
@@ -120,6 +158,39 @@ class TestAscendW4A8MXFP4MoEMethod(TestBase):
         self.assertEqual(layer.w2_weight.shape, (8, 128, 128))
         self.assertEqual(layer.w13_weight_scale.shape, (8, 2, 256, 2))
         self.assertEqual(layer.w2_weight_scale.shape, (8, 4, 128, 2))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch.npu.empty_cache")
+    @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch_npu")
+    def test_process_weights_creates_eplb_weight_lists(self, mock_npu, mock_empty_cache):
+        mock_npu.npu_format_cast.side_effect = lambda tensor, *args, **kwargs: tensor
+        self.scheme.use_expert_weight_list = True
+        layer = nn.Module()
+        layer.w13_weight = nn.Parameter(torch.randint(0, 255, (8, 256, 64), dtype=torch.uint8), requires_grad=False)
+        layer.w2_weight = nn.Parameter(torch.randint(0, 255, (8, 128, 128), dtype=torch.uint8), requires_grad=False)
+        layer.w13_weight_scale = nn.Parameter(
+            torch.randint(0, 255, (8, 256, 4), dtype=torch.uint8), requires_grad=False
+        )
+        layer.w2_weight_scale = nn.Parameter(
+            torch.randint(0, 255, (8, 128, 8), dtype=torch.uint8), requires_grad=False
+        )
+
+        self.scheme.process_weights_after_loading(layer)
+
+        weight_views = self.scheme.get_eplb_weight_views(layer)
+        self.assertEqual(len(weight_views), 4)
+        self.assertEqual(layer.w13_weight_list[0].shape, (64, 256))
+        self.assertEqual(layer.w2_weight_list[0].shape, (128, 128))
+        self.assertEqual(layer.w13_weight_scale_list[0].shape, (2, 256, 2))
+        self.assertEqual(layer.w2_weight_scale_list[0].shape, (4, 128, 2))
+        for expert_list in weight_views:
+            self.assertEqual(len(expert_list), self.num_experts)
+            self.assertTrue(all(expert.storage_offset() == 0 for expert in expert_list))
+        self.assertEqual(mock_npu.npu_format_cast.call_count, 2 * self.num_experts)
+        mock_empty_cache.assert_called_once_with()
+        self.assertFalse(hasattr(layer, "w13_weight"))
+        self.assertFalse(hasattr(layer, "w2_weight"))
+        self.assertFalse(hasattr(layer, "w13_weight_scale"))
+        self.assertFalse(hasattr(layer, "w2_weight_scale"))
 
     @patch("vllm_ascend.quantization.methods.w4a8.w4a8_mxfp4.torch_npu")
     def test_native_fp4_is_limited_to_gmsq_w13(self, mock_npu):

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1250,10 +1250,14 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
         output_dtype = gmm2_kwargs.pop("output_dtype")
 
-        if isinstance(weight, list) and len(weight) != 1:
-            raise ValueError(f"w2 must have a single tensor in MXFP path, but got {len(weight)}.")
-        if isinstance(weight_scale, list) and len(weight_scale) != 1:
-            raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
+        # W4A8MXFP EPLB keeps one independent NZ tensor per physical expert,
+        # and the A5 GMM operator accepts the resulting multi-tensor list.
+        # Other MXFP paths still require a packed tensor.
+        if mxfp_quant_dtype != QuantType.W4A8MXFP:
+            if isinstance(weight, list) and len(weight) != 1:
+                raise ValueError(f"w2 must have a single tensor in MXFP path, but got {len(weight)}.")
+            if isinstance(weight_scale, list) and len(weight_scale) != 1:
+                raise ValueError(f"w2_scale must have a single tensor in MXFP path, but got {len(weight_scale)}.")
         gmm2_weight = weight if isinstance(weight, list) else [weight]
         gmm2_scale = weight_scale if isinstance(weight_scale, list) else [weight_scale]
 
@@ -1272,7 +1276,7 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
             gmm2_scale = None  # type: ignore[assignment]
-            gmm2_kwargs.update({"antiquant_scale": [weight_scale]})
+            gmm2_kwargs.update({"antiquant_scale": weight_scale if isinstance(weight_scale, list) else [weight_scale]})
 
         return torch_npu.npu_grouped_matmul(
             x=[hidden_states],

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+import torch_npu
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -76,6 +77,31 @@ EPLB_EXPERT_WEIGHT_NAMES = {
     (QuantType.W8A8MXFP, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
     (QuantType.W8A8MXFP, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
 }
+
+
+_W4A8MXFP_NZ_WEIGHT_NAMES = {
+    "w13_weight_list",
+    "w2_weight_list",
+}
+
+
+def _new_w4a8_mxfp_nz_buffer(expert_tensor: torch.Tensor) -> torch.Tensor:
+    """Create an offset-0 NZ receive buffer matching an MXFP expert."""
+    buffer_tensor = torch.empty(
+        expert_tensor.shape,
+        dtype=expert_tensor.dtype,
+        device=expert_tensor.device,
+    )
+    input_dtype = (
+        torch.float4_e2m1fn_x2 if expert_tensor.dtype == torch.float4_e2m1fn_x2 else torch_npu.float4_e2m1fn_x2
+    )
+    torch_npu.npu_format_cast_(
+        buffer_tensor,
+        29,
+        customize_dtype=torch.float8_e4m3fn,
+        input_dtype=input_dtype,
+    )
+    return buffer_tensor
 
 
 class VllmEplbAdaptor:
@@ -139,9 +165,13 @@ class VllmEplbAdaptor:
                 continue
             buffer_tensor_shapes[expert_weight_key] = expert_tensor_shapes
             self.buffer_tensor_list[expert_weight_key] = [[] for _ in range(num_buffer_tensor)]
+            quant_type = expert_weight_key[0]
             for buffer_id in range(num_buffer_tensor):
-                for expert_tensor in expert_tensors:
-                    buffer_tensor = torch.empty_like(expert_tensor)
+                for name, expert_tensor in zip(expert_weight_names, expert_tensors):
+                    if quant_type == QuantType.W4A8MXFP and name in _W4A8MXFP_NZ_WEIGHT_NAMES:
+                        buffer_tensor = _new_w4a8_mxfp_nz_buffer(expert_tensor)
+                    else:
+                        buffer_tensor = torch.empty_like(expert_tensor)
                     self.buffer_tensor_list[expert_weight_key][buffer_id].append(buffer_tensor)
 
     def init_expert_param_per_layer(self):

--- a/vllm_ascend/eplb/adaptor/vllm_adaptor.py
+++ b/vllm_ascend/eplb/adaptor/vllm_adaptor.py
@@ -59,6 +59,18 @@ EPLB_EXPERT_WEIGHT_NAMES = {
         "w13_scale_bias_list",
         "w2_scale_bias_list",
     ),
+    (QuantType.W4A8MXFP, False): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_list",
+        "w2_weight_scale_list",
+    ),
+    (QuantType.W4A8MXFP, True): (
+        "w13_weight_list",
+        "w2_weight_list",
+        "w13_weight_scale_list",
+        "w2_weight_scale_list",
+    ),
     (QuantType.W4A4MXFP, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
     (QuantType.W4A4MXFP, True): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
     (QuantType.W8A8MXFP, False): ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"),
@@ -138,8 +150,6 @@ class VllmEplbAdaptor:
         for local_idx, layer in enumerate(self.moe_layers):
             quant_type = QuantType.NONE if self.model.quant_config is None else layer.quant_type
             expert_weight_key = (quant_type, get_ascend_config().enable_fused_mc2 == 1)
-            if expert_weight_key[0] == QuantType.W4A8MXFP:
-                raise RuntimeError(f"EPLB not support {quant_type}")
             if expert_weight_key not in EPLB_EXPERT_WEIGHT_NAMES:
                 raise ValueError(f"EPLB not support {quant_type} with fused MC2 {expert_weight_key[1]}")
             expert_weight_names = EPLB_EXPERT_WEIGHT_NAMES[expert_weight_key]

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -45,7 +45,7 @@ def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation=None):
 
 def _gmm_swiglu_quant_fusion_enabled(use_mxfp_quant, fusion, dynamic_eplb, activation=None):
     activation_name = getattr(activation, "value", activation)
-    return (use_mxfp_quant or (fusion and not dynamic_eplb)) and activation_name not in (
+    return ((use_mxfp_quant or fusion) and not dynamic_eplb) and activation_name not in (
         "situ",
         "swigluoai_uninterleave",
     )
@@ -557,7 +557,11 @@ def quant_apply_mlp(
             elif is_swigluoai_uninterleave:
                 scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, _output_dtype)
             else:
-                scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
+                scale = (
+                    [item.to(w2_scale[0].dtype) for item in w1_scale]
+                    if isinstance(w1_scale, list)
+                    else [w1_scale]
+                )
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -557,11 +557,7 @@ def quant_apply_mlp(
             elif is_swigluoai_uninterleave:
                 scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, _output_dtype)
             else:
-                scale = (
-                    [item.to(w2_scale[0].dtype) for item in w1_scale]
-                    if isinstance(w1_scale, list)
-                    else [w1_scale]
-                )
+                scale = [item.to(w2_scale[0].dtype) for item in w1_scale] if isinstance(w1_scale, list) else [w1_scale]
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],

--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -119,9 +119,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         ascend_config = get_ascend_config()
         self.dynamic_eplb = False if vllm_config.use_v2_model_runner else ascend_config.eplb_config.dynamic_eplb
         self.use_expert_weight_list = (
-            (vllm_config.use_v2_model_runner is True and vllm_config.parallel_config.enable_eplb is True)
-            or self.dynamic_eplb
-        )
+            vllm_config.use_v2_model_runner is True and vllm_config.parallel_config.enable_eplb is True
+        ) or self.dynamic_eplb
 
     @staticmethod
     def get_weight(
@@ -161,14 +160,29 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         if x.dtype not in [torch.float8_e4m3fn]:
             topk_weights = topk_weights.to(x.dtype)
 
+        if self.use_expert_weight_list:
+            # EPLB keeps each expert as an independent N-major NZ tensor.
+            # FP8 x FP4 GroupedMatmul requires transposeWeight=true, which is
+            # represented by a transpose view. This does not allocate or copy
+            # any NPU weight storage.
+            w1 = [weight.transpose(0, 1) for weight in layer.w13_weight_list]
+            w2 = [weight.transpose(0, 1) for weight in layer.w2_weight_list]
+            w1_scale = layer.w13_weight_scale_list
+            w2_scale = layer.w2_weight_scale_list
+        else:
+            w1 = layer.w13_weight
+            w2 = layer.w2_weight
+            w1_scale = layer.w13_weight_scale
+            w2_scale = layer.w2_weight_scale
+
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         return moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
                 hidden_states=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                w1=layer.w13_weight_list if self.use_expert_weight_list else layer.w13_weight,
-                w2=layer.w2_weight_list if self.use_expert_weight_list else layer.w2_weight,
+                w1=w1,
+                w2=w2,
                 quant_type=self.quant_type,
                 dynamic_eplb=self.dynamic_eplb or self.use_expert_weight_list,
                 expert_map=layer.ascend_expert_map,
@@ -182,8 +196,8 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_scale_dtype=torch_npu.float8_e8m0fnu,
                 mxfp_per_token_scale_dtype=torch_npu.float8_e8m0fnu,
                 mxfp_use_bf16=(x.dtype in [torch.bfloat16, torch.float8_e4m3fn]),
-                w1_scale=layer.w13_weight_scale_list if self.use_expert_weight_list else layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale_list if self.use_expert_weight_list else layer.w2_weight_scale,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
             )
         )
 
@@ -204,28 +218,57 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         ]
 
     @staticmethod
-    def _format_mxfp4_weight(weight: torch.Tensor) -> torch.Tensor:
+    def _format_mxfp4_weight(weight: torch.Tensor, input_dtype) -> torch.Tensor:
         return torch_npu.npu_format_cast(
             weight,
             29,
             customize_dtype=torch.float8_e4m3fn,
-            input_dtype=torch_npu.float4_e2m1fn_x2,
+            input_dtype=input_dtype,
         )
+
+    @staticmethod
+    def _format_mxfp4_weight_inplace(weight: torch.Tensor, input_dtype) -> torch.Tensor:
+        """Convert an independent ND expert tensor to NZ in place."""
+        torch_npu.npu_format_cast_(
+            weight,
+            29,
+            customize_dtype=torch.float8_e4m3fn,
+            input_dtype=input_dtype,
+        )
+        return weight
 
     def _process_moe_weights_after_loading(self, layer, reinterpret_as_uint8: bool = False) -> None:
         for tensor_name in ("w13_weight", "w2_weight"):
             tensor = getattr(layer, tensor_name)
-            weight = tensor.data.view(torch.uint8) if reinterpret_as_uint8 else tensor.data
+            weight = tensor.data
+            input_dtype = torch_npu.float4_e2m1fn_x2
+            use_native_fp4 = (
+                not reinterpret_as_uint8
+                and tensor_name == "w13_weight"
+                and getattr(layer, "activation", None) in (MoEActivation.SITU, "situ")
+            )
+            if reinterpret_as_uint8:
+                weight = weight.view(torch.uint8)
+            elif use_native_fp4:
+                input_dtype = torch.float4_e2m1fn_x2
+
             if self.use_expert_weight_list:
-                # EPLB replaces experts independently. Split the ND tensor
-                # before format casting because cloning FRACTAL_NZ views is
-                # not supported by torch_npu.
-                weight = weight.transpose(1, 2).contiguous()
-                expert_list = [self._format_mxfp4_weight(expert.clone()) for expert in weight.unbind(dim=0)]
+                # Keep the checkpoint N-major layout while splitting it by
+                # expert. clone() creates independent storage with
+                # storage_offset == 0 for EPLB D2D replacement.
+                expert_list = []
+                for expert in weight.unbind(dim=0):
+                    expert = expert.clone()
+                    if use_native_fp4:
+                        expert = expert.view(torch.float4_e2m1fn_x2)
+                    expert = self._format_mxfp4_weight_inplace(expert, input_dtype)
+                    expert_list.append(expert)
                 setattr(layer, f"{tensor_name}_list", expert_list)
                 delattr(layer, tensor_name)
             else:
-                tensor.data = self._format_mxfp4_weight(weight).transpose(1, 2)
+                if use_native_fp4:
+                    weight = weight.view(torch.float4_e2m1fn_x2)
+                tensor.data = self._format_mxfp4_weight(weight, input_dtype).transpose(1, 2)
 
         for tensor_name in ("w13_weight_scale", "w2_weight_scale"):
             tensor = getattr(layer, tensor_name)
@@ -233,44 +276,17 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
             scale = tensor.data.reshape(g, n, k // 2, 2)
             if reinterpret_as_uint8:
                 scale = scale.view(torch.uint8)
-            scale = scale.transpose(-3, -2).contiguous()
             if self.use_expert_weight_list:
-                expert_list = [expert.clone() for expert in scale.unbind(dim=0)]
+                expert_list = [expert.transpose(0, 1).contiguous() for expert in scale.unbind(dim=0)]
                 setattr(layer, f"{tensor_name}_list", expert_list)
                 delattr(layer, tensor_name)
             else:
-                tensor.data = scale
+                tensor.data = scale.transpose(-3, -2)
 
         if self.use_expert_weight_list:
             torch.npu.empty_cache()
 
     def process_weights_after_loading(self, layer):
-        # Only GMSQ needs native FP4 Tensor metadata. Keep the legacy loader
-        # for other activations and for W2, which is consumed by ordinary GMM2.
-        w13 = layer.w13_weight.data
-        w13_input_dtype = torch_npu.float4_e2m1fn_x2
-        if getattr(layer, "activation", None) in (MoEActivation.SITU, "situ"):
-            # view(dtype) requires a torch.dtype, not torch_npu's integer type ID.
-            w13 = w13.view(torch.float4_e2m1fn_x2)
-            w13_input_dtype = torch.float4_e2m1fn_x2
-        layer.w13_weight.data = torch_npu.npu_format_cast(
-            w13,
-            29,
-            customize_dtype=torch.float8_e4m3fn,
-            input_dtype=w13_input_dtype,
-        )
-        layer.w2_weight.data = torch_npu.npu_format_cast(
-            layer.w2_weight.data,
-            29,
-            customize_dtype=torch.float8_e4m3fn,
-            input_dtype=torch_npu.float4_e2m1fn_x2,
-        )
-        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
-        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
-        g, n, k = layer.w13_weight_scale.shape
-        layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)
-        g, n, k = layer.w2_weight_scale.shape
-        layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)
         self._process_moe_weights_after_loading(layer)
 
 

--- a/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8/w4a8_mxfp4.py
@@ -110,7 +110,7 @@ class AscendW4A8MXFPDynamicLinearMethod(AscendLinearScheme):
 class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
     """FusedMoe method for Ascend W4A8_DYNAMIC."""
 
-    supports_eplb = False
+    supports_eplb = True
     quant_type: QuantType = QuantType.W4A8MXFP
 
     def __init__(self):
@@ -118,6 +118,10 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 32)
         ascend_config = get_ascend_config()
         self.dynamic_eplb = False if vllm_config.use_v2_model_runner else ascend_config.eplb_config.dynamic_eplb
+        self.use_expert_weight_list = (
+            (vllm_config.use_v2_model_runner is True and vllm_config.parallel_config.enable_eplb is True)
+            or self.dynamic_eplb
+        )
 
     @staticmethod
     def get_weight(
@@ -163,10 +167,10 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 hidden_states=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
+                w1=layer.w13_weight_list if self.use_expert_weight_list else layer.w13_weight,
+                w2=layer.w2_weight_list if self.use_expert_weight_list else layer.w2_weight,
                 quant_type=self.quant_type,
-                dynamic_eplb=self.dynamic_eplb,
+                dynamic_eplb=self.dynamic_eplb or self.use_expert_weight_list,
                 expert_map=layer.ascend_expert_map,
                 global_redundant_expert_num=layer.global_redundant_expert_num,
                 mc2_mask=layer.ascend_mc2_mask,
@@ -178,10 +182,67 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
                 mxfp_scale_dtype=torch_npu.float8_e8m0fnu,
                 mxfp_per_token_scale_dtype=torch_npu.float8_e8m0fnu,
                 mxfp_use_bf16=(x.dtype in [torch.bfloat16, torch.float8_e4m3fn]),
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
+                w1_scale=layer.w13_weight_scale_list if self.use_expert_weight_list else layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale_list if self.use_expert_weight_list else layer.w2_weight_scale,
             )
         )
+
+    @staticmethod
+    def get_eplb_weight_views(layer: torch.nn.Module) -> list:
+        if hasattr(layer, "w13_weight_list"):
+            return [
+                layer.w13_weight_list,
+                layer.w2_weight_list,
+                layer.w13_weight_scale_list,
+                layer.w2_weight_scale_list,
+            ]
+        return [
+            layer.w13_weight.transpose(1, 2),
+            layer.w2_weight.transpose(1, 2),
+            layer.w13_weight_scale.transpose(1, 2),
+            layer.w2_weight_scale.transpose(1, 2),
+        ]
+
+    @staticmethod
+    def _format_mxfp4_weight(weight: torch.Tensor) -> torch.Tensor:
+        return torch_npu.npu_format_cast(
+            weight,
+            29,
+            customize_dtype=torch.float8_e4m3fn,
+            input_dtype=torch_npu.float4_e2m1fn_x2,
+        )
+
+    def _process_moe_weights_after_loading(self, layer, reinterpret_as_uint8: bool = False) -> None:
+        for tensor_name in ("w13_weight", "w2_weight"):
+            tensor = getattr(layer, tensor_name)
+            weight = tensor.data.view(torch.uint8) if reinterpret_as_uint8 else tensor.data
+            if self.use_expert_weight_list:
+                # EPLB replaces experts independently. Split the ND tensor
+                # before format casting because cloning FRACTAL_NZ views is
+                # not supported by torch_npu.
+                weight = weight.transpose(1, 2).contiguous()
+                expert_list = [self._format_mxfp4_weight(expert.clone()) for expert in weight.unbind(dim=0)]
+                setattr(layer, f"{tensor_name}_list", expert_list)
+                delattr(layer, tensor_name)
+            else:
+                tensor.data = self._format_mxfp4_weight(weight).transpose(1, 2)
+
+        for tensor_name in ("w13_weight_scale", "w2_weight_scale"):
+            tensor = getattr(layer, tensor_name)
+            g, n, k = tensor.shape
+            scale = tensor.data.reshape(g, n, k // 2, 2)
+            if reinterpret_as_uint8:
+                scale = scale.view(torch.uint8)
+            scale = scale.transpose(-3, -2).contiguous()
+            if self.use_expert_weight_list:
+                expert_list = [expert.clone() for expert in scale.unbind(dim=0)]
+                setattr(layer, f"{tensor_name}_list", expert_list)
+                delattr(layer, tensor_name)
+            else:
+                tensor.data = scale
+
+        if self.use_expert_weight_list:
+            torch.npu.empty_cache()
 
     def process_weights_after_loading(self, layer):
         # Only GMSQ needs native FP4 Tensor metadata. Keep the legacy loader
@@ -210,6 +271,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
         layer.w13_weight_scale.data = layer.w13_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)
         g, n, k = layer.w2_weight_scale.shape
         layer.w2_weight_scale.data = layer.w2_weight_scale.data.reshape(g, n, k // 2, 2).transpose(-3, -2)
+        self._process_moe_weights_after_loading(layer)
 
 
 @register_scheme(FP8_METHOD, "ds_w4a8_moe")
@@ -236,25 +298,4 @@ class AscendW4A8MXFPDSDynamicFusedMoEMethod(AscendW4A8MXFPDynamicFusedMoEMethod)
         return param_dict
 
     def process_weights_after_loading(self, layer):
-        layer.w13_weight.data = torch_npu.npu_format_cast(
-            layer.w13_weight.data.view(torch.uint8),
-            29,
-            customize_dtype=torch.float8_e4m3fn,
-            input_dtype=torch_npu.float4_e2m1fn_x2,
-        )
-        layer.w2_weight.data = torch_npu.npu_format_cast(
-            layer.w2_weight.data.view(torch.uint8),
-            29,
-            customize_dtype=torch.float8_e4m3fn,
-            input_dtype=torch_npu.float4_e2m1fn_x2,
-        )
-        layer.w13_weight.data = layer.w13_weight.data.transpose(1, 2)
-        layer.w2_weight.data = layer.w2_weight.data.transpose(1, 2)
-        g, n, k = layer.w13_weight_scale.shape
-        layer.w13_weight_scale.data = (
-            layer.w13_weight_scale.data.reshape(g, n, k // 2, 2).view(torch.uint8).transpose(-3, -2)
-        )
-        g, n, k = layer.w2_weight_scale.shape
-        layer.w2_weight_scale.data = (
-            layer.w2_weight_scale.data.reshape(g, n, k // 2, 2).view(torch.uint8).transpose(-3, -2)
-        )
+        self._process_moe_weights_after_loading(layer, reinterpret_as_uint8=True)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR enables EPLB for W4A8 MXFP MoE weights and fixes the runtime issues found while starting Kimi-K3 with DP4/TP8/EP32 on four Ascend nodes.

- Keep one independent offset-0 NZ tensor per physical expert so EPLB can replace experts with D2D copies.
- Use zero-copy transpose views at inference time for the grouped-matmul layout; no additional model-weight storage is allocated compared with EPLB disabled.
- Support W4A8 MXFP expert tensor lists in GMM2 and create format-correct NZ receive buffers.
- Preserve native FP4 metadata for the Kimi-K3 SITU/GMSQ path and add regression coverage.

### Does this PR introduce _any_ user-facing change?

Yes. W4A8 MXFP MoE models can enable EPLB without startup/runtime failures; inference APIs are unchanged.

### How was this patch tested?

- `pytest -q tests/ut/quantization/methods/test_w4a8_mxfp4.py tests/ut/eplb/adaptor/test_vllm_adaptor.py tests/ut/device/test_device_op.py` (`33 passed`).
- Kimi-K3 service startup on four Ascend nodes with DP4/TP8/EP32 and EPLB enabled.
- 64 concurrent requests with 16K input tokens and 1K output tokens (`64/64` successful).
- Confirmed EPLB update cycles completed on all 32 ranks across 92 MoE layers.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
