### PR TITLE
[BugFix][Mooncake] Align MRV2 PCP and DCP KV transfers

### DIFF
--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -17,7 +17,11 @@ from vllm_ascend.attention.indexer import (
 _KERNEL_BLOCK_SIZE = 128
 
 
-def _make_builder(pcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
+def _make_builder(
+    pcp_size: int = 1,
+    dcp_size: int = 1,
+    dsa_cp: bool = False,
+) -> AscendSFAIndexerMetadataBuilder:
     kv_cache_spec = FullAttentionSpec(
         block_size=128,
         num_kv_heads=1,
@@ -26,10 +30,25 @@ def _make_builder(pcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
     )
     layer_names = ["model.layers.0.self_attn.indexer.k_cache"]
     vllm_config = MagicMock()
-    vllm_config.parallel_config.prefill_context_parallel_size = pcp_size
-    with patch(
-        "vllm_ascend.attention.indexer.select_common_block_size",
-        return_value=_KERNEL_BLOCK_SIZE,
+    vllm_config.model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(index_topk=2048),
+        hf_config=SimpleNamespace(),
+        max_model_len=1024,
+    )
+    vllm_config.parallel_config = SimpleNamespace(
+        prefill_context_parallel_size=pcp_size,
+        decode_context_parallel_size=dcp_size,
+    )
+    vllm_config.scheduler_config = SimpleNamespace(
+        max_num_seqs=4,
+        max_num_batched_tokens=16,
+    )
+    with (
+        patch(
+            "vllm_ascend.attention.indexer.select_common_block_size",
+            return_value=_KERNEL_BLOCK_SIZE,
+        ),
+        patch("vllm_ascend.attention.indexer.enable_dsa_cp", return_value=dsa_cp),
     ):
         return AscendSFAIndexerMetadataBuilder(
             kv_cache_spec,
@@ -40,7 +59,7 @@ def _make_builder(pcp_size: int = 1) -> AscendSFAIndexerMetadataBuilder:
 
 
 def _make_common_metadata() -> SimpleNamespace:
-    return SimpleNamespace(
+    metadata = SimpleNamespace(
         num_reqs=2,
         num_actual_tokens=4,
         num_input_tokens=4,
@@ -53,6 +72,15 @@ def _make_common_metadata() -> SimpleNamespace:
         group_key_idx=MagicMock(name="group_key_idx"),
         group_key_cache_idx=MagicMock(name="group_key_cache_idx"),
     )
+
+    def replace(**changes):
+        values = vars(metadata).copy()
+        values.pop("replace", None)
+        values.update(changes)
+        return SimpleNamespace(**values)
+
+    metadata.replace = replace
+    return metadata
 
 
 def test_sfa_indexer_backend_contract():
@@ -131,6 +159,107 @@ def test_sfa_indexer_metadata_builder_primes_reshape_optim(
     common = _make_common_metadata()
     metadata = builder.build(0, common)
 
+    mock_store_kv_block_metadata.assert_called_once_with(
+        metadata.slot_mapping,
+        common.group_len,
+        common.group_key_idx,
+        common.group_key_cache_idx,
+        _KERNEL_BLOCK_SIZE,
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_sfa_indexer_metadata_builder_owns_replicated_dcp_addresses(
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (torch.zeros(5, 1, 1, 8), torch.zeros(5, 1, 1, 8))
+    common = _make_common_metadata()
+
+    metadata = _make_builder(dcp_size=2).build(0, common)
+
+    torch.testing.assert_close(
+        metadata.block_table,
+        torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        metadata.slot_mapping,
+        torch.tensor([0, 1, 512, 513], dtype=torch.int32),
+    )
+    # The builder derives the replicated view without changing the local view
+    # consumed by the SFA cache backend.
+    torch.testing.assert_close(common.slot_mapping, torch.tensor([1, 2, 3, 4, 5]))
+    torch.testing.assert_close(common.block_table_tensor, torch.arange(6).view(3, 2))
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+@patch("vllm_ascend.attention.indexer.get_tp_group")
+def test_sfa_indexer_metadata_builder_pads_replicated_dcp_slots_for_dsa(
+    mock_get_tp_group,
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_tp_group.return_value.world_size = 4
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (torch.zeros(3, 1, 1, 8), torch.zeros(3, 1, 1, 8))
+    common = _make_common_metadata()
+    common.num_actual_tokens = 3
+    common.num_input_tokens = 3
+    common.query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    common.positions = torch.tensor([0, 1, 0], dtype=torch.int64)
+
+    metadata = _make_builder(dcp_size=2, dsa_cp=True).build(0, common)
+
+    torch.testing.assert_close(
+        metadata.slot_mapping,
+        torch.tensor([0, 1, 512, -1], dtype=torch.int32),
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+@patch("vllm_ascend.attention.indexer.torch.ops._C_ascend.store_kv_block_metadata", create=True)
+def test_sfa_indexer_metadata_builder_builds_pcp_dcp_slots_and_c8_groups(
+    mock_store_kv_block_metadata,
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = True
+    mock_cos_sin.return_value = (torch.zeros(5, 1, 1, 8), torch.zeros(5, 1, 1, 8))
+    common = _make_common_metadata()
+    global_batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=3,
+        query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([384], dtype=torch.int32),
+        positions=torch.tensor([0, 128, 256], dtype=torch.int64),
+        is_prefilling_np=torch.tensor([True]),
+    )
+    pcp_context = SimpleNamespace(
+        global_batch=global_batch,
+        global_block_tables=(torch.tensor([[10, 11]], dtype=torch.int32),),
+        padded_gather_idx=torch.tensor([2, 0, 1, 0], dtype=torch.int64),
+        gathered_kv_write_mask=torch.tensor([True, True, True, False]),
+    )
+
+    metadata = _make_builder(pcp_size=2, dcp_size=2).build(
+        0,
+        common,
+        pcp_context=pcp_context,
+        pcp_cache_group_idx=0,
+    )
+
+    torch.testing.assert_close(
+        metadata.block_table,
+        torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        metadata.slot_mapping,
+        torch.tensor([2816, 2560, 2688, -1], dtype=torch.int32),
+    )
     mock_store_kv_block_metadata.assert_called_once_with(
         metadata.slot_mapping,
         common.group_len,

--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -21,6 +21,7 @@ def _make_builder(
     pcp_size: int = 1,
     dcp_size: int = 1,
     dsa_cp: bool = False,
+    num_speculative_tokens: int | None = None,
 ) -> AscendSFAIndexerMetadataBuilder:
     kv_cache_spec = FullAttentionSpec(
         block_size=128,
@@ -38,10 +39,16 @@ def _make_builder(
     vllm_config.parallel_config = SimpleNamespace(
         prefill_context_parallel_size=pcp_size,
         decode_context_parallel_size=dcp_size,
+        tensor_parallel_size=4,
     )
     vllm_config.scheduler_config = SimpleNamespace(
         max_num_seqs=4,
         max_num_batched_tokens=16,
+    )
+    vllm_config.speculative_config = (
+        None
+        if num_speculative_tokens is None
+        else SimpleNamespace(num_speculative_tokens=num_speculative_tokens)
     )
     with (
         patch(
@@ -66,7 +73,11 @@ def _make_common_metadata() -> SimpleNamespace:
         slot_mapping=torch.tensor([1, 2, 3, 4, 5]),
         positions=torch.tensor([0, 1, 0, 1, 9]),
         query_start_loc=torch.tensor([0, 2, 4]),
+        query_start_loc_cpu=torch.tensor([0, 2, 4]),
         seq_lens=torch.tensor([5, 6, 7]),
+        max_query_len=2,
+        is_prefilling=torch.tensor([True, True]),
+        context_parallel_metadata=None,
         block_table_tensor=torch.arange(6).view(3, 2),
         group_len=MagicMock(name="group_len"),
         group_key_idx=MagicMock(name="group_key_idx"),
@@ -118,9 +129,12 @@ def test_sfa_indexer_metadata_builder_builds_kernel_metadata(mock_cos_sin, mock_
     assert torch.equal(metadata.cum_query_lens, common.query_start_loc[1:3])
     assert torch.equal(metadata.block_table, common.block_table_tensor[:2])
     assert metadata.block_size == _KERNEL_BLOCK_SIZE
-    assert metadata.group_len is common.group_len
-    assert metadata.group_key_idx is common.group_key_idx
-    assert metadata.group_key_cache_idx is common.group_key_cache_idx
+    assert metadata.group_len is None
+    assert metadata.group_key_idx is None
+    assert metadata.group_key_cache_idx is None
+    assert torch.equal(metadata.actual_seq_lengths_query, common.query_start_loc[1:3])
+    assert torch.equal(metadata.actual_seq_lengths_key, common.seq_lens[:2])
+    assert metadata.num_decode_tokens == 0
 
     positions = mock_cos_sin.call_args.args[0]
     assert torch.equal(positions, common.positions[:4])
@@ -161,11 +175,13 @@ def test_sfa_indexer_metadata_builder_primes_reshape_optim(
 
     mock_store_kv_block_metadata.assert_called_once_with(
         metadata.slot_mapping,
-        common.group_len,
-        common.group_key_idx,
-        common.group_key_cache_idx,
+        metadata.group_len,
+        metadata.group_key_idx,
+        metadata.group_key_cache_idx,
         _KERNEL_BLOCK_SIZE,
     )
+    assert metadata.group_len is not common.group_len
+    assert metadata.group_len.numel() == metadata.slot_mapping.numel()
 
 
 @patch("vllm_ascend.attention.indexer.get_ascend_config")
@@ -203,6 +219,7 @@ def test_sfa_indexer_metadata_builder_pads_replicated_dcp_slots_for_dsa(
     mock_get_ascend_config,
 ):
     mock_get_tp_group.return_value.world_size = 4
+    mock_get_tp_group.return_value.rank_in_group = 0
     mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
     mock_cos_sin.return_value = (torch.zeros(3, 1, 1, 8), torch.zeros(3, 1, 1, 8))
     common = _make_common_metadata()
@@ -217,6 +234,176 @@ def test_sfa_indexer_metadata_builder_pads_replicated_dcp_slots_for_dsa(
         metadata.slot_mapping,
         torch.tensor([0, 1, 512, -1], dtype=torch.int32),
     )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_sfa_indexer_metadata_builder_pads_dsa_slots_without_dcp(
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (torch.zeros(3, 1, 1, 8), torch.zeros(3, 1, 1, 8))
+    common = _make_common_metadata()
+    common.num_actual_tokens = 3
+    common.num_input_tokens = 3
+    common.query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    common.query_start_loc_cpu = torch.tensor([0, 2, 3], dtype=torch.int32)
+    common.positions = torch.tensor([0, 1, 0], dtype=torch.int64)
+    builder = _make_builder(dcp_size=1, dsa_cp=True)
+
+    with patch("vllm_ascend.attention.indexer.get_tp_group") as mock_get_tp_group:
+        mock_get_tp_group.return_value.rank_in_group = 0
+        first_metadata = builder.build(0, common)
+        second_metadata = builder.build(0, common)
+
+    torch.testing.assert_close(
+        second_metadata.slot_mapping,
+        torch.tensor([1, 2, 3, -1], dtype=torch.int32),
+    )
+    assert first_metadata.slot_mapping.data_ptr() == second_metadata.slot_mapping.data_ptr()
+    torch.testing.assert_close(
+        second_metadata.actual_seq_lengths_query,
+        torch.tensor([1, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        second_metadata.actual_seq_lengths_key,
+        torch.tensor([4, 0], dtype=torch.int32),
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+@patch("vllm_ascend.attention.indexer.get_tp_group")
+def test_sfa_indexer_draft_metadata_owns_per_step_dsa_buffers(
+    mock_get_tp_group,
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_tp_group.return_value.rank_in_group = 0
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (
+        torch.zeros(3, 1, 1, 8),
+        torch.zeros(3, 1, 1, 8),
+    )
+    builder = _make_builder(dsa_cp=True, num_speculative_tokens=3)
+    common = _make_common_metadata()
+    common.num_actual_tokens = 3
+    common.num_input_tokens = 3
+    common.query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+    common.query_start_loc_cpu = common.query_start_loc.clone()
+    common.positions = torch.tensor([0, 1, 0], dtype=torch.int64)
+
+    step_one = builder.build_for_drafting(common, 1)
+    step_one_slots = step_one.slot_mapping.clone()
+    common.slot_mapping = torch.tensor([9, 10, 11], dtype=torch.int32)
+    step_two = builder.build_for_drafting(common, 2)
+
+    assert step_one.slot_mapping.data_ptr() != step_two.slot_mapping.data_ptr()
+    assert step_one.cos.data_ptr() != step_two.cos.data_ptr()
+    assert (
+        step_one.actual_seq_lengths_query.data_ptr()
+        != step_two.actual_seq_lengths_query.data_ptr()
+    )
+    torch.testing.assert_close(step_one.slot_mapping, step_one_slots)
+    torch.testing.assert_close(
+        step_two.slot_mapping,
+        torch.tensor([9, 10, 11, -1], dtype=torch.int32),
+    )
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_sfa_indexer_draft_metadata_owns_per_step_dcp_buffers(
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (
+        torch.zeros(5, 1, 1, 8),
+        torch.zeros(5, 1, 1, 8),
+    )
+    builder = _make_builder(dcp_size=2, num_speculative_tokens=3)
+    common = _make_common_metadata()
+
+    step_one = builder.build_for_drafting(common, 1)
+    step_one_slots = step_one.slot_mapping.clone()
+    step_one_blocks = step_one.block_table.clone()
+    # The proposer owns one persistent slot tensor per logical draft step;
+    # its address is also the key for every derived metadata buffer.
+    common.slot_mapping = common.slot_mapping.clone()
+    common.positions = torch.tensor([2, 3, 2, 3, 9])
+    step_two = builder.build_for_drafting(common, 2)
+
+    assert step_one.slot_mapping.data_ptr() != step_two.slot_mapping.data_ptr()
+    assert step_one.block_table.data_ptr() != step_two.block_table.data_ptr()
+    torch.testing.assert_close(step_one.slot_mapping, step_one_slots)
+    torch.testing.assert_close(step_one.block_table, step_one_blocks)
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+@patch("vllm_ascend.attention.indexer.get_tp_group")
+def test_sfa_indexer_graph_capture_uses_slot_address_as_buffer_key(
+    mock_get_tp_group,
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_tp_group.return_value.rank_in_group = 0
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.return_value = (
+        torch.zeros(4, 1, 1, 8),
+        torch.zeros(4, 1, 1, 8),
+    )
+    builder = _make_builder(dsa_cp=True, num_speculative_tokens=3)
+    common = _make_common_metadata()
+
+    first = builder.build_for_graph_capture(common)
+    first_runtime = builder.build(common_prefix_len=0, common_attn_metadata=common)
+    common.slot_mapping = common.slot_mapping.clone()
+    second = builder.build_for_graph_capture(common)
+    second_runtime = builder.build_for_drafting(common, draft_index=1)
+
+    assert first.slot_mapping.data_ptr() != second.slot_mapping.data_ptr()
+    assert first.cos.data_ptr() != second.cos.data_ptr()
+    assert first.slot_mapping.data_ptr() == first_runtime.slot_mapping.data_ptr()
+    assert first.cos.data_ptr() == first_runtime.cos.data_ptr()
+    assert second.slot_mapping.data_ptr() == second_runtime.slot_mapping.data_ptr()
+    assert second.cos.data_ptr() == second_runtime.cos.data_ptr()
+
+
+@patch("vllm_ascend.attention.indexer.get_ascend_config")
+@patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
+def test_sfa_indexer_graph_capture_owns_stable_rope_buffers_without_dsa(
+    mock_cos_sin,
+    mock_get_ascend_config,
+):
+    mock_get_ascend_config.return_value.c8_reshape_optim_enabled = False
+    mock_cos_sin.side_effect = [
+        (torch.full((4, 1, 1, 8), value), torch.full((4, 1, 1, 8), -value))
+        for value in range(4)
+    ]
+    builder = _make_builder(num_speculative_tokens=3)
+    common = _make_common_metadata()
+
+    first = builder.build_for_graph_capture(common)
+    first_runtime = builder.build(common_prefix_len=0, common_attn_metadata=common)
+    torch.testing.assert_close(first.cos, torch.ones_like(first.cos))
+    torch.testing.assert_close(first.sin, -torch.ones_like(first.sin))
+    common.slot_mapping = common.slot_mapping.clone()
+    second = builder.build_for_graph_capture(common)
+    second_runtime = builder.build_for_drafting(common, draft_index=1)
+
+    assert first.cos.data_ptr() != second.cos.data_ptr()
+    assert first.sin.data_ptr() != second.sin.data_ptr()
+    assert first.cos.data_ptr() == first_runtime.cos.data_ptr()
+    assert first.sin.data_ptr() == first_runtime.sin.data_ptr()
+    assert second.cos.data_ptr() == second_runtime.cos.data_ptr()
+    assert second.sin.data_ptr() == second_runtime.sin.data_ptr()
+    torch.testing.assert_close(first.cos, torch.ones_like(first.cos))
+    torch.testing.assert_close(first.sin, -torch.ones_like(first.sin))
+    torch.testing.assert_close(second.cos, torch.full_like(second.cos, 3))
+    torch.testing.assert_close(second.sin, torch.full_like(second.sin, -3))
 
 
 @patch("vllm_ascend.attention.indexer.get_ascend_config")
@@ -262,8 +449,10 @@ def test_sfa_indexer_metadata_builder_builds_pcp_dcp_slots_and_c8_groups(
     )
     mock_store_kv_block_metadata.assert_called_once_with(
         metadata.slot_mapping,
-        common.group_len,
-        common.group_key_idx,
-        common.group_key_cache_idx,
+        metadata.group_len,
+        metadata.group_key_idx,
+        metadata.group_key_cache_idx,
         _KERNEL_BLOCK_SIZE,
     )
+    assert metadata.group_len is not common.group_len
+    assert metadata.group_len.numel() == metadata.slot_mapping.numel()

--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.kv_cache_interface import FullAttentionSpec
@@ -409,10 +410,12 @@ def test_sfa_indexer_graph_capture_owns_stable_rope_buffers_without_dsa(
 @patch("vllm_ascend.attention.indexer.get_ascend_config")
 @patch("vllm_ascend.attention.indexer.get_cos_and_sin_mla")
 @patch("vllm_ascend.attention.indexer.torch.ops._C_ascend.store_kv_block_metadata", create=True)
+@pytest.mark.parametrize("for_capture", [False, True])
 def test_sfa_indexer_metadata_builder_builds_pcp_dcp_slots_and_c8_groups(
     mock_store_kv_block_metadata,
     mock_cos_sin,
     mock_get_ascend_config,
+    for_capture,
 ):
     mock_get_ascend_config.return_value.c8_reshape_optim_enabled = True
     mock_cos_sin.return_value = (torch.zeros(5, 1, 1, 8), torch.zeros(5, 1, 1, 8))
@@ -432,11 +435,12 @@ def test_sfa_indexer_metadata_builder_builds_pcp_dcp_slots_and_c8_groups(
         gathered_kv_write_mask=torch.tensor([True, True, True, False]),
     )
 
-    metadata = _make_builder(pcp_size=2, dcp_size=2).build(
-        0,
-        common,
-        pcp_context=pcp_context,
-        pcp_cache_group_idx=0,
+    builder = _make_builder(pcp_size=2, dcp_size=2)
+    kwargs = dict(pcp_context=pcp_context, pcp_cache_group_idx=0)
+    metadata = (
+        builder.build_for_cudagraph_capture(common, **kwargs)
+        if for_capture
+        else builder.build(0, common, **kwargs)
     )
 
     torch.testing.assert_close(

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -302,10 +302,7 @@ class TestAscendSFACacheComposition(TestBase):
             impl._get_indexer_attn_metadata()
 
     @patch("vllm_ascend.attention.sfa_v1.get_forward_context")
-    def test_get_indexer_attn_metadata_falls_back_to_main_metadata(self, mock_get_forward_context):
-        # A KV-sharing layer (e.g. an MTP draft layer) owns no indexer cache,
-        # so no metadata is built under its own prefix; the indexer shares
-        # this layer's SFA attention metadata instead.
+    def test_get_indexer_attn_metadata_does_not_fall_back_to_main_metadata(self, mock_get_forward_context):
         impl = AscendSFAImpl.__new__(AscendSFAImpl)
         impl.has_indexer = True
         impl.layer_name = "model.layers.78.self_attn.attn"
@@ -315,7 +312,8 @@ class TestAscendSFACacheComposition(TestBase):
         main_metadata = SimpleNamespace(slot_mapping=torch.tensor([3, 4]))
         mock_get_forward_context.return_value.attn_metadata = {"model.layers.78.self_attn.attn": main_metadata}
 
-        self.assertIs(impl._get_indexer_attn_metadata(), main_metadata)
+        with self.assertRaises(RuntimeError):
+            impl._get_indexer_attn_metadata()
 
     @patch("vllm_ascend.attention.sfa_v1.get_forward_context")
     def test_get_indexer_attn_metadata_resolves_kv_sharing_target(self, mock_get_forward_context):
@@ -335,6 +333,25 @@ class TestAscendSFACacheComposition(TestBase):
         }
 
         self.assertIs(impl._get_indexer_attn_metadata(), target_metadata)
+
+    @patch("vllm_ascend.attention.sfa_v1.get_forward_context")
+    def test_get_indexer_attn_metadata_uses_own_indexer_when_target_is_absent(
+        self,
+        mock_get_forward_context,
+    ):
+        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl.has_indexer = True
+        impl.layer_name = "model.layers.78.self_attn.attn"
+        impl.kv_sharing_target_layer_name = "model.layers.77.self_attn.attn"
+        impl.indexer = SimpleNamespace(
+            k_cache=SimpleNamespace(prefix="model.layers.78.self_attn.indexer.k_cache"),
+        )
+        own_metadata = object()
+        mock_get_forward_context.return_value.attn_metadata = {
+            "model.layers.78.self_attn.indexer.k_cache": own_metadata,
+        }
+
+        self.assertIs(impl._get_indexer_attn_metadata(), own_metadata)
 
     @patch(
         "vllm_ascend.device.device_op.torch.ops._C_ascend.npu_lightning_indexer_quant",
@@ -761,7 +778,7 @@ class TestAscendSFAMetadataBuilder(TestBase):
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
     @patch("torch.ops._C_ascend.store_kv_block_metadata", create=True)
-    def test_ascend_sfa_metadata_builder_automatically_builds_li_c8_metadata_on_prefill_node(
+    def test_ascend_sfa_metadata_builder_does_not_build_indexer_c8_metadata(
         self,
         store_kv_block_metadata,
         mock_get_cos_and_sin_mla,
@@ -833,15 +850,11 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
         assert metadata.slot_mapping.shape == (100, 4, 1024)
 
-        store_kv_block_metadata.assert_called_once()
-        actual_args, _ = store_kv_block_metadata.call_args
-        assert torch.equal(actual_args[0], common_attn_metadata.slot_mapping)
-        assert actual_args[4] == 128
-
+        store_kv_block_metadata.assert_not_called()
         assert metadata.block_size == 128
-        assert metadata.group_len is actual_args[1]
-        assert metadata.group_key_idx is actual_args[2]
-        assert metadata.group_key_cache_idx is actual_args[3]
+        assert metadata.group_len is None
+        assert metadata.group_key_idx is None
+        assert metadata.group_key_cache_idx is None
 
 
 class TestAscendSFAImpl(TestBase):

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1,3 +1,4 @@
+import math
 import os
 import queue
 import socket
@@ -3770,6 +3771,10 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         worker.pcp_size = 1
         worker.dcp_size = 1
         worker._prefill_tp_size = 4
+        worker.kv_group2layeridx = {
+            0: ({"kv_cache_spec_type": "AscendMLAAttentionSpec"}, [0]),
+            1: ({"kv_cache_spec_type": "AscendSFAIndexerCacheSpec"}, [2]),
+        }
         worker.remote_port_send_num = {"remote_engine": {31001: {"num": 1, "host": "localhost"}}}
         worker._get_sfa_replicate_k_block_ids = MagicMock(return_value=(([40],), ([20],)))
         worker._get_kv_split_metadata = MagicMock(
@@ -3781,8 +3786,8 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         )
         worker._get_group_pulls_metadata = MagicMock(
             return_value=[
-                [[GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1)]],
-                [[GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1)]],
+                [[GroupPull(group_id=g, remote_tp_offset=0, num_group_pulls=1) for g in (0, 1)]],
+                [[GroupPull(group_id=g, remote_tp_offset=0, num_group_pulls=1) for g in (0, 1)]],
             ]
         )
         worker._get_remote_host_info_by_port = MagicMock(return_value=("localhost", "remote_engine"))
@@ -3813,6 +3818,8 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
         self.assertEqual(add_request_calls[1].kwargs["remote_handshake_port"], 31003)
         self.assertIsNone(add_request_calls[1].kwargs["local_block_ids_replicate_k"])
         self.assertIsNone(add_request_calls[1].kwargs["remote_block_ids_replicate_k"])
+        self.assertEqual([pull.group_id for pull in add_request_calls[0].kwargs["group_pulls"]], [0, 1])
+        self.assertEqual([pull.group_id for pull in add_request_calls[1].kwargs["group_pulls"]], [0])
 
     def test_get_kv_split_metadata_dp1_remote_port_send_num_uses_absolute_ports(self):
         self.vllm_config.kv_transfer_config.kv_port = 30000
@@ -3953,6 +3960,128 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         self.assertEqual(local_ids, ([20, 21],))
         self.assertEqual(remote_ids, ([20, 21],))
+
+    def test_mrv2_pcp_dcp_transfers_follow_global_block_ownership(self):
+        for remote_dcp in (2, 16):
+            for local_dcp in (1, 8):
+                for rank in range(local_dcp):
+                    with self.subTest(remote_dcp=remote_dcp, local_dcp=local_dcp, rank=rank):
+                        worker = self._build_non_cp_worker()
+                        worker.use_mla = True
+                        worker.use_sfa_sparse = True
+                        worker.enable_sfa_dcp_replicated_indexer = True
+                        worker.tp_size = worker._prefill_tp_size = 8
+                        worker.tp_rank = worker.dcp_rank = rank
+                        worker.dcp_size = local_dcp
+                        worker.pcp_size = 1
+                        worker.pcp_rank = 0
+                        worker.handshake_port = worker.side_channel_port + rank
+                        worker.local_remote_block_port_mapping = {}
+                        worker.remote_port_send_num = {}
+                        worker.block_size_scale = [[1]]
+                        worker.kv_group2layeridx = {0: ({"kv_cache_spec_type": "MLAAttentionSpec"}, [0])}
+                        meta = types.SimpleNamespace(
+                            remote_pcp_size=2,
+                            remote_dcp_size=remote_dcp,
+                            remote_ptp_size=8,
+                            remote_port=30000,
+                            remote_block_ids=(list(range(100, 100 + math.ceil(33 / remote_dcp))),),
+                            local_block_ids=(list(range(200, 200 + math.ceil(33 / local_dcp))),),
+                            local_full_block_ids=(list(range(200, 200 + math.ceil(33 / local_dcp))),),
+                            num_external_tokens=33 * worker.block_size,
+                            num_prompt_blocks=33,
+                            num_computed_tokens=0,
+                            remote_block_size=worker.block_size,
+                            remote_engine_id="pcp_test",
+                            remote_host="localhost",
+                            remote_multi_nodes_meta_mapping={},
+                        )
+                        ports, local_ids, remote_ids = worker._get_kv_split_metadata("pcp", cast(ReqMeta, meta))
+                        seen = []
+                        for shard_ports, dst, src in zip(ports, local_ids, remote_ids):
+                            self.assertEqual(len(shard_ports), 1)
+                            offset = shard_ports[0] - meta.remote_port
+                            source_cp_rank = ((offset % 8) * 2 + offset // 8) % remote_dcp
+                            for local_block, remote_block in zip(dst[0], src[0]):
+                                global_block = (remote_block - 100) * remote_dcp + source_cp_rank
+                                self.assertEqual(global_block % local_dcp, rank)
+                                self.assertEqual(local_block, 200 + global_block // local_dcp)
+                                seen.append(global_block)
+                        self.assertEqual(sorted(seen), list(range(rank, 33, local_dcp)))
+                        local_index, remote_index = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+                        self.assertEqual(local_index, (list(range(200 * local_dcp, 200 * local_dcp + 33)),))
+                        self.assertEqual(remote_index, (list(range(100 * remote_dcp, 100 * remote_dcp + 33)),))
+                        pulls = worker._get_dcp_shard_pulls(ports, 8, 30000, remote_pcp_size=2)
+                        self.assertTrue(
+                            all(p.prefill_pp_rank == 0 for shard in pulls for group in shard for p in group)
+                        )
+
+    def test_sfa_replicated_indexer_cp_ratio(self):
+        for remote_cp, local_cp in ((8, 2), (2, 8), (4, 4), (6, 4), (0, 4), (4, 0)):
+            with self.subTest(remote_cp=remote_cp, local_cp=local_cp):
+                worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+                worker.enable_sfa_dcp_replicated_indexer = True
+                worker.use_sfa_sparse = True
+                worker.pcp_size = 1
+                worker.dcp_size = local_cp
+                worker.block_size = 16
+                meta = types.SimpleNamespace(
+                    remote_pcp_size=1,
+                    remote_dcp_size=remote_cp,
+                    remote_block_ids=([10, 11, 12, 13],),
+                    local_block_ids=([20, 21, 22, 23],),
+                    local_full_block_ids=([20, 21, 22, 23],),
+                    num_external_tokens=128,
+                    num_prompt_blocks=8,
+                    num_computed_tokens=0,
+                )
+                if (remote_cp, local_cp) in ((6, 4), (0, 4), (4, 0)):
+                    with self.assertRaisesRegex(AssertionError, "one divisible by the other"):
+                        worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+                else:
+                    local_ids, remote_ids = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+                    self.assertEqual(local_ids, (list(range(20 * local_cp, 20 * local_cp + 8)),))
+                    self.assertEqual(remote_ids, (list(range(10 * remote_cp, 10 * remote_cp + 8)),))
+
+    def test_sfa_decode_only_dcp_maps_global_blocks_to_each_rank(self):
+        for rank, remote_pcp_size in ((rank, pcp) for rank in range(8) for pcp in (1, 2)):
+            for prompt_blocks, prefix_blocks in ((1, 0), (17, 0), (17, 9)):
+                with self.subTest(rank=rank, pcp=remote_pcp_size, prompt=prompt_blocks, prefix=prefix_blocks):
+                    worker = self._build_non_cp_worker()
+                    worker.use_sfa_sparse = True
+                    worker.enable_sfa_dcp_replicated_indexer = True
+                    worker.dcp_size = 8
+                    worker.dcp_rank = rank
+                    worker._get_selected_pcp_rank = MagicMock(return_value=remote_pcp_size - 1)
+                    worker.block_size_scale = [[2], [8]]
+                    worker.kv_group2layeridx = {
+                        0: ({"kv_cache_spec_type": "MLAAttentionSpec", "kv_cache_group_id": 0}, [0]),
+                        1: ({"kv_cache_spec_type": "AscendSFAIndexerCacheSpec", "kv_cache_group_id": 0}, [1]),
+                    }
+                    meta = types.SimpleNamespace(
+                        remote_pcp_size=remote_pcp_size,
+                        remote_dcp_size=1,
+                        remote_ptp_size=1,
+                        remote_port=30000,
+                        remote_block_ids=(list(range(100, 100 + prompt_blocks)),),
+                        local_block_ids=([20, 21, 22],),
+                        local_full_block_ids=([20, 21, 22],),
+                        num_external_tokens=(prompt_blocks - prefix_blocks) * 16,
+                        num_prompt_blocks=prompt_blocks,
+                        num_computed_tokens=prefix_blocks * 16,
+                        remote_block_size=16,
+                        remote_engine_id="sfa_p1_d8",
+                        remote_host="localhost",
+                        remote_multi_nodes_meta_mapping={},
+                    )
+                    ports, local_ids, remote_ids = worker._get_kv_split_metadata("r", cast(ReqMeta, meta))
+                    selected = [g for g in range(prefix_blocks, prompt_blocks) if g % 8 == rank]
+                    self.assertEqual(ports, [[30000 + remote_pcp_size - 1]])
+                    self.assertEqual(local_ids, [([2 * (20 + g // 8) + k for g in selected for k in range(2)], [])])
+                    self.assertEqual(remote_ids, [([2 * (100 + g) + k for g in selected for k in range(2)], [])])
+                    local_index, remote_index = worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+                    self.assertEqual(local_index, ([160 + g for g in range(prefix_blocks, prompt_blocks)],))
+                    self.assertEqual(remote_index, ([100 + g for g in range(prefix_blocks, prompt_blocks)],))
 
     def test_get_sfa_replicated_indexer_block_ids_requires_full_blocks_for_prefix(self):
         worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -375,6 +375,22 @@ def test_runner_reduction_contract(monkeypatch, moe_comm_type, is_sequence_paral
     assert runner._maybe_reduce_shared_expert_output(shared_output) is shared_output
 
 
+def test_runner_compiles_with_capture_moe_reduction_contract(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    runner.moe_config = SimpleNamespace(is_sequence_parallel=False)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            moe_comm_type=MoECommType.ALLGATHER,
+            compiled_moe_comm_type=MoECommType.MC2,
+        ),
+    )
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+
+    assert runner._fused_output_is_reduced is True
+
+
 @pytest.mark.parametrize(
     ("is_sequence_parallel", "output_is_reduced", "should_reduce"),
     [
@@ -1733,6 +1749,96 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
         )
         assert result is routed_out
         ascend_shared_experts.forward.assert_not_called()
+
+
+def test_nonlatent_sp_multistream_serializes_shared_input_gather_before_routed_moe(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    runner.routed_input_transform = None
+    runner.routed_output_transform = None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+
+    hidden_states = torch.randn(2, 4)
+    gathered_states = torch.randn(8, 4)
+    router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 4)
+    all_gather_done = MagicMock(name="all_gather_done")
+    before_routed = MagicMock(name="before_routed")
+    after_routed_finalize = MagicMock(name="after_routed_finalize")
+    operation_order = []
+
+    def start_input_all_gather(states):
+        operation_order.append("start_input_all_gather")
+        assert states is hidden_states
+        return gathered_states, all_gather_done
+
+    def routed_forward(**kwargs):
+        operation_order.append("routed_moe")
+        assert kwargs["hidden_states"] is hidden_states
+        return routed_out, FusedMoEEvents(
+            before_routed_experts=None,
+            after_routed_experts=None,
+            before_dispatch=None,
+            before_gmm2=None,
+            before_combine=None,
+        )
+
+    def shared_forward(*args, **kwargs):
+        operation_order.append("shared_moe")
+        return shared_out
+
+    shared_experts = SimpleNamespace(
+        multistream_overlap=True,
+        parallel_mode=MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY),
+        start_input_all_gather=MagicMock(side_effect=start_input_all_gather),
+        forward=MagicMock(side_effect=shared_forward),
+    )
+    runner.ascend_shared_experts = shared_experts
+    runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(side_effect=routed_forward))
+    current_stream = MagicMock()
+
+    def wait_event(event):
+        assert event is all_gather_done
+        operation_order.append("wait_input_all_gather")
+
+    def record_event():
+        if "routed_moe" in operation_order:
+            operation_order.append("record_routed_finalize")
+            return after_routed_finalize
+        operation_order.append("record_before_routed")
+        return before_routed
+
+    current_stream.wait_event.side_effect = wait_event
+    current_stream.record_event.side_effect = record_event
+    monkeypatch.setattr(AscendMoERunner, "is_internal_router", property(lambda _: False))
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", lambda: current_stream)
+    monkeypatch.setattr(fused_moe_module, "_EXTRA_CTX", SimpleNamespace(num_tokens=7))
+
+    result = runner._forward_impl(
+        hidden_states,
+        router_logits,
+        shared_experts_input=None,
+    )
+
+    assert operation_order == [
+        "start_input_all_gather",
+        "record_before_routed",
+        "wait_input_all_gather",
+        "routed_moe",
+        "record_routed_finalize",
+        "shared_moe",
+    ]
+    shared_call = shared_experts.forward.call_args
+    torch.testing.assert_close(shared_call.args[0], gathered_states[:7])
+    assert shared_call.args[1].before_routed_experts is before_routed
+    assert shared_call.args[1].after_routed_finalize is after_routed_finalize
+    assert shared_call.kwargs == {
+        "input_is_gathered": True,
+        "defer_output_wait": False,
+    }
+    assert result[0] is shared_out
+    assert result[1] is routed_out
 
 
 def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):

--- a/tests/ut/ops/test_mla.py
+++ b/tests/ut/ops/test_mla.py
@@ -121,6 +121,8 @@ class TestAscendSFAIndexerBackend(TestBase):
             num_decode_tokens=0,
             actual_seq_lengths_query=MagicMock(),
             actual_seq_lengths_key=MagicMock(),
+            cos=MagicMock(name="cos"),
+            sin=MagicMock(name="sin"),
         )
 
     def test_forward_runs_full_pipeline(self):
@@ -147,8 +149,6 @@ class TestAscendSFAIndexerBackend(TestBase):
         hidden_states = torch.zeros(2, 32)
         q_c = torch.zeros(2, 16)
         k_hidden_states = torch.zeros(2, 32)
-        cos, sin = MagicMock(name="cos"), MagicMock(name="sin")
-
         with (
             patch("vllm_ascend.attention.indexer.HAS_TRITON", True),
             patch(
@@ -160,12 +160,16 @@ class TestAscendSFAIndexerBackend(TestBase):
                 side_effect=_select,
             ),
         ):
-            result = indexer.forward(hidden_states, q_c, cos, sin, k_hidden_states, indexer_metadata)
+            result = indexer.forward(hidden_states, q_c, k_hidden_states, indexer_metadata)
 
         self.assertIs(result, expected_topk)
         # The write completes before the selection kernel reads the cache.
         self.assertEqual(calls, ["forward_k", "write_cache", "select"])
-        indexer.forward_k.assert_called_once_with(k_hidden_states, cos, sin)
+        indexer.forward_k.assert_called_once_with(
+            k_hidden_states,
+            indexer_metadata.cos,
+            indexer_metadata.sin,
+        )
         indexer.write_cache.assert_called_once_with(
             k_li,
             None,
@@ -185,8 +189,6 @@ class TestAscendSFAIndexerBackend(TestBase):
             result = indexer.forward(
                 torch.zeros(2, 32),
                 None,
-                MagicMock(name="cos"),
-                MagicMock(name="sin"),
                 torch.zeros(2, 32),
                 indexer_metadata,
                 compute_topk=False,
@@ -327,8 +329,8 @@ class TestIndexerWrapper(TestBase):
         self.assertIs(wrapper.impl, mock_backend_cls.return_value)
         self.assertIs(wrapper.k_cache, wrapper.impl.k_cache)
 
-        wrapper("hidden", "q_c", "cos", "sin", "k_hidden", "meta", False)
-        wrapper.impl.assert_called_once_with("hidden", "q_c", "cos", "sin", "k_hidden", "meta", False)
+        wrapper("hidden", "q_c", "k_hidden", "meta", False)
+        wrapper.impl.assert_called_once_with("hidden", "q_c", "k_hidden", "meta", False)
 
         wrapper.process_weights_after_loading()
         wrapper.impl.process_weights_after_loading.assert_called_once_with()

--- a/tests/ut/spec_decode/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/test_eagle_proposer.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 import inspect
 import unittest
+from contextlib import nullcontext
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -140,6 +141,157 @@ def assert_attr_equal(attr: str | tuple[str, Any, Any], expect: Any, actual: Any
         assert torch.equal(expect_value, actual_value), f"{attr_name} tensor mismatch"
     else:
         assert expect_value == actual_value, f"{attr_name} value mismatch"
+
+
+def test_load_model_retains_split_indexer_metadata_dependency():
+    proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+    proposer.method = "mtp"
+    proposer.vllm_config = MagicMock()
+    proposer.maybe_eager_context = nullcontext()
+    proposer._get_model = MagicMock(return_value=MagicMock())
+    proposer.supports_mm_inputs = False
+    proposer.parallel_drafting = False
+    proposer.draft_window_size = None
+    proposer.sliding_window = None
+    proposer._maybe_share_embeddings = MagicMock()
+    proposer._maybe_share_topk_indices = MagicMock()
+    proposer._maybe_share_lm_head = MagicMock()
+
+    target_name = "model.layers.0.self_attn.attn"
+    draft_name = "model.layers.1.self_attn.attn"
+    indexer_name = "model.layers.1.self_attn.indexer.k_cache"
+    target_layer = MagicMock()
+    draft_layer = MagicMock()
+    indexer_layer = MagicMock()
+    draft_layer.get_kv_cache_spec.return_value = MagicMock()
+    indexer_layer.get_kv_cache_spec.return_value = MagicMock()
+    draft_layer.get_attn_backend.return_value.get_supported_kernel_block_sizes.return_value = [128]
+
+    target_model = MagicMock()
+    with (
+        patch.object(llm_base_proposer, "get_pp_group", return_value=SimpleNamespace(is_last_rank=True)),
+        patch.object(llm_base_proposer, "supports_multimodal", return_value=False),
+        patch.object(
+            llm_base_proposer,
+            "get_layers_from_vllm_config",
+            side_effect=[
+                {target_name: target_layer},
+                {
+                    target_name: target_layer,
+                    draft_name: draft_layer,
+                    indexer_name: indexer_layer,
+                },
+                {
+                    target_name: target_layer,
+                    draft_name: draft_layer,
+                    indexer_name: indexer_layer,
+                },
+            ],
+        ),
+        patch("vllm_ascend.ascend_config.get_ascend_config", return_value=SimpleNamespace(draft_window_size=None)),
+    ):
+        proposer.load_model(target_model)
+
+    assert proposer._draft_attn_layer_names == {draft_name, indexer_name}
+    assert proposer.attn_layer_names == [draft_name, indexer_name]
+
+
+def test_dummy_run_full_graph_builds_metadata_for_each_draft_group():
+    proposer = AscendEagleProposer.__new__(AscendEagleProposer)
+    proposer.num_speculative_tokens = 2
+    proposer.dcp_size = 1
+    proposer.use_cuda_graph = True
+    proposer.use_compress = False
+    proposer.method = "mtp"
+    proposer.device = torch.device("cpu")
+    proposer.kv_cache_gid = 0
+    proposer.supports_mm_inputs = False
+    proposer.extra_slots_per_request = 1
+    proposer.vllm_config = MagicMock()
+    proposer.block_table_tensor_clone = None
+    proposer.positions = torch.arange(6, dtype=torch.int32)
+    proposer.token_indices_to_sample = torch.zeros(8, dtype=torch.int32)
+    proposer.slot_mapping_group = [torch.zeros(8, dtype=torch.int32) for _ in range(2)]
+    proposer.seq_lens_group = [torch.zeros(4, dtype=torch.int32) for _ in range(2)]
+    proposer.query_start_loc_group = [torch.zeros(4, dtype=torch.int32) for _ in range(2)]
+    proposer.query_start_loc = SimpleNamespace(
+        cpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+        gpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+        copy_to_gpu=lambda: None,
+    )
+    proposer._get_positions = MagicMock(return_value=proposer.positions)
+    proposer._runnable = MagicMock()
+
+    main_name = "model.layers.1.self_attn.attn"
+    indexer_name = "model.layers.1.self_attn.indexer.k_cache"
+    main_metadata = object()
+    indexer_metadata = object()
+    main_builder = MagicMock()
+    main_builder.build_for_graph_capture.return_value = main_metadata
+    indexer_builder = MagicMock()
+    indexer_builder.build_for_graph_capture.return_value = indexer_metadata
+    main_group = MagicMock()
+    main_group.layer_names = [main_name]
+    main_group.backend = None
+    main_group.get_metadata_builder.return_value = main_builder
+    indexer_group = MagicMock()
+    indexer_group.layer_names = [indexer_name]
+    indexer_group.get_metadata_builder.return_value = indexer_builder
+    proposer.draft_attn_groups = [main_group, indexer_group]
+
+    block_table = MagicMock()
+    block_table.get_device_tensor.return_value = torch.zeros((2, 2), dtype=torch.int32)
+    block_table.slot_mapping.gpu = torch.arange(6, dtype=torch.int32)
+    runner = MagicMock()
+    runner._sync_metadata_across_dp.return_value = (6, None, CUDAGraphMode.NONE)
+    runner.dcp_manager = None
+    runner.attn_groups = [MagicMock()]
+    runner.synchronize_input_prep.return_value = nullcontext()
+    runner.query_start_loc = SimpleNamespace(
+        cpu=torch.tensor([0, 3, 6], dtype=torch.int32),
+    )
+    runner.input_batch.num_computed_tokens_cpu_tensor = torch.tensor([0, 0], dtype=torch.int32)
+    runner.input_batch.block_table = {0: block_table}
+    runner.optimistic_seq_lens_cpu = torch.tensor([3, 3], dtype=torch.int32)
+    runner.seq_lens = torch.tensor([3, 3], dtype=torch.int32)
+    runner.actual_seq_lengths_q = [3, 3]
+    runner.attn_state = AscendAttentionState.SpecDecoding
+    runner.decode_token_per_req = 3
+    runner.group_len.gpu = torch.zeros(2, dtype=torch.int32)
+    runner.group_key_idx.gpu = torch.zeros(2, dtype=torch.int32)
+    runner.group_key_cache_idx.gpu = torch.zeros(2, dtype=torch.int32)
+    runner._dsa_positions_cpu_buf = None
+    runner.dynamic_eplb = False
+    runner.eplb_heat_collection_status = False
+    proposer.runner = runner
+
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE, moe_layer_index=0)
+    with (
+        patch.object(
+            llm_base_proposer,
+            "prepare_sparse_kv_offload_mtp_dummy_metadata",
+            return_value=(None, None),
+        ),
+        patch.object(llm_base_proposer, "set_ascend_forward_context") as mock_set_context,
+        patch.object(llm_base_proposer, "get_forward_context", return_value=forward_context),
+    ):
+        mock_set_context.return_value = nullcontext()
+        proposer.dummy_run(
+            num_tokens=6,
+            num_reqs=2,
+            in_graph_capturing=True,
+            aclgraph_runtime_mode=CUDAGraphMode.FULL,
+        )
+
+    draft_metadatas = mock_set_context.call_args.kwargs["draft_attn_metadatas"]
+    assert len(draft_metadatas) == proposer.num_speculative_tokens
+    assert main_builder.build_for_graph_capture.call_count == proposer.num_speculative_tokens
+    assert indexer_builder.build_for_graph_capture.call_count == proposer.num_speculative_tokens
+    for per_layer_metadata in draft_metadatas:
+        assert per_layer_metadata == {
+            main_name: main_metadata,
+            indexer_name: indexer_metadata,
+        }
 
 
 def test_prepare_inputs_padded_preserves_internal_seq_lens_cpu():
@@ -966,14 +1118,30 @@ class TestEagleProposerPropose:
             self.proposer.hidden_states = torch.zeros(8192, 7168, device=self.device, dtype=torch.bfloat16)
         else:
             self.proposer.hidden_states = torch.zeros(8192, 4096, device=self.device, dtype=torch.bfloat16)
+        main_layer_name = 'model.layers.36.self_attn.attn'
+        indexer_layer_name = 'model.layers.36.self_attn.indexer.k_cache'
         mock_attn_group = MagicMock()
         mock_builder = MagicMock()
         mock_attn_metadata = MagicMock()
         mock_builder.build.return_value = mock_attn_metadata
         mock_attn_group.get_metadata_builder.return_value = mock_builder
-        mock_attn_group.layer_names = ['model.layers.36.self_attn.attn']
+        mock_attn_group.layer_names = [main_layer_name]
         self.proposer.draft_attn_groups = [mock_attn_group]
-        self.proposer.attn_layer_names = ['model.layers.36.self_attn.attn']
+        self.proposer.attn_layer_names = [main_layer_name]
+        mock_indexer_builder = None
+        mock_indexer_metadata = None
+        mock_indexer_draft_metadata = None
+        if model_type == 'deepseek':
+            mock_indexer_group = MagicMock()
+            mock_indexer_builder = MagicMock()
+            mock_indexer_metadata = object()
+            mock_indexer_draft_metadata = object()
+            mock_indexer_builder.build.return_value = mock_indexer_metadata
+            mock_indexer_builder.build_for_drafting.return_value = mock_indexer_draft_metadata
+            mock_indexer_group.get_metadata_builder.return_value = mock_indexer_builder
+            mock_indexer_group.layer_names = [indexer_layer_name]
+            self.proposer.draft_attn_groups.append(mock_indexer_group)
+            self.proposer.attn_layer_names.append(indexer_layer_name)
         self.proposer.kernel_block_size = 128
         self.proposer.block_size = 128
         self.proposer._runnable = MagicMock()
@@ -1122,7 +1290,11 @@ class TestEagleProposerPropose:
 
         #run
         with (
-            patch.object(self.proposer, 'attn_update_stack_num_spec_norm', side_effect=side_effect),
+            patch.object(
+                self.proposer,
+                'attn_update_stack_num_spec_norm',
+                side_effect=side_effect,
+            ) as mock_update_metadata,
             set_current_vllm_config(self.vllm_config),
         ):
             self.proposer._propose(self.proposer.num_speculative_tokens,
@@ -1132,6 +1304,23 @@ class TestEagleProposerPropose:
                                 scheduler_output, num_scheduled_tokens, num_rejected_tokens_gpu,
                                 )
             self.assert_value_common_attn_metadata(captured_common_attn_metadata, flag_prefill_decode, model_type, graphmode)
+            if model_type == 'deepseek':
+                expected_followup_steps = self.proposer.num_speculative_tokens - 1
+                assert mock_update_metadata.call_count == expected_followup_steps
+                assert all(call.kwargs['attn_group'] is mock_attn_group for call in mock_update_metadata.call_args_list)
+                assert mock_indexer_builder is not None
+                assert mock_indexer_builder.build_for_drafting.call_count == expected_followup_steps
+
+                multi_steps_attn_metadata = self.proposer._runnable.call_args.kwargs['multi_steps_attn_metadata']
+                assert len(multi_steps_attn_metadata) == self.proposer.num_speculative_tokens
+                assert multi_steps_attn_metadata[0] == {
+                    main_layer_name: mock_attn_metadata,
+                    indexer_layer_name: mock_indexer_metadata,
+                }
+                for per_layer_metadata in multi_steps_attn_metadata[1:]:
+                    assert set(per_layer_metadata) == {main_layer_name, indexer_layer_name}
+                    assert per_layer_metadata[indexer_layer_name] is mock_indexer_draft_metadata
+                    assert per_layer_metadata[main_layer_name] is not mock_indexer_draft_metadata
 
     # give common_attn_metadata value
     def value_mock_common_attn_metadata(self, mock_common_attn_metadata, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -193,7 +193,7 @@ def test_load_model_reads_validated_draft_window_size():
         patch("vllm_ascend.spec_decode.llm_base_proposer.get_pp_group") as mock_pp_group,
         patch(
             "vllm_ascend.spec_decode.llm_base_proposer.get_layers_from_vllm_config",
-            side_effect=[{}, {"draft": draft_layer}, {}, {"draft": draft_layer}],
+            side_effect=[{}, {"draft": draft_layer}, {"draft": draft_layer}],
         ),
         patch("vllm_ascend.ascend_config.get_ascend_config") as mock_get_ascend_config,
         patch("vllm_ascend.spec_decode.llm_base_proposer.SlidingWindowAdapter") as mock_adapter,

--- a/tests/ut/spec_decode/test_step3p5_source_regression.py
+++ b/tests/ut/spec_decode/test_step3p5_source_regression.py
@@ -82,7 +82,9 @@ def test_step3p5_draft_window_and_config_contracts() -> None:
     create_config = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_create_draft_vllm_config"))
 
     assert [arg.arg for arg in step_run.args.args] == [arg.arg for arg in base_run.args.args]
-    assert "multi_steps_attn_metadata.append(per_step_attn_metadata)" in build_metadata
+    assert ".self_attn." in build_metadata
+    assert "per_step_layer_metadata.setdefault(step_key, {})" in build_metadata
+    assert "self._primary_step_attn_metadata(metadata)" in build_metadata
     assert "multi_steps_attn_metadata[spec_step_idx]" in run_window
     assert "self.input_ids[token_indices_to_sample]" in roll_inputs
     assert "_ensure_draft_layer_types_cover_mtp_layers()" in create_config

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -39,6 +39,7 @@ def _make_vllm_config(
     kv_connector: str | None = None,
     kv_role: str | None = None,
     recompute_scheduler_enable: bool = False,
+    use_sequence_parallel_moe: bool = False,
 ):
     hf_text_config_attrs: dict[str, object] = {"top_k_experts": top_k_experts}
     if quant_type is not None:
@@ -56,6 +57,7 @@ def _make_vllm_config(
         world_size_across_dp=world_size,
         pipeline_parallel_size=pipeline_parallel_size,
         tensor_parallel_size=tensor_parallel_size,
+        use_sequence_parallel_moe=use_sequence_parallel_moe,
     )
     compilation_config = SimpleNamespace(
         cudagraph_capture_sizes=cudagraph_capture_sizes or [],
@@ -470,6 +472,96 @@ def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     )
 
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER
+
+
+@pytest.mark.parametrize(
+    ("actual", "compiled", "sequence_parallel", "expected"),
+    [
+        (MoECommType.ALLGATHER, MoECommType.MC2, False, True),
+        (MoECommType.ALLGATHER, MoECommType.MC2, True, False),
+        (MoECommType.MC2, MoECommType.FUSED_MC2, False, False),
+        (MoECommType.ALLTOALL, MoECommType.MC2, False, False),
+        (MoECommType.ALLGATHER, MoECommType.ALLGATHER, False, False),
+        (MoECommType.ALLGATHER, None, False, False),
+    ],
+)
+def test_moe_comm_contract_mismatch(actual, compiled, sequence_parallel, expected):
+    assert afc.moe_comm_contract_mismatch(actual, compiled, sequence_parallel) is expected
+
+
+def test_set_ascend_forward_context_skips_mismatched_compiled_moe(monkeypatch):
+    vllm_config = _make_vllm_config()
+    forward_context = SimpleNamespace(dp_metadata=None, skip_compiled=False)
+
+    @contextmanager
+    def fake_set_current(_config):
+        yield
+
+    @contextmanager
+    def fake_set_forward_context(**kwargs):
+        forward_context.skip_compiled = kwargs["skip_compiled"]
+        yield
+
+    monkeypatch.setattr(afc, "set_current_vllm_config", fake_set_current)
+    monkeypatch.setattr(afc, "set_forward_context", fake_set_forward_context)
+    monkeypatch.setattr(afc, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(afc, "has_layer_idx", lambda _model: False)
+    monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: 128)
+    monkeypatch.setattr(
+        afc,
+        "select_moe_comm_method",
+        lambda num_tokens, _config: MoECommType.MC2 if num_tokens <= 128 else MoECommType.ALLGATHER,
+    )
+    monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
+
+    moe_mod_name = "vllm_ascend.ops.fused_moe.moe_comm_method"
+    monkeypatch.setattr(sys.modules[moe_mod_name], "get_moe_comm_method", lambda _type: None)
+
+    with afc.set_ascend_forward_context(None, vllm_config, num_tokens=129):
+        assert forward_context.moe_comm_type == MoECommType.ALLGATHER
+        assert forward_context.compiled_moe_comm_type == MoECommType.MC2
+        assert forward_context.skip_compiled is True
+
+
+def test_set_ascend_forward_context_keeps_profile_compiled(monkeypatch):
+    vllm_config = _make_vllm_config()
+    forward_context = SimpleNamespace(dp_metadata=None, skip_compiled=False)
+
+    @contextmanager
+    def fake_set_current(_config):
+        yield
+
+    @contextmanager
+    def fake_set_forward_context(**kwargs):
+        forward_context.skip_compiled = kwargs["skip_compiled"]
+        yield
+
+    monkeypatch.setattr(afc, "set_current_vllm_config", fake_set_current)
+    monkeypatch.setattr(afc, "set_forward_context", fake_set_forward_context)
+    monkeypatch.setattr(afc, "get_forward_context", lambda: forward_context)
+    monkeypatch.setattr(afc, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(afc, "get_dp_group", lambda: SimpleNamespace(world_size=1))
+    monkeypatch.setattr(afc, "has_layer_idx", lambda _model: False)
+    monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: 128)
+    monkeypatch.setattr(
+        afc,
+        "select_moe_comm_method",
+        lambda num_tokens, _config: MoECommType.MC2 if num_tokens <= 128 else MoECommType.ALLGATHER,
+    )
+    monkeypatch.setattr(afc, "get_mc2_mask", lambda: None)
+
+    moe_mod_name = "vllm_ascend.ops.fused_moe.moe_comm_method"
+    monkeypatch.setattr(sys.modules[moe_mod_name], "get_moe_comm_method", lambda _type: None)
+
+    with afc.set_ascend_forward_context(
+        None,
+        vllm_config,
+        num_tokens=129,
+        in_profile_run=True,
+    ):
+        assert forward_context.skip_compiled is False
 
 
 def test_set_ascend_forward_context_pins_current_vllm_config(monkeypatch):

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -848,6 +848,10 @@ class _CaptureStateBuilder(_PrefillStateBuilder):
         return common_attn_metadata.is_prefilling
 
 
+class _PCPContextOptInBuilder(_PrefillStateBuilder):
+    consumes_pcp_context = True
+
+
 @pytest.mark.parametrize("for_cudagraph_capture", [False, True])
 def test_build_attn_metadata_propagates_prefill_and_pcp_context(monkeypatch, for_cudagraph_capture):
     monkeypatch.setattr(attn_utils, "AscendSFAMetadataBuilder", _PrefillStateBuilder)
@@ -882,6 +886,41 @@ def test_build_attn_metadata_propagates_prefill_and_pcp_context(monkeypatch, for
     )
 
     assert metadata["layer.0"] is is_prefilling
+    assert builder.extra_kwargs == {
+        "pcp_context": pcp_context,
+        "pcp_cache_group_idx": 0,
+    }
+
+
+def test_build_attn_metadata_passes_pcp_context_to_opted_in_cache_backend(monkeypatch):
+    monkeypatch.setattr(attn_utils, "AscendSFAMetadataBuilder", type("UnrelatedSFABuilder", (), {}))
+    builder = _PCPContextOptInBuilder()
+    attn_group = SimpleNamespace(
+        layer_names=["layer.0.indexer.k_cache"],
+        get_metadata_builder=lambda _: builder,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=object())],
+    )
+    pcp_context = object()
+
+    attn_utils.build_attn_metadata(
+        attn_groups=[[attn_group]],
+        num_reqs=1,
+        num_tokens=1,
+        query_start_loc_gpu=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        max_query_len=1,
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        max_seq_len=1,
+        block_tables=(torch.zeros((1, 1), dtype=torch.int32),),
+        slot_mappings=(torch.zeros(1, dtype=torch.int64),),
+        kv_cache_config=kv_cache_config,
+        pcp_context=pcp_context,
+        seq_lens_np=np.array([1], dtype=np.int32),
+        positions=torch.tensor([0], dtype=torch.int64),
+    )
+
     assert builder.extra_kwargs == {
         "pcp_context": pcp_context,
         "pcp_cache_group_idx": 0,

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -148,9 +148,20 @@ def set_ascend_forward_context(
             max_num_tokens,
             vllm_config,
         )
+        compiled_moe_comm_type = get_compiled_moe_comm_type(vllm_config)
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)
+        forward_context.compiled_moe_comm_type = compiled_moe_comm_type
+        if not in_profile_run and moe_comm_contract_mismatch(
+            moe_comm_type,
+            compiled_moe_comm_type,
+            vllm_config.parallel_config.use_sequence_parallel_moe,
+        ):
+            # The compiled MoE graph uses the decode/capture communication
+            # contract.  Large prefill batches may select a method with a
+            # different reduction contract, so execute those calls eagerly.
+            forward_context.skip_compiled = True
         forward_context.is_decode_only_node = _is_decode_only_node(vllm_config)
         forward_context.use_mega_moe = use_cann_megamoe(vllm_config)
 
@@ -382,12 +393,50 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
     return moe_comm_type
 
 
+def moe_output_is_reduced(
+    moe_comm_type: MoECommType | None,
+    sequence_parallel: bool,
+) -> bool:
+    """Return the routed-output reduction contract for a MoE method."""
+    return moe_comm_type in {
+        MoECommType.ALLTOALL,
+        MoECommType.MC2,
+        MoECommType.FUSED_MC2,
+    } or (moe_comm_type == MoECommType.ALLGATHER and sequence_parallel)
+
+
+def get_compiled_moe_comm_type(vllm_config: VllmConfig) -> MoECommType | None:
+    """Return the MoE method whose outer contract is baked into V1 graphs."""
+    mc2_tokens_capacity = get_mc2_tokens_capacity()
+    if mc2_tokens_capacity is None:
+        return None
+    return select_moe_comm_method(mc2_tokens_capacity, vllm_config)
+
+
+def moe_comm_contract_mismatch(
+    moe_comm_type: MoECommType | None,
+    compiled_moe_comm_type: MoECommType | None,
+    sequence_parallel: bool,
+) -> bool:
+    """Whether a runtime MoE method disagrees with the compiled graph."""
+    if compiled_moe_comm_type is None:
+        return False
+    return moe_output_is_reduced(
+        moe_comm_type,
+        sequence_parallel,
+    ) != moe_output_is_reduced(
+        compiled_moe_comm_type,
+        sequence_parallel,
+    )
+
+
 class _ExtraForwardContextProxy:
     """Unified forward-context access for v1/v2 model runners."""
 
     extra_attrs = (
         "capturing",
         "moe_comm_type",
+        "compiled_moe_comm_type",
         "moe_comm_method",
         "is_decode_only_node",
         "use_mega_moe",

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -8,7 +8,6 @@ from torch import nn
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON
-from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 import vllm_ascend.ops.triton.sfa_cp  # noqa: F401
@@ -17,6 +16,12 @@ from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
     get_dcp_local_seq_lens,
+)
+from vllm_ascend.attention.context_parallel.sfa_dcp_utils import (
+    build_sfa_dcp_replicated_block_table,
+    build_sfa_dcp_replicated_slot_mapping,
+    get_sfa_dcp_local_block_table,
+    get_sfa_dcp_max_local_block_table_cols,
 )
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
@@ -602,10 +607,11 @@ class AscendSFADSACPImpl(OProjWeightSwitchMixin, AscendSFAImpl):
 # - SFA KV cache remains DCP-local to preserve the KV memory saving. The sparse
 #   topk indices produced from the replicated indexer view are remapped to local
 #   KV indices before calling sparse flash attention.
-# - BlockTable only owns the DCP-local physical layout. This builder derives the
-#   replicated block table and slot mapping on demand, temporarily builds the
-#   indexer-facing metadata with that replicated view, and then stores the
-#   original DCP-local view in metadata.dcp_context for KV writes and SFA reads.
+# - BlockTable only owns the DCP-local physical layout. This builder derives its
+#   replicated block table and slot mapping on demand, then stores the original
+#   DCP-local view in metadata.dcp_context for KV writes and SFA reads. The
+#   independent indexer builder derives its own replicated view from common
+#   metadata using the same stateless address helpers.
 # - The replicated view uses the same logical/kernel block size as BlockTable,
 #   including hybrid block splitting.
 class AscendSFADCPMetadataBuilder(
@@ -661,8 +667,11 @@ class AscendSFADCPMetadataBuilder(
         total_cp_size = self.dcp_size
         # The generic vLLM BlockTable may expose global-width storage, while
         # the DCP physical KV layout only populates rank-local block columns.
-        self.max_local_block_table_cols = (
-            cdiv(max_model_len, kv_cache_spec.block_size * total_cp_size) * self.blocks_per_phys_block
+        self.max_local_block_table_cols = get_sfa_dcp_max_local_block_table_cols(
+            max_model_len,
+            kv_cache_spec.block_size,
+            total_cp_size,
+            self.blocks_per_phys_block,
         )
         max_replicated_block_table_cols = self.max_local_block_table_cols * total_cp_size
         self.block_table_replicated_view_buf: torch.Tensor = torch.empty(
@@ -705,8 +714,11 @@ class AscendSFADCPMetadataBuilder(
         )[:, self.dcp_rank]
 
     def _get_dcp_local_block_table(self, block_table: torch.Tensor, num_reqs: int) -> torch.Tensor:
-        local_cols = min(block_table.shape[1], self.max_local_block_table_cols)
-        return block_table[:num_reqs, :local_cols]
+        return get_sfa_dcp_local_block_table(
+            block_table,
+            num_reqs,
+            self.max_local_block_table_cols,
+        )
 
     def _ensure_replicated_view_buffers(
         self,
@@ -749,28 +761,14 @@ class AscendSFADCPMetadataBuilder(
             local_block_table_cols,
         )
 
-        total_cp_size = self.dcp_size
-        blocks_per_phys_block = self.blocks_per_phys_block
-        local_col_idx = (
-            replicated_col_idx // (total_cp_size * blocks_per_phys_block) * blocks_per_phys_block
-            + replicated_col_idx % blocks_per_phys_block
+        return build_sfa_dcp_replicated_block_table(
+            dcp_block_table,
+            seq_lens,
+            block_table_replicated_view,
+            replicated_col_idx,
+            self.dcp_size,
+            self.blocks_per_phys_block,
         )
-        rank_in_replicated_view = (replicated_col_idx // blocks_per_phys_block) % total_cp_size
-
-        local_logical_blocks = torch.index_select(dcp_block_table, 1, local_col_idx)
-        if blocks_per_phys_block == 1:
-            replicated_blocks = local_logical_blocks * total_cp_size + rank_in_replicated_view
-        else:
-            local_sub_blocks = local_logical_blocks % blocks_per_phys_block
-            local_phys_blocks = local_logical_blocks // blocks_per_phys_block
-            replicated_blocks = (
-                local_phys_blocks * total_cp_size + rank_in_replicated_view
-            ) * blocks_per_phys_block + local_sub_blocks
-
-        valid_req_mask = (seq_lens[:num_reqs].to(device=self.device) > 0).to(replicated_blocks.dtype).view(-1, 1)
-        replicated_blocks = replicated_blocks * valid_req_mask
-        block_table_replicated_view.copy_(replicated_blocks)
-        return block_table_replicated_view
 
     def _build_slot_mapping_replicated_view(
         self,
@@ -779,42 +777,19 @@ class AscendSFADCPMetadataBuilder(
     ) -> torch.Tensor:
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
-        num_actual_tokens = min(common_attn_metadata.num_actual_tokens, num_input_tokens)
         local_block_table_cols = block_table_replicated_view.shape[1] // self.dcp_size
         _, _, slot_mapping_replicated_view = self._ensure_replicated_view_buffers(
             num_reqs,
             num_input_tokens,
             local_block_table_cols,
         )
-        slot_mapping_replicated_view.fill_(-1)
-        if num_actual_tokens == 0:
-            return slot_mapping_replicated_view
-
-        query_lens = (
-            common_attn_metadata.query_start_loc[1 : num_reqs + 1] - common_attn_metadata.query_start_loc[:num_reqs]
+        return build_sfa_dcp_replicated_slot_mapping(
+            common_attn_metadata,
+            block_table_replicated_view,
+            slot_mapping_replicated_view,
+            self.replicated_view_block_size,
+            self.device,
         )
-        req_indices = torch.repeat_interleave(
-            torch.arange(num_reqs, dtype=torch.int32, device=self.device),
-            query_lens.to(device=self.device),
-            output_size=num_input_tokens,
-        )[:num_actual_tokens]
-        if req_indices.numel() == 0:
-            return slot_mapping_replicated_view
-
-        num_actual_tokens = min(num_actual_tokens, req_indices.shape[0])
-        req_indices = req_indices[:num_actual_tokens]
-        positions = common_attn_metadata.positions[:num_actual_tokens].to(
-            device=self.device,
-            dtype=torch.int32,
-        )
-        logical_block_idx = positions // self.replicated_view_block_size
-        block_offsets = positions % self.replicated_view_block_size
-        block_table_indices = req_indices * block_table_replicated_view.shape[1] + logical_block_idx
-        block_numbers = block_table_replicated_view.flatten()[block_table_indices]
-        slot_mapping_replicated_view[:num_actual_tokens] = (
-            block_numbers * self.replicated_view_block_size + block_offsets
-        )
-        return slot_mapping_replicated_view
 
     def _build_compact_kv_gather_metadata(
         self,

--- a/vllm_ascend/attention/context_parallel/sfa_dcp_utils.py
+++ b/vllm_ascend/attention/context_parallel/sfa_dcp_utils.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import torch
+from vllm.utils.math_utils import cdiv
+
+
+def get_sfa_dcp_max_local_block_table_cols(
+    max_model_len: int,
+    physical_block_size: int,
+    dcp_size: int,
+    blocks_per_physical_block: int,
+) -> int:
+    """Return the local logical-block width of an SFA DCP block table."""
+    return cdiv(max_model_len, physical_block_size * dcp_size) * blocks_per_physical_block
+
+
+def get_sfa_dcp_local_block_table(
+    block_table: torch.Tensor,
+    num_reqs: int,
+    max_local_block_table_cols: int,
+) -> torch.Tensor:
+    """Select the rank-local physical block-table view."""
+    local_cols = min(block_table.shape[1], max_local_block_table_cols)
+    return block_table[:num_reqs, :local_cols]
+
+
+def build_sfa_dcp_replicated_block_table(
+    dcp_block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table_output: torch.Tensor,
+    replicated_col_idx: torch.Tensor,
+    dcp_size: int,
+    blocks_per_physical_block: int,
+) -> torch.Tensor:
+    """Expand a local SFA block table into replicated-indexer addresses."""
+    local_col_idx = (
+        replicated_col_idx // (dcp_size * blocks_per_physical_block) * blocks_per_physical_block
+        + replicated_col_idx % blocks_per_physical_block
+    )
+    rank_in_replicated_view = (replicated_col_idx // blocks_per_physical_block) % dcp_size
+
+    local_logical_blocks = torch.index_select(dcp_block_table, 1, local_col_idx)
+    if blocks_per_physical_block == 1:
+        replicated_blocks = local_logical_blocks * dcp_size + rank_in_replicated_view
+    else:
+        local_sub_blocks = local_logical_blocks % blocks_per_physical_block
+        local_physical_blocks = local_logical_blocks // blocks_per_physical_block
+        replicated_blocks = (
+            local_physical_blocks * dcp_size + rank_in_replicated_view
+        ) * blocks_per_physical_block + local_sub_blocks
+
+    valid_req_mask = (
+        (seq_lens[: dcp_block_table.shape[0]].to(device=dcp_block_table.device) > 0)
+        .to(replicated_blocks.dtype)
+        .view(-1, 1)
+    )
+    block_table_output.copy_(replicated_blocks * valid_req_mask)
+    return block_table_output
+
+
+def build_sfa_dcp_replicated_slot_mapping(
+    common_attn_metadata: Any,
+    block_table_replicated_view: torch.Tensor,
+    slot_mapping_output: torch.Tensor,
+    replicated_view_block_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build slots that address the physically replicated indexer cache."""
+    num_reqs = common_attn_metadata.num_reqs
+    num_input_tokens = common_attn_metadata.num_input_tokens
+    num_actual_tokens = min(common_attn_metadata.num_actual_tokens, num_input_tokens)
+    slot_mapping_output.fill_(-1)
+    if num_actual_tokens == 0:
+        return slot_mapping_output
+
+    query_lens = (
+        common_attn_metadata.query_start_loc[1 : num_reqs + 1] - common_attn_metadata.query_start_loc[:num_reqs]
+    )
+    req_indices = torch.repeat_interleave(
+        torch.arange(num_reqs, dtype=torch.int32, device=device),
+        query_lens.to(device=device),
+        output_size=num_input_tokens,
+    )[:num_actual_tokens]
+    if req_indices.numel() == 0:
+        return slot_mapping_output
+
+    num_actual_tokens = min(num_actual_tokens, req_indices.shape[0])
+    req_indices = req_indices[:num_actual_tokens]
+    positions = common_attn_metadata.positions[:num_actual_tokens].to(
+        device=device,
+        dtype=torch.int32,
+    )
+    logical_block_idx = positions // replicated_view_block_size
+    block_offsets = positions % replicated_view_block_size
+    block_table_indices = req_indices * block_table_replicated_view.shape[1] + logical_block_idx
+    block_numbers = block_table_replicated_view.flatten()[block_table_indices]
+    slot_mapping_output[:num_actual_tokens] = block_numbers * replicated_view_block_size + block_offsets
+    return slot_mapping_output

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -24,6 +24,7 @@ from vllm_ascend.attention.context_parallel.sfa_dcp_utils import (
     get_sfa_dcp_local_block_table,
     get_sfa_dcp_max_local_block_table_cols,
 )
+from vllm_ascend.attention.utils import split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.utils import all_gather_async
@@ -47,11 +48,9 @@ class AscendSFAIndexerMetadata:
     """Engine-side metadata owned by an SFA indexer cache layer.
 
     Carries everything the indexer kernels need from the engine: the paged
-    cache view (block table, slot mapping), the rope tables, and the LI C8
-    reshape-optim fields. The sequence lengths and rope tables reflect the
-    unsharded batch; the parallel-layout sequence lengths the top-k kernel
-    consumes are injected per forward by SFA (see
-    ``actual_seq_lengths_query`` / ``actual_seq_lengths_key``).
+    cache view (block table, slot mapping), the rope tables, the parallel
+    sequence lengths, and the LI C8 reshape-optim fields. All fields are
+    derived from common attention metadata by the indexer's own builder.
     """
 
     num_actual_tokens: int
@@ -70,15 +69,12 @@ class AscendSFAIndexerMetadata:
     group_len: torch.Tensor | None = None
     group_key_idx: torch.Tensor | None = None
     group_key_cache_idx: torch.Tensor | None = None
-    # Parallel-layout sequence lengths consumed by the top-k kernel, injected
-    # by SFA per forward: base/PCP modes use the unsharded ``cum_query_lens``
-    # / ``seq_lens`` equivalents, DSA-CP shards them per rank. Transported on
-    # this metadata so the indexer forward interface stays layout-agnostic.
+    # Parallel-layout sequence lengths consumed by the top-k kernel. Base/PCP
+    # modes use the unsharded values; DSA-CP uses rank-local lengths.
     actual_seq_lengths_query: torch.Tensor | None = None
     actual_seq_lengths_key: torch.Tensor | None = None
-    # Decode-token count injected by SFA per forward; the PCP cache-write
-    # gather splits the local prefill region on it (all-decode batches skip
-    # the gather).
+    # The PCP cache-write gather splits the local prefill region on this
+    # independently computed decode-token count.
     num_decode_tokens: int = 0
 
 
@@ -97,8 +93,8 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
     KV-cache planner can assign an independent physical tensor while sharing
     block ids with the main MLA cache group. Its builder constructs the
     metadata the indexer forward consumes (paged cache view, rope tables,
-    LI C8 reshape-optim fields); SFA only injects the parallel-layout values
-    (sequence lengths, decode count) onto that metadata per forward.
+    LI C8 reshape-optim fields, RoPE, and parallel-layout values). SFA only
+    consumes the completed indexer metadata during its forward.
 
     Do not reuse AscendSFAMetadataBuilder here. It inherits vLLM's
     MLACommonMetadataBuilder, whose initializer assumes layer_names[0] points to
@@ -360,8 +356,6 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         self,
         hidden_states: torch.Tensor,
         q_c: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-        cos: torch.Tensor,
-        sin: torch.Tensor,
         k_hidden_states: torch.Tensor,
         indexer_metadata: AscendSFAIndexerMetadata,
         compute_topk: bool = True,
@@ -373,10 +367,11 @@ class AscendSFAIndexerBackend(nn.Module, AttentionBackend):
         sharing top-k indices) still runs the k path and the write so the
         cache stays up to date, and returns None.
 
-        ``cos`` / ``sin`` come from SFA's metadata, not the indexer's own:
-        DSA-CP shards them to the local token shard, matching the sharded
-        inputs. ``indexer_metadata`` carries the indexer's own cache view
-        plus the parallel-layout values injected by SFA."""
+        The indexer metadata owns its RoPE tables and parallel-layout values;
+        DSA-CP metadata contains the local token shard that matches these
+        inputs."""
+        cos = indexer_metadata.cos
+        sin = indexer_metadata.sin
         k_li, k_li_scale = self.forward_k(k_hidden_states, cos, sin)
         k_li, k_li_scale, slot_mapping = self._gather_cache_inputs(k_li, k_li_scale, indexer_metadata)
         self.write_cache(k_li, k_li_scale, slot_mapping, indexer_attn_metadata=indexer_metadata)
@@ -479,12 +474,53 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFAIndexerBackend])
+        scheduler_config = vllm_config.scheduler_config
+        self.decode_threshold = 1
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None:
+            self.decode_threshold += speculative_config.num_speculative_tokens
+
         self._pcp_active = vllm_config.parallel_config.prefill_context_parallel_size > 1
+        self._dsa_cp_active = enable_dsa_cp()
+        self._group_metadata_buffers: dict[
+            object,
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        ] = {}
+        self._rope_buffers: dict[object, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._dsa_cp_rope_buffers: dict[object, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._dsa_cp_slot_mapping_buffers: dict[object, torch.Tensor] = {}
+        self._dsa_cp_seq_buffers: dict[object, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._dcp_block_table_buffers: dict[object, torch.Tensor] = {}
+        self._dcp_slot_mapping_buffers: dict[object, torch.Tensor] = {}
+        self._pcp_indexer_slot_mapping_buffers: dict[object, torch.Tensor] = {}
+        max_num_input_tokens = scheduler_config.max_num_batched_tokens
+        self._rope_capacity = max_num_input_tokens
+        pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self._dcp_slot_capacity = max_num_input_tokens * pcp_size
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        self._slot_capacity = max(
+            max_num_input_tokens * pcp_size,
+            _round_up(max_num_input_tokens, tp_size),
+        )
+
+        if self._dsa_cp_active and not self._pcp_active:
+            self.dsa_cp_world_size = tp_size
+            self.dsa_cp_slot_capacity = _round_up(
+                max_num_input_tokens,
+                self.dsa_cp_world_size,
+            )
+            max_num_reqs = scheduler_config.max_num_seqs
+            self.dsa_cp_seq_capacity = max_num_reqs + 1
+            if speculative_config is not None:
+                spec_tokens = speculative_config.num_speculative_tokens
+                self.dsa_cp_seq_capacity = max(
+                    self.dsa_cp_seq_capacity,
+                    max_num_reqs * (spec_tokens + 1) + 1,
+                )
         self._dcp_active = enable_sfa_dcp_replicated_indexer(vllm_config)
         if not self._dcp_active:
             return
 
-        self._dsa_cp_active = enable_dsa_cp()
         self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
         self.replicated_view_block_size = self.kernel_block_size
         if kv_cache_spec.block_size % self.replicated_view_block_size != 0:
@@ -495,11 +531,10 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             )
         self.blocks_per_phys_block = kv_cache_spec.block_size // self.replicated_view_block_size
 
-        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        max_num_reqs = scheduler_config.max_num_seqs
         if self._pcp_active:
             max_num_reqs *= 2
         max_num_reqs += 1
-        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         self.max_local_block_table_cols = get_sfa_dcp_max_local_block_table_cols(
             vllm_config.model_config.max_model_len,
             kv_cache_spec.block_size,
@@ -507,26 +542,15 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             self.blocks_per_phys_block,
         )
         max_replicated_block_table_cols = self.max_local_block_table_cols * self.dcp_size
-        self.block_table_replicated_view_buf = torch.empty(
-            (max_num_reqs, max_replicated_block_table_cols),
-            dtype=torch.int32,
-            device=device,
-        )
+        self._dcp_block_table_shape = (max_num_reqs, max_replicated_block_table_cols)
         self.replicated_col_idx_buf = torch.arange(
             max_replicated_block_table_cols,
             dtype=torch.int32,
             device=device,
         )
-        self.slot_mapping_replicated_view_buf = torch.empty(
-            max_num_input_tokens,
-            dtype=torch.int32,
-            device=device,
-        )
         if self._pcp_active:
-            self.pcp_indexer_slot_mapping_buf = torch.empty(
-                max_num_input_tokens * vllm_config.parallel_config.prefill_context_parallel_size,
-                dtype=torch.int32,
-                device=device,
+            self._pcp_indexer_slot_capacity = (
+                max_num_input_tokens * vllm_config.parallel_config.prefill_context_parallel_size
             )
 
     @classmethod
@@ -542,39 +566,58 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         num_reqs: int,
         num_input_tokens: int,
         local_block_table_cols: int,
+        buffer_key: object,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         block_table_cols = local_block_table_cols * self.dcp_size
+        block_table_buffer = self._dcp_block_table_buffers.get(buffer_key)
+        if block_table_buffer is None:
+            block_table_buffer = torch.empty(
+                self._dcp_block_table_shape,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._dcp_block_table_buffers[buffer_key] = block_table_buffer
+        slot_mapping_buffer = self._dcp_slot_mapping_buffers.get(buffer_key)
+        if slot_mapping_buffer is None:
+            slot_mapping_buffer = torch.empty(
+                self._dcp_slot_capacity,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._dcp_slot_mapping_buffers[buffer_key] = slot_mapping_buffer
         if (
-            self.block_table_replicated_view_buf.shape[0] < num_reqs
-            or self.block_table_replicated_view_buf.shape[1] < block_table_cols
+            block_table_buffer.shape[0] < num_reqs
+            or block_table_buffer.shape[1] < block_table_cols
         ):
             raise RuntimeError(
                 "Replicated indexer metadata buffer is too small: "
-                f"block_table_shape={self.block_table_replicated_view_buf.shape}, "
+                f"block_table_shape={block_table_buffer.shape}, "
                 f"num_reqs={num_reqs}, block_table_cols={block_table_cols}."
             )
-        if self.slot_mapping_replicated_view_buf.shape[0] < num_input_tokens:
+        if slot_mapping_buffer.shape[0] < num_input_tokens:
             raise RuntimeError(
                 "Replicated indexer metadata buffer is too small: "
-                f"slot_mapping_shape={self.slot_mapping_replicated_view_buf.shape}, "
+                f"slot_mapping_shape={slot_mapping_buffer.shape}, "
                 f"num_input_tokens={num_input_tokens}."
             )
         return (
-            self.block_table_replicated_view_buf[:num_reqs, :block_table_cols],
+            block_table_buffer[:num_reqs, :block_table_cols],
             self.replicated_col_idx_buf[:block_table_cols],
-            self.slot_mapping_replicated_view_buf[:num_input_tokens],
+            slot_mapping_buffer[:num_input_tokens],
         )
 
     def _build_block_table_replicated_view(
         self,
         dcp_block_table: torch.Tensor,
         seq_lens: torch.Tensor,
+        buffer_key: object,
     ) -> torch.Tensor:
         num_reqs, local_block_table_cols = dcp_block_table.shape
         block_table, replicated_col_idx, _ = self._ensure_replicated_view_buffers(
             num_reqs,
             0,
             local_block_table_cols,
+            buffer_key,
         )
         return build_sfa_dcp_replicated_block_table(
             dcp_block_table,
@@ -589,6 +632,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         self,
         common_attn_metadata: CommonAttentionMetadata,
         block_table_replicated_view: torch.Tensor,
+        buffer_key: object,
     ) -> torch.Tensor:
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
@@ -597,6 +641,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             num_reqs,
             num_input_tokens,
             local_block_table_cols,
+            buffer_key,
         )
         return build_sfa_dcp_replicated_slot_mapping(
             common_attn_metadata,
@@ -611,6 +656,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         common_attn_metadata: CommonAttentionMetadata,
         pcp_context: Any,
         pcp_cache_group_idx: int,
+        buffer_key: object,
     ) -> torch.Tensor:
         global_batch = pcp_context.global_batch
         num_reqs = global_batch.num_reqs
@@ -632,10 +678,12 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         replicated_block_table = self._build_block_table_replicated_view(
             dcp_block_table,
             global_common_attn_metadata.seq_lens,
+            buffer_key,
         )
         global_slot_mapping = self._build_slot_mapping_replicated_view(
             global_common_attn_metadata,
             replicated_block_table,
+            buffer_key,
         )
 
         gather_idx = pcp_context.padded_gather_idx
@@ -643,13 +691,21 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         if gather_idx is None or write_mask is None:
             raise RuntimeError("PCP+DCP indexer metadata requires the PCP gathered-token layout.")
         num_pcp_ordered_tokens = gather_idx.numel()
-        if self.pcp_indexer_slot_mapping_buf.shape[0] < num_pcp_ordered_tokens:
+        pcp_slot_mapping_buffer = self._pcp_indexer_slot_mapping_buffers.get(buffer_key)
+        if pcp_slot_mapping_buffer is None:
+            pcp_slot_mapping_buffer = torch.empty(
+                self._pcp_indexer_slot_capacity,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._pcp_indexer_slot_mapping_buffers[buffer_key] = pcp_slot_mapping_buffer
+        if pcp_slot_mapping_buffer.shape[0] < num_pcp_ordered_tokens:
             raise RuntimeError(
                 "PCP+DCP indexer slot buffer is too small: "
-                f"capacity={self.pcp_indexer_slot_mapping_buf.shape[0]}, "
+                f"capacity={pcp_slot_mapping_buffer.shape[0]}, "
                 f"required={num_pcp_ordered_tokens}."
             )
-        pcp_slot_mapping = self.pcp_indexer_slot_mapping_buf[:num_pcp_ordered_tokens]
+        pcp_slot_mapping = pcp_slot_mapping_buffer[:num_pcp_ordered_tokens]
         torch.index_select(global_slot_mapping, 0, gather_idx, out=pcp_slot_mapping)
         pcp_slot_mapping.masked_fill_(~write_mask, -1)
         return pcp_slot_mapping
@@ -659,6 +715,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         common_attn_metadata: CommonAttentionMetadata,
         pcp_context: Any | None,
         pcp_cache_group_idx: int | None,
+        buffer_key: object,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         pcp_slot_mapping = None
         if self._pcp_active and pcp_context is not None and bool(pcp_context.global_batch.is_prefilling_np.any()):
@@ -668,6 +725,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
                 common_attn_metadata,
                 pcp_context,
                 pcp_cache_group_idx,
+                buffer_key,
             )
 
         num_reqs = common_attn_metadata.num_reqs
@@ -679,24 +737,182 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         block_table = self._build_block_table_replicated_view(
             dcp_block_table,
             common_attn_metadata.seq_lens,
+            buffer_key,
         )
         slot_mapping = self._build_slot_mapping_replicated_view(
             common_attn_metadata,
             block_table,
+            buffer_key,
         )
         if pcp_slot_mapping is not None:
             slot_mapping = pcp_slot_mapping
-        elif self._dsa_cp_active:
-            num_tokens_pad = _round_up(
-                common_attn_metadata.num_input_tokens,
-                get_tp_group().world_size,
-            )
-            slot_mapping = nn.functional.pad(
-                slot_mapping,
-                (0, num_tokens_pad - slot_mapping.shape[0]),
-                value=-1,
-            )
         return block_table, slot_mapping
+
+    def _build_dsa_cp_slot_mapping(
+        self,
+        slot_mapping: torch.Tensor,
+        num_input_tokens: int,
+        buffer_key: object,
+    ) -> torch.Tensor:
+        num_tokens_pad = _round_up(num_input_tokens, self.dsa_cp_world_size)
+        slot_mapping_buffer = self._dsa_cp_slot_mapping_buffers.get(buffer_key)
+        if slot_mapping_buffer is None:
+            slot_mapping_buffer = torch.empty(
+                self.dsa_cp_slot_capacity,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._dsa_cp_slot_mapping_buffers[buffer_key] = slot_mapping_buffer
+        if slot_mapping_buffer.shape[0] < num_tokens_pad:
+            raise RuntimeError(
+                "DSA-CP indexer slot buffer is too small: "
+                f"capacity={slot_mapping_buffer.shape[0]}, "
+                f"required={num_tokens_pad}."
+            )
+        padded_slot_mapping = slot_mapping_buffer[:num_tokens_pad]
+        padded_slot_mapping.fill_(-1)
+        padded_slot_mapping[: slot_mapping.shape[0]].copy_(slot_mapping)
+        return padded_slot_mapping
+
+    def _get_dsa_cp_seq_buffers(
+        self,
+        buffer_key: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        buffers = self._dsa_cp_seq_buffers.get(buffer_key)
+        if buffers is None:
+            query = torch.empty(
+                self.dsa_cp_seq_capacity,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            buffers = (query, torch.empty_like(query))
+            self._dsa_cp_seq_buffers[buffer_key] = buffers
+        return buffers
+
+    def _build_dsa_cp_parallel_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        buffer_key: object,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        num_tokens = common_attn_metadata.num_input_tokens
+        num_tokens_pad = _round_up(num_tokens, self.dsa_cp_world_size)
+        num_tokens_per_device = num_tokens_pad // self.dsa_cp_world_size
+        local_start = get_tp_group().rank_in_group * num_tokens_per_device
+        local_end = local_start + num_tokens_per_device
+
+        rope_buffers = self._dsa_cp_rope_buffers.get(buffer_key)
+        if rope_buffers is None:
+            local_capacity = self.dsa_cp_slot_capacity // self.dsa_cp_world_size
+            rope_shape = (local_capacity, *cos.shape[1:])
+            rope_buffers = (
+                torch.empty(rope_shape, dtype=cos.dtype, device=cos.device),
+                torch.empty(rope_shape, dtype=sin.dtype, device=sin.device),
+            )
+            self._dsa_cp_rope_buffers[buffer_key] = rope_buffers
+        local_cos_buf, local_sin_buf = rope_buffers
+        if local_cos_buf.shape[0] < num_tokens_per_device:
+            raise RuntimeError(
+                "DSA-CP indexer RoPE buffer is too small: "
+                f"capacity={local_cos_buf.shape[0]}, required={num_tokens_per_device}."
+            )
+        local_cos = local_cos_buf[:num_tokens_per_device]
+        local_sin = local_sin_buf[:num_tokens_per_device]
+        local_cos.zero_()
+        local_sin.zero_()
+        source_end = min(local_end, cos.shape[0])
+        if source_end > local_start:
+            source_slice = slice(local_start, source_end)
+            target_slice = slice(0, source_end - local_start)
+            local_cos[target_slice].copy_(cos[source_slice])
+            local_sin[target_slice].copy_(sin[source_slice])
+
+        cum_query_lens = common_attn_metadata.query_start_loc[1 : common_attn_metadata.num_reqs + 1]
+        seq_lens = common_attn_metadata.seq_lens[: common_attn_metadata.num_reqs]
+        actual_seq_lengths_query, actual_seq_lengths_key = self._get_dsa_cp_seq_buffers(buffer_key)
+        num_segs = cum_query_lens.shape[0]
+        if actual_seq_lengths_query.shape[0] < num_segs:
+            raise RuntimeError(
+                "DSA-CP indexer sequence buffer is too small: "
+                f"capacity={actual_seq_lengths_query.shape[0]}, required={num_segs}."
+            )
+        global_start = common_attn_metadata.query_start_loc[:num_segs]
+        req_local_start = global_start.clamp(min=local_start)
+        req_local_end = cum_query_lens.clamp(max=local_end)
+        num_local_tokens = req_local_end - req_local_start
+        actual_seq_lengths_query[:num_segs] = torch.cumsum(
+            num_local_tokens.clamp(min=0),
+            dim=0,
+        )
+        offset = cum_query_lens - req_local_end
+        actual_seq_lengths_key[:num_segs] = torch.where(
+            num_local_tokens > 0,
+            torch.clamp_min(seq_lens - offset, 0),
+            0,
+        )
+        return (
+            local_cos,
+            local_sin,
+            actual_seq_lengths_query[:num_segs],
+            actual_seq_lengths_key[:num_segs],
+        )
+
+    def _copy_rope_to_metadata_buffers(
+        self,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        buffer_key: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens = cos.shape[0]
+        if num_tokens > self._rope_capacity:
+            raise RuntimeError(
+                "Indexer RoPE metadata buffer is too small: "
+                f"capacity={self._rope_capacity}, required={num_tokens}."
+            )
+        buffers = self._rope_buffers.get(buffer_key)
+        if buffers is None:
+            shape = (self._rope_capacity, *cos.shape[1:])
+            buffers = (
+                torch.empty(shape, dtype=cos.dtype, device=cos.device),
+                torch.empty(shape, dtype=sin.dtype, device=sin.device),
+            )
+            self._rope_buffers[buffer_key] = buffers
+        cos_buffer, sin_buffer = buffers
+        if cos_buffer.shape[1:] != cos.shape[1:] or sin_buffer.shape[1:] != sin.shape[1:]:
+            raise RuntimeError(
+                "Indexer RoPE metadata shape changed after initialization: "
+                f"cos={tuple(cos.shape)}, buffer={tuple(cos_buffer.shape)}."
+            )
+        cos_view = cos_buffer[:num_tokens]
+        sin_view = sin_buffer[:num_tokens]
+        cos_view.copy_(cos)
+        sin_view.copy_(sin)
+        return cos_view, sin_view
+
+    def _get_group_metadata_buffers(
+        self,
+        draft_index: object,
+        num_slots: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if num_slots > self._slot_capacity:
+            raise RuntimeError(
+                "Indexer C8 group metadata buffer is too small: "
+                f"capacity={self._slot_capacity}, required={num_slots}."
+            )
+        buffers = self._group_metadata_buffers.get(draft_index)
+        if buffers is None:
+            buffers = (
+                torch.empty(self._slot_capacity, dtype=torch.int32, device=self.device),
+                torch.empty(self._slot_capacity, dtype=torch.int32, device=self.device),
+                torch.empty(self._slot_capacity, dtype=torch.int32, device=self.device),
+            )
+            self._group_metadata_buffers[draft_index] = buffers
+        return (
+            buffers[0][:num_slots],
+            buffers[1][:num_slots],
+            buffers[2][:num_slots],
+        )
 
     def build(
         self,
@@ -706,6 +922,56 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         **kwargs,
     ) -> AscendSFAIndexerMetadata:
         # common_prefix_len / fast_build are unused; kept for API compatibility.
+        return self._build(
+            common_attn_metadata,
+            buffer_key=self._metadata_buffer_key(common_attn_metadata),
+            use_cached_rope=True,
+            **kwargs,
+        )
+
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+        fast_build: bool = False,
+        **kwargs,
+    ) -> AscendSFAIndexerMetadata:
+        return self._build(
+            common_attn_metadata,
+            buffer_key=self._metadata_buffer_key(common_attn_metadata),
+            use_cached_rope=False,
+            **kwargs,
+        )
+
+    def build_for_graph_capture(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        attn_state: Any = None,
+        **kwargs,
+    ) -> AscendSFAIndexerMetadata:
+        return self._build(
+            common_attn_metadata,
+            buffer_key=self._metadata_buffer_key(common_attn_metadata),
+            # Match the normal first-step build: the cached RoPE tables have
+            # persistent addresses that graph replay updates in place.
+            use_cached_rope=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _metadata_buffer_key(common_attn_metadata: CommonAttentionMetadata) -> tuple[str, int]:
+        # The proposer uses one persistent slot-mapping tensor per logical
+        # draft step. Key every mutable derived buffer by that address so
+        # graph capture and runtime rebuild update the exact same storage.
+        return ("slot_mapping", common_attn_metadata.slot_mapping.data_ptr())
+
+    def _build(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        buffer_key: object,
+        use_cached_rope: bool,
+        **kwargs,
+    ) -> AscendSFAIndexerMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
         if self._dcp_active:
@@ -713,6 +979,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
                 common_attn_metadata,
                 kwargs.get("pcp_context"),
                 kwargs.get("pcp_cache_group_idx"),
+                buffer_key,
             )
         elif self._pcp_active:
             # PCP writes cover the gathered prefill region too, which
@@ -722,30 +989,83 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         else:
             slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
             block_table = common_attn_metadata.block_table_tensor[:num_reqs]
+        if self._dsa_cp_active and not self._pcp_active:
+            slot_mapping = self._build_dsa_cp_slot_mapping(
+                slot_mapping,
+                num_input_tokens,
+                buffer_key,
+            )
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
         block_size = self.kernel_block_size
 
-        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
+        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=use_cached_rope)
+        cos = cos[:num_input_tokens]
+        sin = sin[:num_input_tokens]
+        cum_query_lens = common_attn_metadata.query_start_loc[1 : num_reqs + 1]
+        seq_lens = common_attn_metadata.seq_lens[:num_reqs]
+        actual_seq_lengths_query = cum_query_lens
+        actual_seq_lengths_key = seq_lens
+        if self._dsa_cp_active and not self._pcp_active:
+            (
+                cos,
+                sin,
+                actual_seq_lengths_query,
+                actual_seq_lengths_key,
+            ) = self._build_dsa_cp_parallel_metadata(
+                common_attn_metadata,
+                cos,
+                sin,
+                buffer_key,
+            )
+        else:
+            cos, sin = self._copy_rope_to_metadata_buffers(
+                cos,
+                sin,
+                buffer_key,
+            )
 
+        num_decode_tokens = 0
+        if self._pcp_active:
+            # Only PCP's cache-write gather consumes this boundary. Dummy
+            # decode metadata does not always carry is_prefilling, so treat
+            # its short queries as decode instead of requiring that field.
+            _, _, num_decode_tokens, _ = split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.decode_threshold,
+                treat_short_extends_as_decodes=(
+                    getattr(common_attn_metadata, "is_prefilling", None) is None
+                ),
+            )
+
+        group_len = None
+        group_key_idx = None
+        group_key_cache_idx = None
         if get_ascend_config().c8_reshape_optim_enabled:
+            group_len, group_key_idx, group_key_cache_idx = self._get_group_metadata_buffers(
+                buffer_key,
+                slot_mapping.numel(),
+            )
             torch.ops._C_ascend.store_kv_block_metadata(
                 slot_mapping,
-                common_attn_metadata.group_len,
-                common_attn_metadata.group_key_idx,
-                common_attn_metadata.group_key_cache_idx,
+                group_len,
+                group_key_idx,
+                group_key_cache_idx,
                 block_size,
             )
 
         return AscendSFAIndexerMetadata(
             num_actual_tokens=common_attn_metadata.num_actual_tokens,
             slot_mapping=slot_mapping,
-            seq_lens=common_attn_metadata.seq_lens[:num_reqs],
-            cum_query_lens=common_attn_metadata.query_start_loc[1 : num_reqs + 1],
+            seq_lens=seq_lens,
+            cum_query_lens=cum_query_lens,
             block_table=block_table,
-            sin=sin[:num_input_tokens],
-            cos=cos[:num_input_tokens],
+            sin=sin,
+            cos=cos,
             block_size=block_size,
-            group_len=common_attn_metadata.group_len,
-            group_key_idx=common_attn_metadata.group_key_idx,
-            group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            group_len=group_len,
+            group_key_idx=group_key_idx,
+            group_key_cache_idx=group_key_cache_idx,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_key=actual_seq_lengths_key,
+            num_decode_tokens=num_decode_tokens,
         )

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -18,12 +18,18 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.utils import select_common_block_size
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.attention.context_parallel.sfa_dcp_utils import (
+    build_sfa_dcp_replicated_block_table,
+    build_sfa_dcp_replicated_slot_mapping,
+    get_sfa_dcp_local_block_table,
+    get_sfa_dcp_max_local_block_table_cols,
+)
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.ops.triton.rope import rope_forward_triton_siso
-from vllm_ascend.utils import enable_dsa_cp, vllm_version_is
+from vllm_ascend.utils import _round_up, enable_dsa_cp, enable_sfa_dcp_replicated_indexer, vllm_version_is
 
 if vllm_version_is("0.28.0"):
     from vllm.model_executor.layers.attention.pcp import _gather_prefill_cache_inputs  # type: ignore[import-not-found]
@@ -453,14 +459,15 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
     """Builds the metadata consumed by SFA indexer forwards.
 
     The indexer cache layer shares block ids with the main SFA cache group,
-    so the slot mapping and block table mirror the ``*.attn`` layer's; the
-    rope tables are rebuilt from the same positions via the shared helper.
-    The slot mapping is emitted write-ready for the active parallel mode
-    (full gather mapping under PCP). Variants with their own cache geometry
-    override this construction to supply their layout's equivalents.
+    but owns its physical cache and constructs its metadata independently.
+    Under DCP it expands the local common block table and slot mapping into
+    the indexer's replicated address space directly; it never reads metadata
+    built for the SFA attention layer. The slot mapping is emitted write-ready
+    for the active parallel mode (full gather mapping under PCP).
     """
 
     reorder_batch_threshold = None
+    consumes_pcp_context = True
 
     def __init__(
         self,
@@ -473,6 +480,54 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFAIndexerBackend])
         self._pcp_active = vllm_config.parallel_config.prefill_context_parallel_size > 1
+        self._dcp_active = enable_sfa_dcp_replicated_indexer(vllm_config)
+        if not self._dcp_active:
+            return
+
+        self._dsa_cp_active = enable_dsa_cp()
+        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        self.replicated_view_block_size = self.kernel_block_size
+        if kv_cache_spec.block_size % self.replicated_view_block_size != 0:
+            raise RuntimeError(
+                "SFA replicated indexer metadata requires the physical block "
+                f"size ({kv_cache_spec.block_size}) to be divisible by the "
+                f"kernel block size ({self.replicated_view_block_size})."
+            )
+        self.blocks_per_phys_block = kv_cache_spec.block_size // self.replicated_view_block_size
+
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        if self._pcp_active:
+            max_num_reqs *= 2
+        max_num_reqs += 1
+        max_num_input_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.max_local_block_table_cols = get_sfa_dcp_max_local_block_table_cols(
+            vllm_config.model_config.max_model_len,
+            kv_cache_spec.block_size,
+            self.dcp_size,
+            self.blocks_per_phys_block,
+        )
+        max_replicated_block_table_cols = self.max_local_block_table_cols * self.dcp_size
+        self.block_table_replicated_view_buf = torch.empty(
+            (max_num_reqs, max_replicated_block_table_cols),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.replicated_col_idx_buf = torch.arange(
+            max_replicated_block_table_cols,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.slot_mapping_replicated_view_buf = torch.empty(
+            max_num_input_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+        if self._pcp_active:
+            self.pcp_indexer_slot_mapping_buf = torch.empty(
+                max_num_input_tokens * vllm_config.parallel_config.prefill_context_parallel_size,
+                dtype=torch.int32,
+                device=device,
+            )
 
     @classmethod
     def get_cudagraph_support(
@@ -481,6 +536,167 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         kv_cache_spec: AttentionSpec,
     ) -> AttentionCGSupport:
         return AttentionCGSupport.UNIFORM_BATCH
+
+    def _ensure_replicated_view_buffers(
+        self,
+        num_reqs: int,
+        num_input_tokens: int,
+        local_block_table_cols: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        block_table_cols = local_block_table_cols * self.dcp_size
+        if (
+            self.block_table_replicated_view_buf.shape[0] < num_reqs
+            or self.block_table_replicated_view_buf.shape[1] < block_table_cols
+        ):
+            raise RuntimeError(
+                "Replicated indexer metadata buffer is too small: "
+                f"block_table_shape={self.block_table_replicated_view_buf.shape}, "
+                f"num_reqs={num_reqs}, block_table_cols={block_table_cols}."
+            )
+        if self.slot_mapping_replicated_view_buf.shape[0] < num_input_tokens:
+            raise RuntimeError(
+                "Replicated indexer metadata buffer is too small: "
+                f"slot_mapping_shape={self.slot_mapping_replicated_view_buf.shape}, "
+                f"num_input_tokens={num_input_tokens}."
+            )
+        return (
+            self.block_table_replicated_view_buf[:num_reqs, :block_table_cols],
+            self.replicated_col_idx_buf[:block_table_cols],
+            self.slot_mapping_replicated_view_buf[:num_input_tokens],
+        )
+
+    def _build_block_table_replicated_view(
+        self,
+        dcp_block_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        num_reqs, local_block_table_cols = dcp_block_table.shape
+        block_table, replicated_col_idx, _ = self._ensure_replicated_view_buffers(
+            num_reqs,
+            0,
+            local_block_table_cols,
+        )
+        return build_sfa_dcp_replicated_block_table(
+            dcp_block_table,
+            seq_lens,
+            block_table,
+            replicated_col_idx,
+            self.dcp_size,
+            self.blocks_per_phys_block,
+        )
+
+    def _build_slot_mapping_replicated_view(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        block_table_replicated_view: torch.Tensor,
+    ) -> torch.Tensor:
+        num_reqs = common_attn_metadata.num_reqs
+        num_input_tokens = common_attn_metadata.num_input_tokens
+        local_block_table_cols = block_table_replicated_view.shape[1] // self.dcp_size
+        _, _, slot_mapping = self._ensure_replicated_view_buffers(
+            num_reqs,
+            num_input_tokens,
+            local_block_table_cols,
+        )
+        return build_sfa_dcp_replicated_slot_mapping(
+            common_attn_metadata,
+            block_table_replicated_view,
+            slot_mapping,
+            self.replicated_view_block_size,
+            self.device,
+        )
+
+    def _build_pcp_ordered_slot_mapping(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        pcp_context: Any,
+        pcp_cache_group_idx: int,
+    ) -> torch.Tensor:
+        global_batch = pcp_context.global_batch
+        num_reqs = global_batch.num_reqs
+        global_block_table = pcp_context.global_block_tables[pcp_cache_group_idx]
+        global_common_attn_metadata = common_attn_metadata.replace(
+            query_start_loc=global_batch.query_start_loc,
+            seq_lens=global_batch.seq_lens[:num_reqs],
+            num_reqs=num_reqs,
+            num_actual_tokens=global_batch.num_tokens,
+            num_input_tokens=global_batch.num_tokens,
+            positions=global_batch.positions,
+            block_table_tensor=global_block_table,
+        )
+        dcp_block_table = get_sfa_dcp_local_block_table(
+            global_block_table,
+            num_reqs,
+            self.max_local_block_table_cols,
+        )
+        replicated_block_table = self._build_block_table_replicated_view(
+            dcp_block_table,
+            global_common_attn_metadata.seq_lens,
+        )
+        global_slot_mapping = self._build_slot_mapping_replicated_view(
+            global_common_attn_metadata,
+            replicated_block_table,
+        )
+
+        gather_idx = pcp_context.padded_gather_idx
+        write_mask = pcp_context.gathered_kv_write_mask
+        if gather_idx is None or write_mask is None:
+            raise RuntimeError("PCP+DCP indexer metadata requires the PCP gathered-token layout.")
+        num_pcp_ordered_tokens = gather_idx.numel()
+        if self.pcp_indexer_slot_mapping_buf.shape[0] < num_pcp_ordered_tokens:
+            raise RuntimeError(
+                "PCP+DCP indexer slot buffer is too small: "
+                f"capacity={self.pcp_indexer_slot_mapping_buf.shape[0]}, "
+                f"required={num_pcp_ordered_tokens}."
+            )
+        pcp_slot_mapping = self.pcp_indexer_slot_mapping_buf[:num_pcp_ordered_tokens]
+        torch.index_select(global_slot_mapping, 0, gather_idx, out=pcp_slot_mapping)
+        pcp_slot_mapping.masked_fill_(~write_mask, -1)
+        return pcp_slot_mapping
+
+    def _build_dcp_cache_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        pcp_context: Any | None,
+        pcp_cache_group_idx: int | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pcp_slot_mapping = None
+        if self._pcp_active and pcp_context is not None and bool(pcp_context.global_batch.is_prefilling_np.any()):
+            if pcp_cache_group_idx is None:
+                raise RuntimeError("PCP+DCP indexer metadata requires the PCP cache-group index.")
+            pcp_slot_mapping = self._build_pcp_ordered_slot_mapping(
+                common_attn_metadata,
+                pcp_context,
+                pcp_cache_group_idx,
+            )
+
+        num_reqs = common_attn_metadata.num_reqs
+        dcp_block_table = get_sfa_dcp_local_block_table(
+            common_attn_metadata.block_table_tensor,
+            num_reqs,
+            self.max_local_block_table_cols,
+        )
+        block_table = self._build_block_table_replicated_view(
+            dcp_block_table,
+            common_attn_metadata.seq_lens,
+        )
+        slot_mapping = self._build_slot_mapping_replicated_view(
+            common_attn_metadata,
+            block_table,
+        )
+        if pcp_slot_mapping is not None:
+            slot_mapping = pcp_slot_mapping
+        elif self._dsa_cp_active:
+            num_tokens_pad = _round_up(
+                common_attn_metadata.num_input_tokens,
+                get_tp_group().world_size,
+            )
+            slot_mapping = nn.functional.pad(
+                slot_mapping,
+                (0, num_tokens_pad - slot_mapping.shape[0]),
+                value=-1,
+            )
+        return block_table, slot_mapping
 
     def build(
         self,
@@ -492,12 +708,20 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
         # common_prefix_len / fast_build are unused; kept for API compatibility.
         num_reqs = common_attn_metadata.num_reqs
         num_input_tokens = common_attn_metadata.num_input_tokens
-        if self._pcp_active:
+        if self._dcp_active:
+            block_table, slot_mapping = self._build_dcp_cache_metadata(
+                common_attn_metadata,
+                kwargs.get("pcp_context"),
+                kwargs.get("pcp_cache_group_idx"),
+            )
+        elif self._pcp_active:
             # PCP writes cover the gathered prefill region too, which
             # requires the full slot mapping.
             slot_mapping = common_attn_metadata.slot_mapping
+            block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         else:
             slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
+            block_table = common_attn_metadata.block_table_tensor[:num_reqs]
         input_positions = common_attn_metadata.positions[:num_input_tokens].long()
         block_size = self.kernel_block_size
 
@@ -517,7 +741,7 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             slot_mapping=slot_mapping,
             seq_lens=common_attn_metadata.seq_lens[:num_reqs],
             cum_query_lens=common_attn_metadata.query_start_loc[1 : num_reqs + 1],
-            block_table=common_attn_metadata.block_table_tensor[:num_reqs],
+            block_table=block_table,
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             block_size=block_size,

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -943,6 +943,11 @@ class AscendSFAIndexerMetadataBuilder(AttentionMetadataBuilder[AscendSFAIndexerM
             **kwargs,
         )
 
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata, **kwargs: Any
+    ) -> AscendSFAIndexerMetadata:
+        return self.build_for_graph_capture(common_attn_metadata, **kwargs)
+
     def build_for_graph_capture(
         self,
         common_attn_metadata: CommonAttentionMetadata,

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -356,15 +356,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             draft_index,
         )
 
-        if get_ascend_config().c8_reshape_optim_enabled:
-            torch.ops._C_ascend.store_kv_block_metadata(
-                slot_mapping,
-                common_attn_metadata.group_len,
-                common_attn_metadata.group_key_idx,
-                common_attn_metadata.group_key_cache_idx,
-                block_size,
-            )
-
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=num_actual_tokens,
@@ -380,9 +371,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
             block_size=block_size,
-            group_len=common_attn_metadata.group_len,
-            group_key_idx=common_attn_metadata.group_key_idx,
-            group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
             **parallel_metadata,
         )
 
@@ -1286,26 +1274,27 @@ class AscendSFAImpl(MLAAttentionImpl):
         backend's builder; ``None`` when this layer has no indexer."""
         if not self.has_indexer:
             return None
-        prefix = self.indexer.k_cache.prefix
+        own_prefix = self.indexer.k_cache.prefix
+        prefixes = [own_prefix]
         kv_sharing_target = getattr(self, "kv_sharing_target_layer_name", None)
         if kv_sharing_target is not None:
-            # A KV-sharing layer (e.g. an MTP draft layer) owns no cache of
-            # its own, so no metadata is built under its own prefix; resolve
-            # to the sharing target's indexer cache prefix instead.
+            # Prefer the sharing target's cache view, but keep the draft
+            # indexer's own independently built metadata as a valid fallback.
+            # Some proposers register the draft indexer as its own metadata
+            # dependency even when the physical cache is shared.
             target_base = kv_sharing_target.removesuffix(".attn")
-            prefix = f"{target_base}.indexer.k_cache"
+            prefixes = [f"{target_base}.indexer.k_cache", own_prefix]
         forward_metadata = get_forward_context().attn_metadata
-        indexer_metadata = forward_metadata.get(prefix) if isinstance(forward_metadata, dict) else None
-        if indexer_metadata is None and isinstance(forward_metadata, dict):
-            # During MTP draft propose the proposer only builds metadata for
-            # the draft attention layers (keyed by layer name), so fall back
-            # to this layer's SFA attention metadata - the same metadata the
-            # pre-refactor inline indexer consumed (slot_mapping/block_table
-            # are identical for both caches).
-            indexer_metadata = forward_metadata.get(self.layer_name)
+        indexer_metadata = None
+        if isinstance(forward_metadata, dict):
+            for prefix in prefixes:
+                indexer_metadata = forward_metadata.get(prefix)
+                if indexer_metadata is not None:
+                    break
         if indexer_metadata is None:
             raise RuntimeError(
-                f"No metadata was built for the indexer cache layer prefix={prefix}. layer_name={self.layer_name}."
+                "No metadata was built for the indexer cache layer "
+                f"prefixes={prefixes}. layer_name={self.layer_name}."
             )
         return indexer_metadata
 
@@ -1452,20 +1441,14 @@ class AscendSFAImpl(MLAAttentionImpl):
             # selection (the selection kernel reads the freshly written
             # cache). skip_topk layers still run the k path and the write
             # (compute_topk=False) so their cache stays up to date, then
-            # reuse the shared top-k indices. The parallel-layout values the
-            # indexer needs ride on its own metadata: sequence lengths
-            # (sharded under DSA-CP) and the decode-token count the PCP
-            # cache-write gather splits on.
+            # reuse the shared top-k indices. Cache layout, RoPE, parallel
+            # sequence lengths, and decode count all come from the indexer's
+            # independently built metadata.
             assert k_hidden_states is not None
             assert indexer_attn_metadata is not None
-            indexer_attn_metadata.actual_seq_lengths_query = parallel_context.actual_seq_lengths_query
-            indexer_attn_metadata.actual_seq_lengths_key = parallel_context.actual_seq_lengths_key
-            indexer_attn_metadata.num_decode_tokens = attn_metadata.num_decode_tokens
             topk_indices = self.indexer(
                 hidden_states,
                 q_c,
-                cos,
-                sin,
                 k_hidden_states,
                 indexer_attn_metadata,
                 compute_topk=not self.skip_topk,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -2777,6 +2777,8 @@ class MooncakeConnectorWorker:
             # block_idx-th pulled block maps to global prompt block (in P-units):
             #   global_p_block = (shard_first_p_block + block_idx) * Rcp + shard_cp_rank
             global_p_block = (shard_first_p_block + block_idx) * remote_cp_size + shard_cp_rank
+            if (global_p_block // block_size_ratio) % local_cp_size != rank_first_d_block % local_cp_size:
+                continue
             if remote_block_size > self.block_size:
                 # Bp > Bd (only supported when D-side has no CP): one P-block spans multiple
                 # D-blocks, so walk it kernel by kernel via the absolute token offset within
@@ -2892,9 +2894,10 @@ class MooncakeConnectorWorker:
         Also validates that P/D block sizes are compatible under D-side CP.
         """
         remote_block_size = meta.remote_block_size or self.block_size
-        local_cp_rank = self.dcp_rank + self.pcp_rank * self.dcp_size
-        local_cp_size = self.dcp_size * self.pcp_size
-        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
+        # MRV2's DCP group already spans PCP; PCP is not another KV shard axis.
+        local_cp_rank = self.dcp_rank
+        local_cp_size = self.dcp_size
+        remote_cp_size = meta.remote_dcp_size
 
         if remote_block_size != self.block_size:
             assert self.block_size % remote_block_size == 0 or remote_block_size % self.block_size == 0, (
@@ -2912,6 +2915,51 @@ class MooncakeConnectorWorker:
 
         r_blk = self.block_size // remote_block_size if self.block_size > remote_block_size else 1
         return remote_block_size, local_cp_rank, local_cp_size, remote_cp_size, r_blk
+
+    def _get_sfa_decode_only_dcp_metadata(
+        self,
+        req_id: str,
+        meta: ReqMeta,
+        prefill_tp_size: int,
+    ) -> tuple[list[list[int]], list[BlockIds], list[BlockIds]]:
+        assert (meta.remote_block_size or self.block_size) == self.block_size, (
+            "SFA decode-only DCP requires equal P/D block sizes."
+        )
+        if self._is_hma_required:
+            chosen_rank_list, _ = self._get_hybrid_remote_rank_group_pulls(req_id, prefill_tp_size)
+        else:
+            chosen_rank_list = self._get_remote_rank(req_id, prefill_tp_size)
+        pcp_offset = self._get_selected_pcp_rank(req_id, meta.remote_pcp_size) * prefill_tp_size
+        remote_handshake_port_list = [[x + meta.remote_port + pcp_offset for x in chosen_rank_list]]
+        use_transfer_group_block_ids = transfer_groups_need_independent_block_ids(
+            self.kv_group2layeridx, self.block_size_scale
+        )
+        local_block_ids = [
+            [] for _ in (self.kv_group2layeridx if use_transfer_group_block_ids else meta.local_block_ids)
+        ]
+        remote_block_ids = [
+            [] for _ in (self.kv_group2layeridx if use_transfer_group_block_ids else meta.remote_block_ids)
+        ]
+        for group_idx, (group_spec, layer_indices) in self.kv_group2layeridx.items():
+            if group_spec["kv_cache_spec_type"] == "AscendSFAIndexerCacheSpec":
+                # The full indexer cache is transferred separately.
+                continue
+            group_id = self._get_kv_cache_group_id(group_idx, group_spec)
+            local_blocks = (meta.local_full_block_ids or meta.local_block_ids)[group_id]
+            remote_blocks = meta.remote_block_ids[group_id]
+            first_block = meta.num_computed_tokens // self.block_size
+            first_block += (self.dcp_rank - first_block) % self.dcp_size
+            # P owns the full sequence; D rank r owns r, r + DCP, ... .
+            global_blocks = range(first_block, min(meta.num_prompt_blocks, len(remote_blocks)), self.dcp_size)
+            scale = self._get_kernel_block_scale(layer_indices)
+            block_id_idx = group_idx if use_transfer_group_block_ids else group_id
+            local_block_ids[block_id_idx] = self._expand_block_ids(
+                [local_blocks[block // self.dcp_size] for block in global_blocks], scale
+            )
+            remote_block_ids[block_id_idx] = self._expand_block_ids(
+                [remote_blocks[block] for block in global_blocks], scale
+            )
+        return remote_handshake_port_list, [tuple(local_block_ids)], [tuple(remote_block_ids)]
 
     def _get_kv_split_metadata(
         self,
@@ -2944,6 +2992,10 @@ class MooncakeConnectorWorker:
         remote blocks that still need to be pulled.
         """
         prefill_tp_size: int = meta.remote_ptp_size if meta.remote_ptp_size is not None else self._prefill_tp_size
+
+        is_sfa_decode_only_dcp = self.use_sfa_sparse and self.dcp_size > 1 and meta.remote_dcp_size == 1
+        if is_sfa_decode_only_dcp:
+            return self._get_sfa_decode_only_dcp_metadata(req_id, meta, prefill_tp_size)
 
         if self.dcp_size == meta.remote_dcp_size == 1:
             if self._is_hma_required:
@@ -2987,7 +3039,9 @@ class MooncakeConnectorWorker:
             )
 
         def context_parallel_parameters_check():
-            assert (meta.remote_pcp_size * meta.remote_dcp_size) % (self.pcp_size * self.dcp_size) == 0
+            assert remote_cp_size % local_cp_size == 0 or local_cp_size % remote_cp_size == 0, (
+                f"P/D CP sizes must be divisible in either direction, got P={remote_cp_size}, D={local_cp_size}."
+            )
             if not (self.use_mla or self.use_sparse):
                 p_node_heads_per_rank = math.ceil(self.num_key_value_heads / prefill_tp_size)
                 d_node_heads_per_rank = math.ceil(self.num_key_value_heads / self.tp_size)
@@ -3018,7 +3072,7 @@ class MooncakeConnectorWorker:
             # key is kv_head_group, value is cp_groups and which cp_groups to select
             cp_group_meta: dict = {}
             kv_head_groups = get_kv_head_groups(tp_size)
-            dcp_repeat_num = tp_size // len(kv_head_groups) // dcp_size
+            dcp_repeat_num = tp_size * pcp_size // len(kv_head_groups) // dcp_size
 
             for kv_head_group_idx, kv_head_group in enumerate(kv_head_groups):
                 if kv_head_group not in cp_group_meta:
@@ -3027,15 +3081,14 @@ class MooncakeConnectorWorker:
                     cp_group_meta[kv_head_group]["select_cp_groups_id"] = 0
                 kv_head_group_offset = tp_size // len(kv_head_groups) * kv_head_group_idx
                 for dcp_repeat_idx in range(dcp_repeat_num):
-                    # len(cp_group) == pcp_size * dcp_size
+                    # MRV2 orders DCP ranks along PCP first, then TP.
                     cp_group = []
                     dcp_repeat_offset = dcp_size * dcp_repeat_idx
-                    for pcp_rank in range(pcp_size):
-                        pcp_rank_offset = tp_size * pcp_rank
-                        for dcp_rank in range(dcp_size):
-                            cp_group.append(
-                                dcp_rank + port_base + pcp_rank_offset + dcp_repeat_offset + kv_head_group_offset
-                            )
+                    for dcp_rank in range(dcp_size):
+                        flat_rank = dcp_repeat_offset + dcp_rank
+                        pcp_rank = flat_rank % pcp_size
+                        tp_rank = flat_rank // pcp_size + kv_head_group_offset
+                        cp_group.append(port_base + pcp_rank * tp_size + tp_rank)
                     cp_group_meta[kv_head_group]["cp_groups"].append(cp_group)
 
             return cp_group_meta
@@ -3067,7 +3120,7 @@ class MooncakeConnectorWorker:
                             for p_idx, p_port in enumerate(p_cp_group):
                                 # When Bd == Bp, r_blk = 1, which degenerates to the original `p_idx % Lcp` rule.
                                 # When Bd = r * Bp, all blocks of P CP rank q are mapped to D rank `(q // r) % Lcp`.
-                                if (p_idx // r_blk) % len(d_cp_group) == d_idx:
+                                if (p_idx // r_blk - d_idx) % min(len(d_cp_group), len(p_cp_group)) == 0:
                                     p_port_remote_list.append(p_port)
                             local_remote_block_port_mappings[d_port].append(p_port_remote_list)
 
@@ -3192,10 +3245,8 @@ class MooncakeConnectorWorker:
             ),
             0,
         )
-        assert math.ceil(num_external_blocks / (self.pcp_size * self.dcp_size)) == len(
-            meta.local_block_ids[sequence_group_idx]
-        ), (
-            f"num_external_blocks({num_external_blocks}), cp_size({self.pcp_size * self.dcp_size}), "
+        assert math.ceil(num_external_blocks / local_cp_size) == len(meta.local_block_ids[sequence_group_idx]), (
+            f"num_external_blocks({num_external_blocks}), cp_size({local_cp_size}), "
             f"local_block_ids_len ({len(meta.local_block_ids[sequence_group_idx])})"
         )
         assert meta.num_prompt_blocks >= num_external_blocks_p, (
@@ -3222,7 +3273,7 @@ class MooncakeConnectorWorker:
 
         for cp_rank, block_num in enumerate(remote_block_nums_all):
             # When r_blk = 1, it degrades to the original cp_rank % Lcp rule.
-            if (cp_rank // r_blk) % local_cp_size == local_cp_rank:
+            if (cp_rank // r_blk - local_cp_rank) % min(local_cp_size, remote_cp_size) == 0:
                 if last_block_location == cp_rank:
                     final_block_idx = len(remote_block_nums)
                 remote_block_nums.append(block_num)
@@ -3307,6 +3358,13 @@ class MooncakeConnectorWorker:
                 remote_logical = list(
                     meta.remote_block_ids[kv_cache_group_id][remote_first : remote_first + num_blocks_to_pull]
                 )
+                if local_cp_size > remote_cp_size:
+                    remote_logical = [
+                        block_id
+                        for offset, block_id in enumerate(remote_logical)
+                        if ((remote_first + offset) * remote_cp_size + shard_cp_rank) // r_blk % local_cp_size
+                        == local_cp_rank
+                    ]
                 kernel_remote = self._expand_block_ids(remote_logical, remote_scale)
                 kernel_local = self._local_kernel_ids_for_shard(
                     remote_first,
@@ -3342,7 +3400,7 @@ class MooncakeConnectorWorker:
 
         return remote_handshake_port_list, local_block_ids_list, remote_block_ids_list
 
-    def _get_dcp_shard_pulls(self, remote_handshake_port_list, prefill_tp_size, remote_base_port):
+    def _get_dcp_shard_pulls(self, remote_handshake_port_list, prefill_tp_size, remote_base_port, remote_pcp_size):
         """Build group pulls from the selected ports of each DCP shard."""
         mamba_num = prefill_tp_size // self.tp_size
         attn_num = self._get_tp_num_need_pulls(prefill_tp_size)
@@ -3360,7 +3418,7 @@ class MooncakeConnectorWorker:
             for port_idx, port in enumerate(ports):
                 pulls = []
                 port_tp = (port - remote_base_port) % prefill_tp_size
-                pp_rank = (port - remote_base_port) // prefill_tp_size
+                pp_rank = (port - remote_base_port) // (prefill_tp_size * remote_pcp_size)
                 # Attention uses the leading ports selected for each DCP shard.
                 if port_idx < attn_num:
                     pulls += [
@@ -3437,7 +3495,9 @@ class MooncakeConnectorWorker:
                 ]
 
             # The DCP path has already selected the source ports for each shard.
-            return self._get_dcp_shard_pulls(remote_handshake_port_list, prefill_tp_size, remote_base_port)
+            return self._get_dcp_shard_pulls(
+                remote_handshake_port_list, prefill_tp_size, remote_base_port, remote_pcp_size
+            )
 
         tp_num_need_pulls = self._get_tp_num_need_pulls(prefill_tp_size)
         group_ids = [group_id for group_id, (_, layer_indices) in self.kv_group2layeridx.items() if layer_indices]
@@ -3642,14 +3702,17 @@ class MooncakeConnectorWorker:
                 f"Got remote groups={len(meta.remote_block_ids)}, local groups={len(meta.local_block_ids)}."
             )
 
-        remote_cp_size = meta.remote_pcp_size * meta.remote_dcp_size
-        local_cp_size = self.pcp_size * self.dcp_size
-        if local_cp_size == 0 or remote_cp_size % local_cp_size != 0:
+        remote_cp_size = meta.remote_dcp_size
+        local_cp_size = self.dcp_size
+        if (
+            local_cp_size <= 0
+            or remote_cp_size <= 0
+            or (remote_cp_size % local_cp_size != 0 and local_cp_size % remote_cp_size != 0)
+        ):
             raise AssertionError(
-                f"SFA replicate-K expects remote cp size({remote_cp_size}) to be divisible by "
-                f"local cp size({local_cp_size})."
+                f"SFA replicate-K requires positive P/D CP sizes with one divisible by the other, "
+                f"got P CP={remote_cp_size}, D CP={local_cp_size}."
             )
-
         num_prefix_cached_blocks = min(meta.num_computed_tokens // self.block_size, meta.num_prompt_blocks)
         num_external_blocks = meta.num_prompt_blocks - num_prefix_cached_blocks
         num_external_blocks_from_tokens = math.ceil(meta.num_external_tokens / self.block_size)
@@ -3772,12 +3835,22 @@ class MooncakeConnectorWorker:
                         if replicate_k_transfer_port is not None and remote_handshake_port == replicate_k_transfer_port
                         else None
                     )
+                    group_pulls = group_pulls_list[shard_idx][remote_tp_offset]
+                    if has_replicate_k_blocks and remote_handshake_port != replicate_k_transfer_port:
+                        # The indexer is replicated, not an attention DCP shard.
+                        # Other ports must not overwrite its full-cache transfer.
+                        group_pulls = [
+                            pull
+                            for pull in group_pulls
+                            if self.kv_group2layeridx[pull.group_id][0]["kv_cache_spec_type"]
+                            != "AscendSFAIndexerCacheSpec"
+                        ]
                     self.kv_recv_thread.add_request(
                         request_id=req_id,
                         remote_request_id=remote_req_id,
                         local_block_ids=local_block_ids_list[shard_idx],
                         remote_block_ids=remote_block_ids_list[shard_idx],
-                        group_pulls=group_pulls_list[shard_idx][remote_tp_offset],
+                        group_pulls=group_pulls,
                         remote_engine_id=remote_engine_id,
                         remote_host=remote_host,
                         remote_handshake_port=remote_handshake_port,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -27,7 +27,11 @@ from vllm.model_executor.layers.fused_moe.layer import MoERunner
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import _moe_forward_shared
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_forward_context import (
+    _EXTRA_CTX,
+    MoECommType,
+    moe_output_is_reduced,
+)
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
@@ -175,11 +179,19 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # MoERunner.forward() so _maybe_reduce_final_output does not apply a
         # second TP all-reduce (which would double-count the contributions).
         moe_comm_type = _EXTRA_CTX.moe_comm_type
-        return moe_comm_type in {
-            MoECommType.ALLTOALL,
-            MoECommType.MC2,
-            MoECommType.FUSED_MC2,
-        } or (moe_comm_type == MoECommType.ALLGATHER and self.moe_config.is_sequence_parallel)
+        if torch.compiler.is_compiling():
+            # Profile runs still compile at max_num_batched_tokens, where the
+            # runtime method can be ALLGATHER.  FULL decode capture uses the
+            # capacity-sized MC2 contract, so bake that contract into the
+            # outer graph.  The profile output is discarded; real calls with
+            # a different contract bypass this graph in the forward context.
+            compiled_moe_comm_type = _EXTRA_CTX.compiled_moe_comm_type
+            if compiled_moe_comm_type is not None:
+                moe_comm_type = compiled_moe_comm_type
+        return moe_output_is_reduced(
+            moe_comm_type,
+            self.moe_config.is_sequence_parallel,
+        )
 
     def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
         shared_experts = getattr(self, "ascend_shared_experts", None)
@@ -317,13 +329,29 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     router_logits=router_logits,
                     input_ids=input_ids,
                 )
-            # The runner input transform provides a padded gathered tensor in
-            # SP multistream mode. Trim the shared-MLP view before use.
+            # A routed input transform can overlap the shared-input gather and
+            # passes the gathered tensor into this custom op explicitly. For
+            # models without such a transform, start the same gather here and
+            # join it before routed MoE so TP and EP AIV collectives cannot be
+            # interleaved in a rank-dependent order.
+            uses_sp_multistream = (
+                self.ascend_shared_experts.multistream_overlap
+                and self.ascend_shared_experts.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+            )
             shared_input_is_gathered = self._can_overlap_sp_shared_with(self.routed_input_transform)
             defer_shared_output_wait = self._can_overlap_sp_shared_with(self.routed_output_transform)
-            shared_expert_input = (
-                shared_hidden_states[: _EXTRA_CTX.num_tokens] if shared_input_is_gathered else shared_hidden_states
-            )
+            shared_expert_input = shared_hidden_states
+            all_gather_done = None
+            if uses_sp_multistream and not shared_input_is_gathered:
+                shared_expert_input, all_gather_done = self.ascend_shared_experts.start_input_all_gather(
+                    shared_hidden_states
+                )
+                assert all_gather_done is not None
+                shared_input_is_gathered = True
+            if shared_input_is_gathered:
+                # start_input_all_gather keeps TP padding for the custom-op
+                # boundary; the shared MLP consumes only real tokens.
+                shared_expert_input = shared_expert_input[: _EXTRA_CTX.num_tokens]
             if self.is_internal_router:
                 gate = self.gate
                 assert gate is not None
@@ -344,6 +372,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 before_routed_experts = torch.npu.current_stream().record_event()
                 after_routed_experts = None
 
+            if all_gather_done is not None:
+                torch.npu.current_stream().wait_event(all_gather_done)
             routed_out, fused_moe_events = self.routed_experts.forward_impl(
                 hidden_states=hidden_states,
                 router_logits=router_logits,
@@ -351,7 +381,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             )
             fused_moe_events.before_routed_experts = before_routed_experts
             fused_moe_events.after_routed_experts = after_routed_experts
-            if shared_input_is_gathered:
+            if uses_sp_multistream:
                 fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
             shared_out = self.ascend_shared_experts.forward(

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -86,13 +86,11 @@ class IndexerWrapper(nn.Module):
         self,
         hidden_states: torch.Tensor,
         q_c: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-        cos: torch.Tensor,
-        sin: torch.Tensor,
         k_hidden_states: torch.Tensor,
         indexer_metadata: AscendSFAIndexerMetadata,
         compute_topk: bool = True,
     ) -> torch.Tensor | None:
-        return self.impl(hidden_states, q_c, cos, sin, k_hidden_states, indexer_metadata, compute_topk)
+        return self.impl(hidden_states, q_c, k_hidden_states, indexer_metadata, compute_topk)
 
 
 class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -23,7 +23,6 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausalLM
-from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 from vllm.model_executor.models.qwen3_dflash import DFlashQwen3ForCausalLM
 from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
@@ -365,13 +364,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
-        all_indexer_layer_names = set(get_layers_from_vllm_config(self.vllm_config, DeepseekV32IndexerCache).keys())
-        # Filter to only layers that have KV cache specs.
+        # Filter to only layers that have KV cache specs. Split indexer cache
+        # layers must stay in this set: they now own a metadata builder even
+        # though the draft model shares their physical cache with the target.
         self._draft_attn_layer_names = {
             name
             for name in (set(all_attn_layers.keys()) - target_attn_layer_names)
             if all_attn_layers[name].get_kv_cache_spec(self.vllm_config) is not None
-        } - all_indexer_layer_names
+        }
 
         self.attn_layer_names = list(sorted(self._draft_attn_layer_names))
         draft_attn_layers_dict = get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase)
@@ -756,7 +756,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     common_attn_metadata.context_parallel_metadata = dcp_manager.long_seq_metadata
 
                 assert len(self.draft_attn_groups) > 0
-                builder = self.draft_attn_groups[0].get_metadata_builder()
                 # update the tensor's address for each step.
                 for draft_index in range(self.num_speculative_tokens):
                     common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
@@ -779,23 +778,25 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     if self.dcp_size > 1 and draft_index > 0:
                         assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
                         common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
-                    if not self.use_compress or draft_index == 0:
-                        attn_metadata_eagle = builder.build_for_graph_capture(
-                            common_attn_metadata,
-                            AscendAttentionState.SpecDecoding
-                            if self.method == "mtp"
-                            else AscendAttentionState.ChunkedPrefill,
-                            **extra_attn_metadata_args,
-                        )
-                    else:
-                        attn_metadata_eagle = builder.build_for_drafting(
-                            common_attn_metadata,
-                            draft_index,
-                            **extra_attn_metadata_args,
-                        )
                     per_layer_attn_metadata = dict()
-                    for layer_name in self.attn_layer_names:
-                        per_layer_attn_metadata[layer_name] = attn_metadata_eagle
+                    for attn_group in self.draft_attn_groups:
+                        builder = attn_group.get_metadata_builder()
+                        if not self.use_compress or draft_index == 0:
+                            attn_metadata_eagle = builder.build_for_graph_capture(
+                                common_attn_metadata,
+                                AscendAttentionState.SpecDecoding
+                                if self.method == "mtp"
+                                else AscendAttentionState.ChunkedPrefill,
+                                **extra_attn_metadata_args,
+                            )
+                        else:
+                            attn_metadata_eagle = builder.build_for_drafting(
+                                common_attn_metadata,
+                                draft_index,
+                                **extra_attn_metadata_args,
+                            )
+                        for layer_name in attn_group.layer_names:
+                            per_layer_attn_metadata[layer_name] = attn_metadata_eagle
                     multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         model_positions = self._get_positions(num_tokens)
@@ -1138,8 +1139,21 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # Copy the old attn_metadata and update
             for draft_index in range(1, self.num_speculative_tokens):
                 per_layer_attn_metadata = dict()
-                for attn_group in self.draft_attn_groups:
-                    common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
+                if self.method == "mtp" and len(self.draft_attn_groups) > 1:
+                    # SFA and its split indexer have distinct metadata groups,
+                    # but they describe the same draft-token step. Advance the
+                    # shared sequence/position/slot state exactly once, then
+                    # let every remaining builder derive its own metadata from
+                    # that updated common view.
+                    primary_group = next(
+                        (
+                            group
+                            for group in self.draft_attn_groups
+                            if not all(name.endswith(".indexer.k_cache") for name in group.layer_names)
+                        ),
+                        self.draft_attn_groups[0],
+                    )
+                    common_attn_metadata, primary_metadata = self.attn_update_stack_num_spec_norm(
                         draft_index,
                         common_attn_metadata,
                         batch_size,
@@ -1147,10 +1161,34 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         used_update_positions,
                         aclgraph_runtime_mode,
                         **draft_cp_kwargs,
-                        attn_group=attn_group,
+                        attn_group=primary_group,
                     )
-                    for layer_name in self.attn_layer_names:
-                        per_layer_attn_metadata[layer_name] = attn_metadata
+                    for layer_name in primary_group.layer_names:
+                        per_layer_attn_metadata[layer_name] = primary_metadata
+                    for attn_group in self.draft_attn_groups:
+                        if attn_group is primary_group:
+                            continue
+                        builder = attn_group.get_metadata_builder()
+                        attn_metadata = builder.build_for_drafting(
+                            common_attn_metadata,
+                            draft_index,
+                        )
+                        for layer_name in attn_group.layer_names:
+                            per_layer_attn_metadata[layer_name] = attn_metadata
+                else:
+                    for attn_group in self.draft_attn_groups:
+                        common_attn_metadata, attn_metadata = self.attn_update_stack_num_spec_norm(
+                            draft_index,
+                            common_attn_metadata,
+                            batch_size,
+                            num_input_tokens,
+                            used_update_positions,
+                            aclgraph_runtime_mode,
+                            **draft_cp_kwargs,
+                            attn_group=attn_group,
+                        )
+                        for layer_name in attn_group.layer_names:
+                            per_layer_attn_metadata[layer_name] = attn_metadata
                 multi_steps_attn_metadata.append(per_layer_attn_metadata)
 
         token_indices_to_sample_len = token_indices_to_sample.shape[0]

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -136,15 +136,16 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
 
         The full-window path still reuses the same logical window for every MTP
         layer, but graph-param update/replay expects draft metadata to be
-        indexed by speculative step.  Each Step3.5 MTP attention group maps to
-        one draft step/KV-cache group, so return:
+        indexed by speculative step. A logical MTP layer maps to one draft
+        step, while its main attention and split indexer can belong to
+        different backend/cache groups. Group the results by layer prefix, so
+        return:
 
         ``[{layer0: meta0}, {layer1: meta1}, {layer2: meta2}]``
 
         instead of one dict containing all MTP layers.
         """
-        per_group_attn_metadata: list[Any] = []
-        multi_steps_attn_metadata: list[dict[str, Any]] = []
+        per_step_layer_metadata: dict[str, dict[str, Any]] = {}
         extra_attn_metadata_args: dict[str, Any] = {}
         if self.use_compress:
             extra_attn_metadata_args = dict(
@@ -168,12 +169,36 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
                 )
                 if hasattr(attn_metadata, "causal") and not attn_metadata.causal:
                     attn_metadata.attn_mask = None
-            per_group_attn_metadata.append(attn_metadata)
-            per_step_attn_metadata: dict[str, Any] = {}
             for layer_name in attn_group.layer_names:
+                step_key = layer_name.split(".self_attn.", maxsplit=1)[0]
+                per_step_attn_metadata = per_step_layer_metadata.setdefault(step_key, {})
                 per_step_attn_metadata[layer_name] = attn_metadata
-            multi_steps_attn_metadata.append(per_step_attn_metadata)
-        return per_group_attn_metadata, multi_steps_attn_metadata
+
+        def step_number(step_key: str) -> int:
+            marker = ".layers."
+            if marker not in step_key:
+                return 0
+            return int(step_key.split(marker, maxsplit=1)[1].split(".", maxsplit=1)[0])
+
+        multi_steps_attn_metadata = [
+            metadata
+            for _, metadata in sorted(
+                per_step_layer_metadata.items(),
+                key=lambda item: step_number(item[0]),
+            )
+        ]
+        primary_attn_metadata = [
+            self._primary_step_attn_metadata(metadata)
+            for metadata in multi_steps_attn_metadata
+        ]
+        return primary_attn_metadata, multi_steps_attn_metadata
+
+    @staticmethod
+    def _primary_step_attn_metadata(per_layer_metadata: dict[str, Any]) -> Any:
+        for layer_name, metadata in per_layer_metadata.items():
+            if not layer_name.endswith(".indexer.k_cache"):
+                return metadata
+        raise RuntimeError("Step3.5 MTP step is missing its main attention metadata.")
 
     def _sample_draft_tokens_for_step(
         self,
@@ -461,7 +486,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         common_attn_metadata.query_start_loc = self.query_start_loc_group[0][: num_reqs_padded + 1]
         common_attn_metadata.num_input_tokens = num_input_tokens
         _, multi_steps_attn_metadata = self._build_step_attn_metadatas(common_attn_metadata)
-        attn_metadata_i = next(iter(multi_steps_attn_metadata[0].values()))
+        attn_metadata_i = self._primary_step_attn_metadata(multi_steps_attn_metadata[0])
 
         if not self.use_cuda_graph:
             common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor.clone()

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -286,6 +286,7 @@ def build_attn_metadata(
             attn_metadata_builder = attn_group.get_metadata_builder(0)
             is_dsa_builder = isinstance(attn_metadata_builder, AscendDSAMetadataBuilder)
             is_sfa_builder = isinstance(attn_metadata_builder, AscendSFAMetadataBuilder)
+            consumes_pcp_context = bool(getattr(attn_metadata_builder, "consumes_pcp_context", False))
             attn_metadata_extra_kwargs = (
                 model_specific_attn_metadata.get_extra_attn_kwargs(
                     attn_metadata_builder,
@@ -300,8 +301,9 @@ def build_attn_metadata(
                     num_actual_reqs=num_actual_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                 )
-            # Only SFA and DSA metadata builders consume PCP context.
-            if pcp_context is not None and (is_sfa_builder or is_dsa_builder):
+            # Parallel attention and cache-only backends opt in to the PCP
+            # context needed to construct their own metadata.
+            if pcp_context is not None and (is_sfa_builder or is_dsa_builder or consumes_pcp_context):
                 attn_metadata_extra_kwargs.update(
                     pcp_context=pcp_context,
                     pcp_cache_group_idx=i,


### PR DESCRIPTION
### What this PR does / why we need it?

Depends on #16325 and is based on its head `b43f34281887e689ae978c54c0b7ff7f246f078d`. Until that PR lands, this comparison also includes its commits.

Align Mooncake transfers with MRV2 DCP groups, which already span PCP ranks. Handle SFA prefill without DCP and decode with DCP in a separate entry branch, selecting an existing PCP replica and mapping global prompt blocks to each decode rank. Preserve the original SFA scope, equal-block-size requirement, and transfer interfaces.

Keep replicated indexer KV on one source port, account for PCP when decoding PP ports, and require callers to pass `remote_pcp_size` explicitly. Forward the MRV2 indexer graph-capture entry point to the implementation from #16325.

### Does this PR introduce _any_ user-facing change?

Fixes KV transfer for the affected SFA/MRV2 PCP and DCP configurations. No new configuration options.

### How was this patch tested?

Regression results for `be493cbba7a841a0d1cc0567b3b805275e762349` (2026-09-13):

- Verified all 3,880 tracked source files in the isolated test directory against the commit snapshot.
- **182 passed** across `test_mooncake_connector.py`, `test_indexer.py`, `test_sfa_cp.py`, and `test_attn_utils_v2.py`, using paired vLLM `b2f685834a6456197e7033966fdef52a23f1abcd` in the remote CPU-mock UT environment.
- **252/252 real NPU transfer checks passed** using Mooncake's `ascend` backend on two NPUs. The harness extracts the current production entry/mapping methods and checks every destination element, including untouched regions. It covers DCP2/4/8 ranks, PCP1/2 source replicas, short/tail prompts, cached prefixes, and replicated indexer transfers.
- This synthetic-buffer transfer check is not an end-to-end model or cross-host P/D serving test. Full model P/D regression for this revision remains pending. Test processes have exited and the two NPUs have been released.
- The transfer-engine wheel has a separately reproduced import-only shutdown allocator failure in this environment. The harness performs assertions and memory unregistration before explicit process exit; normal library destruction is not claimed as validated.
- Production Mooncake file SHA256: `37c45fb33ba57949236c082345cc3a1e583ff9d13820b6b50ceb334de2bc2a4c`.

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
