### PR TITLE
[CI][BugFix] at-13946-with-15216

### DIFF
--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -90,18 +90,15 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # in their native format without explicit casting here.
         enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if enable_fused_mc2:
-            if _MEGA_MOE_SUPPORTED:
-                layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
-                layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
-            else:
+            if not _MEGA_MOE_SUPPORTED:
                 layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
                 layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
-                if enable_fused_mc2 == 1 and self.dynamic_eplb:
-                    layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
-                    layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
-                    del layer.w13_weight
-                    del layer.w2_weight
-                    torch.npu.empty_cache()
+            if _MEGA_MOE_SUPPORTED or self.dynamic_eplb:
+                layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
+                layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
+                del layer.w13_weight
+                del layer.w2_weight
+                torch.npu.empty_cache()
         else:
             layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
             layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)


### PR DESCRIPTION
### What this PR does / why we need it?

When fused MC2 uses CANN MegaMoe, unquantized expert weights are cloned into per-expert `w13_weight_list` and `w2_weight_list` tensors. The original fused `w13_weight` and `w2_weight` parameters remain registered even though the forward and dynamic EPLB paths consume the cloned lists, which keeps a redundant full copy of the local expert weights on the NPU.

This change:

- creates split expert-weight lists for CANN MegaMoe or dynamic EPLB through one shared path;
- removes the original fused parameters after the independent clones are ready;
- releases cached NPU allocator blocks after removing the unused parameters.

The execution tensors are unchanged: fused MC2 and dynamic EPLB continue to receive the same cloned per-expert weights.

For a BF16 example with 43 MoE layers, 4 local experts per rank, hidden size 4096, and expert intermediate size 2048, the calculated persistent saving per rank is:

`43 × 4 × 3 × 4096 × 2048 × 2 bytes = 8.0625 GiB`

This is a calculated weight-memory saving. No end-to-end throughput improvement is claimed.

### Does this PR introduce _any_ user-facing change?

No API or inference-output behavior changes. It reduces NPU memory usage for unquantized fused-MC2 deployments that materialize per-expert weight lists.

### How was this patch tested?

- `git diff --check github/main...HEAD`
- `python3 -m py_compile vllm_ascend/ops/fused_moe/routed_experts.py`
- Reviewed the fused-MC2 and dynamic-EPLB consumers to confirm they use `w13_weight_list` and `w2_weight_list` after split-list creation.

The focused pytest file was not run on the development control host because `pytest` is not installed there (`No module named pytest`).

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
