### PR TITLE
[BugFix][Core] Disable multistream_overlap_shared_expert with FlashComm1 on DP>1

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -604,6 +604,46 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_multistream_disabled_with_flashcomm1_and_dp_gt1(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.parallel_config.data_parallel_size = 2
+        test_vllm_config.additional_config = {
+            "multistream_overlap_shared_expert": True,
+            "enable_flashcomm1": True,
+        }
+
+        ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertFalse(ascend_config.multistream_overlap_shared_expert)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_multistream_kept_with_flashcomm1_and_dp1(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "multistream_overlap_shared_expert": True,
+            "enable_flashcomm1": True,
+        }
+
+        ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.multistream_overlap_shared_expert)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_multistream_kept_without_flashcomm1_and_dp_gt1(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.parallel_config.data_parallel_size = 2
+        test_vllm_config.additional_config = {
+            "multistream_overlap_shared_expert": True,
+        }
+
+        ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.multistream_overlap_shared_expert)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_get_ascend_config(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
         ascend_config = init_ascend_config(test_vllm_config)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -692,6 +692,18 @@ class AscendConfig:
                 "enable_fused_mc2 and multistream_overlap_shared_expert "
                 "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
             )
+        if (
+            self.multistream_overlap_shared_expert
+            and effective_flashcomm
+            and vc.parallel_config.data_parallel_size > 1
+        ):
+            self.multistream_overlap_shared_expert = False
+            logger.warning_once(
+                "multistream_overlap_shared_expert is disabled: combined with FlashComm1 (SP) "
+                "it deadlocks during engine startup (determine_available_memory dummy run) "
+                "when data_parallel_size > 1, surfacing as vector core timeout (507034). "
+                "See https://github.com/vllm-project/vllm-ascend/issues/16446."
+            )
         if self.enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED and not self._is_megamoe_supported_by_config(vc):
             self.enable_fused_mc2 = 0
             logger.warning_once(


### PR DESCRIPTION
### What this PR does / why we need it?

When all three of the following are enabled at the same time, `vllm serve` hangs during engine initialization (`determine_available_memory -> profile_run -> _dummy_run`) and dies after ~13 minutes with `aclrtSynchronizeEvent` error code 507034 (`Vector core execution timed out`), with workers across all DP ranks failing at the same second:

1. FlashComm1 / SP enabled (`VLLM_ASCEND_ENABLE_FLASHCOMM1=1` env var or `additional_config.enable_flashcomm1`, including the DSA-CP auto-enable path)
2. `multistream_overlap_shared_expert: true` in `--additional-config`
3. `--data-parallel-size > 1`

Each factor alone is harmless; only the combination on DP>1 hangs. This was verified with a 12-experiment single-variable matrix on GLM-5.2-w4a8c8 (DP2xTP8, single node 16x 910B): removing any one of the three factors makes the identical config start normally, and the full combo starts normally on DP=1 (TP16). Details in the linked issue.

This PR adds an auto-disable in `AscendConfig.derive_and_validate` (following the existing `enable_fused_mc2` auto-disable precedent for the same option): when FlashComm1 is effective and `data_parallel_size > 1`, `multistream_overlap_shared_expert` is turned off with a warning pointing to the issue. 

`multistream_overlap_shared_expert` is a pure performance option (default off), and users who need FlashComm1 on DP>1 (e.g. for DSA-CP, which requires SP) keep working - only the shared-expert side-stream overlap is sacrificed until the underlying stream-synchronization deadlock is root-caused.

Fixes #16446

### Does this PR introduce _any_ user-facing change?

Yes: when FlashComm1 is active with `data_parallel_size > 1`, `additional_config.multistream_overlap_shared_expert` is now silently ignored (disabled) with a warning log. Previously this combination deadlocked at startup; users who deliberately ran this combination without hanging (e.g. models/paths not affected by the deadlock) will lose the shared-expert overlap optimization on DP>1.

### How was this patch tested?

1. **Unit tests** (new, in `tests/ut/test_ascend_config.py`):
   - `test_multistream_disabled_with_flashcomm1_and_dp_gt1` - the mutex triggers
   - `test_multistream_kept_with_flashcomm1_and_dp1` - DP=1 keeps the option
   - `test_multistream_kept_without_flashcomm1_and_dp_gt1` - no FlashComm1 keeps the option
   - Full file result: **109 passed** (`python -m pytest tests/ut/test_ascend_config.py -v` on the test container)

2. **End-to-end** on the reproduction environment (Atlas 800 A3, 16x 910B, CANN 9.1.0, vllm 0.28.0, editable install of this branch, GLM-5.2-w4a8c8):
   - Before fix: `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` + `multistream_overlap_shared_expert:true` + DP2xTP8 dies at ~13 min with 72 vector core timeouts (multiple runs, 2 days)
   - After fix: the identical serve command starts in ~4.5 min, logs the new warning, and serves inference correctly - zero vector core timeouts. Verified both via in-place file overlay and via a fresh container with a full editable build of this branch.

Reproduce command (fails on main, passes on this branch):

```bash
export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
vllm serve /path/to/GLM-5.2-w4a8c8 --host 0.0.0.0 --port 8177 \
  --safetensors-load-strategy prefetch --api-server-count 1 \
  --data-parallel-size 2 --enable-expert-parallel --tensor-parallel-size 8 \
  --seed 1024 --served-model-name glm-5 \
  --tool-call-parser glm47 --reasoning-parser glm45 --enable-auto-tool-choice \
  --max-num-seqs 12 --max-model-len 135000 --max-num-batched-tokens 8192 \
  --trust-remote-code --gpu-memory-utilization 0.92 --quantization ascend \
  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
  --additional-config '{"multistream_overlap_shared_expert":true}' \
  --speculative-config '{"num_speculative_tokens":3,"method":"deepseek_mtp","enforce_eager":true}'
```

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
