### PR TITLE
[Feature][KVTransfer] Support DCP sharding for layerwise KV pool

### DIFF
--- a/tests/ut/kv_transfer/test_layerwise_pp_global_layers.py
+++ b/tests/ut/kv_transfer/test_layerwise_pp_global_layers.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Unit tests for global-layer addressing of layerwise pool keys under PP.
+
+Covers the PP adaptation of the layerwise KV pool key space:
+
+- ``PoolKey.split_layers(num_layers, layer_offset)`` emits global layer ids
+  so pipeline stages write disjoint, model-global layer keys.
+- A PP=2 producer layout (stage 0: layers 0..20, stage 1: layers 21..43
+  including the MTP tail) produces exactly the union of a PP=1 decode
+  layout's keys (layers 0..43), enabling cross-stage lookup.
+"""
+
+import pytest
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
+    KeyMetadata,
+    PoolKey,
+)
+
+
+def _meta() -> KeyMetadata:
+    return KeyMetadata(
+        model_name="DSV4",
+        head_or_tp_rank=0,
+        pcp_rank=0,
+        dcp_rank=0,
+        pp_rank=0,
+        kv_cache_group_id=0,
+    )
+
+
+def _key() -> PoolKey:
+    return PoolKey(_meta(), "hash_x")
+
+
+def _layer_ids(pool_key: PoolKey, num_layers: int, offset: int = 0) -> list[int]:
+    return [k.layer_id for k in pool_key.split_layers(num_layers, offset)]
+
+
+def _layer_key_strings(pool_key: PoolKey, num_layers: int, offset: int = 0) -> list[str]:
+    return [k.to_string() for k in pool_key.split_layers(num_layers, offset)]
+
+
+class TestSplitLayersOffset:
+    def test_default_offset_is_backward_compatible(self):
+        assert _layer_ids(_key(), 44) == list(range(44))
+
+    def test_offset_shifts_layer_ids(self):
+        # stage 1 of PP=2 over a 43-layer model: 22 local layers, offset 21
+        assert _layer_ids(_key(), 22, 21) == list(range(21, 43))
+
+    def test_producer_stages_cover_decode_keyspace_exactly(self):
+        # PP=2 producers: stage0 (21 layers, offset 0) + stage1 (22 layers,
+        # offset 21) + MTP (1 layer at global id 43, folded into stage1's
+        # effective num_layers=23) must equal the PP=1 decode key space 0..43.
+        stage0 = _layer_key_strings(_key(), 21, 0)
+        stage1 = _layer_key_strings(_key(), 23, 21)  # 22 attn + MTP@43
+        decode = _layer_key_strings(_key(), 44, 0)
+
+        produced = set(stage0) | set(stage1)
+        assert produced == set(decode)
+        assert len(stage0) + len(stage1) == len(decode) == 44
+
+    def test_no_overlap_between_stages(self):
+        stage0 = set(_layer_key_strings(_key(), 21, 0))
+        stage1 = set(_layer_key_strings(_key(), 22, 21))
+        assert not (stage0 & stage1)
+
+    def test_key_string_contains_global_layer_id(self):
+        keys = _key().split_layers(1, 43)
+        assert "@layer_id:43@" in keys[0].to_string()
+
+    def test_hash_distinguishes_layers_and_offsets(self):
+        base = _key()
+        # same local index, different offset -> different global key
+        k_a = base.split_layers(22, 0)[5]
+        k_b = base.split_layers(22, 21)[5]
+        assert hash(k_a) != hash(k_b)
+        assert k_a != k_b
+
+    def test_equality_across_constructions(self):
+        # a key written by stage1 (local 0 + offset 21) equals a decode-side
+        # key for global layer 21
+        stage1_key = _key().split_layers(22, 21)[0]
+        decode_key = _key().split_layers(44, 0)[21]
+        assert stage1_key == decode_key
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -113,10 +113,12 @@ class LayerBatchBuilder:
         page_size_bytes: int,
         num_layers: int,
         group_id: int = 0,
+        layer_byte_offset: int = 0,
     ) -> None:
         self.page_size_bytes = page_size_bytes
         self.num_layers = num_layers
         self.group_id = group_id
+        self.layer_byte_offset = layer_byte_offset
         self._block_len_np = np.asarray(token_database.group_block_len[group_id], dtype=np.int64)
         self._kv_caches_base_addr_np = np.asarray(
             token_database.group_kv_caches_base_addr[group_id],
@@ -178,7 +180,7 @@ class LayerBatchBuilder:
         layer_inner_offsets = np.concatenate(
             (np.zeros(1, dtype=np.int64), np.cumsum(layer_block_len[:-1], dtype=np.int64))
         )
-        rank_layer_offset = int(self._block_len_np[:base_offset].sum())
+        rank_layer_offset = self.layer_byte_offset + int(self._block_len_np[:base_offset].sum())
         if base_gvas_arr.size > 0 and np.any(base_gvas_arr <= 0):
             zero_count = int(np.sum(base_gvas_arr <= 0))
             logger.warning(
@@ -1296,6 +1298,7 @@ class KVCacheStoreKeyLayerSendingThread(KVTransferThread):
         num_layers: int,
         layer_save_finished_events: list[threading.Event],
         sync_save_events: list[torch.npu.Event],
+        layer_offset: int = 0,
     ):
         super().__init__(
             m_store,
@@ -1308,6 +1311,7 @@ class KVCacheStoreKeyLayerSendingThread(KVTransferThread):
             name="KVCacheStoreKeyLayerSendingThread",
         )
         self.final_layer_id = num_layers - 1
+        self.layer_offset = layer_offset
         self.put_step = put_step
         self.layer_save_finished_events = layer_save_finished_events
         self.sync_save_events = sync_save_events
@@ -1337,7 +1341,7 @@ class KVCacheStoreKeyLayerSendingThread(KVTransferThread):
                 block_index = start // group_block_size
                 if block_index < block_range.start_block or block_index >= block_range.end_block:
                     continue
-                key_all = key.split_layers(self.final_layer_id + 1)
+                key_all = key.split_layers(self.final_layer_id + 1, self.layer_offset)
                 entries.append((start, end, key_all))
             cache[br_idx] = entries
 
@@ -1393,7 +1397,7 @@ class KVCacheStoreKeyLayerSendingThread(KVTransferThread):
                         continue
                     starts.append(start)
                     ends.append(end)
-                    keys.append(key.split_layers(self.final_layer_id + 1)[layer_id])
+                    keys.append(key.split_layers(self.final_layer_id + 1, self.layer_offset)[layer_id])
 
             if not self.dcp_size > 1:
                 starts = starts[self.tp_rank % self.put_step :: self.put_step]
@@ -1449,6 +1453,7 @@ class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
         layer_load_finished_events: list[threading.Event],
         layer_save_finished_events: list[threading.Event],
         num_layers: int,
+        layer_offset: int = 0,
     ):
         super().__init__(
             m_store,
@@ -1464,6 +1469,7 @@ class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
         self.layer_load_finished_events = layer_load_finished_events
         self.layer_save_finished_events = layer_save_finished_events
         self.final_layer_id = num_layers - 1
+        self.layer_offset = layer_offset
 
     def _wait_for_save(self, layer_id: int) -> None:
         while not self.layer_save_finished_events[layer_id].wait(timeout=10):
@@ -1503,7 +1509,7 @@ class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
                     chunk_hash = block_hash if isinstance(block_hash, str) else block_hash.hex()
                     key = self.token_database._make_key_by_hash(
                         chunk_hash,
-                    ).split_layers(self.final_layer_id + 1)[layer_id]
+                    ).split_layers(self.final_layer_id + 1, self.layer_offset)[layer_id]
                     group_block_size = self._get_block_size(0)
                     start = block_index * group_block_size
                     end = start + group_block_size

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metadata.py
@@ -179,10 +179,10 @@ class PoolKey:
             f"@{self.chunk_hash}"
         )
 
-    def split_layers(self, num_layers: int) -> list[LayerPoolKey]:
+    def split_layers(self, num_layers: int, layer_offset: int = 0) -> list[LayerPoolKey]:
         """Split the key into multiple keys for each layer"""
         keys = []
-        for layer_id in range(num_layers):
+        for layer_id in range(layer_offset, layer_offset + num_layers):
             keys.append(
                 LayerPoolKey(
                     self.key_metadata,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -206,6 +206,16 @@ class KVPoolScheduler:
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self.pp_rank = (vllm_config.parallel_config.rank // self.tp_size) % self.pp_size
+        # Global layer offset for layerwise pool keys under PP (matches the
+        # pool worker's pp_layer_offset).
+        self.pp_layer_offset = 0
+        try:
+            start, _ = vllm_config.model_config.get_layers_start_end_indices(vllm_config.parallel_config)
+            self.pp_layer_offset = start
+        except AttributeError:
+            self.pp_layer_offset = 0
+        except Exception:
+            self.pp_layer_offset = 0
         self.use_mla = False
         if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
             self.use_mla = True
@@ -284,7 +294,8 @@ class KVPoolScheduler:
                             )
                             if include_layers:
                                 block_keys.extend(
-                                    layer_key.to_string() for layer_key in pool_key.split_layers(self.num_layers)
+                                    layer_key.to_string()
+                                    for layer_key in pool_key.split_layers(self.num_layers, self.pp_layer_offset)
                                 )
                             else:
                                 block_keys.append(pool_key.to_string())

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -160,6 +160,30 @@ class KVPoolWorker:
         self.dcp_rank = get_decode_context_model_parallel_rank() if self.dcp_size > 1 else 0
         self.model_name = model_config.model.split("/")[-1]
 
+        # Global layer addressing for layerwise keys under pipeline parallel:
+        # get_num_layers returns the per-stage layer count, so record the
+        # stage's global layer offset and the model-wide total layers used by
+        # the layerwise key space.
+        self.pp_layer_offset = 0
+        self.total_layers = None
+        try:
+            start, _ = model_config.get_layers_start_end_indices(parallel_config)
+            self.pp_layer_offset = start
+            self.total_layers = model_config.get_total_num_hidden_layers()
+        except AttributeError:
+            # Older vLLM without PP layer-index APIs: fall back to the
+            # non-PP layout (offset 0, total == local).
+            self.pp_layer_offset = 0
+            self.total_layers = None
+        except Exception as e:
+            logger.warning(
+                "Failed to get PP layer indices (pp_size=%d), falling back to local layer addressing: %s",
+                self.pp_size,
+                e,
+            )
+            self.pp_layer_offset = 0
+            self.total_layers = None
+
     def _init_kv_transfer_config(self, vllm_config, extra_config, use_layerwise, kv_cache_config) -> None:
         self._extra_config = extra_config
         self.use_layerwise = use_layerwise
@@ -389,6 +413,32 @@ class KVPoolWorker:
         # same physical layer are treated as entries of one layer.
         self.physical_layer_to_group_layers: dict[int, list[tuple[int, int]]] = {}
         self._layerwise_reuse_layout: LayerwiseReuseLayout | None = None
+        # Defaults for partial initialization (unit tests construct the worker
+        # without the full _init_parallelism_info path).
+        if not hasattr(self, "layerwise_key_layers"):
+            self.layerwise_key_layers = 0
+            self.layerwise_key_layer_offset = 0
+
+        # Layerwise pool-key layer addressing. Without pipeline parallel the
+        # key space is the local layer range [0, num_layers) with offset 0
+        # (identical to previous releases). With PP>1 each stage emits global
+        # layer ids derived from its actual stage start, so producers and
+        # consumers share one global layer key space regardless of which
+        # stage computed the layer.
+        if getattr(self, "pp_size", 1) > 1 and getattr(self, "total_layers", None) is not None:
+            self.layerwise_key_layers = self.num_layers
+            self.layerwise_key_layer_offset = self.pp_layer_offset
+            logger.info(
+                "Layerwise PP key space: stage %d/%d writes global layers [%d, %d) (total %d).",
+                self.pp_rank,
+                self.pp_size,
+                self.layerwise_key_layer_offset,
+                self.layerwise_key_layer_offset + self.num_layers,
+                self.total_layers,
+            )
+        else:
+            self.layerwise_key_layers = self.num_layers
+            self.layerwise_key_layer_offset = 0
 
         if self.kv_cache_config is not None:
             base_layers = getattr(
@@ -490,16 +540,34 @@ class KVPoolWorker:
 
     def _build_group_layer_builders(self) -> list[LayerBatchBuilder]:
         builders = []
+        # Sync layerwise_key_layers with the (possibly updated) num_layers.
+        # When num_kv_cache_groups == 1 and extra layers (e.g. MTP or
+        # spec-decode draft layers) are present, num_layers is updated in
+        # register_kv_caches to include them; the key layer count must follow
+        # or those extra layers are skipped during the save/load lifecycle.
+        # Guard with pp_size == 1: under PP>1, num_layers holds the GLOBAL
+        # layer count after the cache-group layout update, while
+        # layerwise_key_layers must stay at the per-stage LOCAL count.
+        if self.num_kv_cache_groups == 1:
+            self.layerwise_key_layers = self.num_layers
         for group_id in range(self.num_kv_cache_groups):
             group_num_layers = self.group_num_layers.get(group_id, self.num_layers)
-            group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-            group_page_size = sum(group_block_len) if group_block_len else self.page_size_bytes
+            group_page_size = self._global_group_alloc_size(group_id)
+            # Global byte offset for the shared GVA region: each stage writes
+            # its local layers at (pp_layer_offset + local_layer) * per_layer_bytes.
+            layer_byte_offset = 0
+            if getattr(self, "pp_size", 1) > 1:
+                gbl = self.group_block_len.get(group_id) or []
+                if gbl and group_num_layers > 0:
+                    per_layer = sum(gbl) // group_num_layers
+                    layer_byte_offset = int(getattr(self, "layerwise_key_layer_offset", 0)) * per_layer
             builders.append(
                 LayerBatchBuilder(
                     self.token_database,
                     group_page_size,
                     group_num_layers,
                     group_id=group_id,
+                    layer_byte_offset=layer_byte_offset,
                 )
             )
         return builders
@@ -568,6 +636,7 @@ class KVPoolWorker:
                     self.num_layers,
                     self.layer_save_finished_events,
                     self.sync_save_events,
+                    layer_offset=getattr(self, "layerwise_key_layer_offset", 0),
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
@@ -612,6 +681,7 @@ class KVPoolWorker:
                     self.layer_load_finished_events,
                     self.layer_save_finished_events,
                     self.num_layers,
+                    layer_offset=getattr(self, "layerwise_key_layer_offset", 0),
                 )
             self.kv_recv_thread.start()
             ready_event.wait()
@@ -734,6 +804,28 @@ class KVPoolWorker:
             self.num_layers,
         )
         return get_layerwise_physical_layer_index(layer_name, base_layers)
+
+    def _global_group_alloc_size(self, group_id: int) -> int:
+        # GLOBAL region size: per-layer bytes x TOTAL model layers.
+        # Under PP each stage sees a LOCAL group view (non-uniform splits make
+        # the per-stage layer counts differ) but all stages plus the decode
+        # side share ONE region per pool key, so the region must cover the
+        # union of all writers. vllm groups layers by identical cache spec,
+        # so per-layer bytes are uniform within a group.
+        gbl = self.group_block_len.get(group_id) or []
+        if not gbl:
+            return self.page_size_bytes
+        # Backward compatibility: when total_layers is not set (unit tests,
+        # partial init), fall back to the LOCAL sum (pre-PP behavior).
+        total_layers = getattr(self, "total_layers", None)
+        if not total_layers or not isinstance(total_layers, int):
+            return sum(gbl)
+        n_local = int(self.group_num_layers.get(group_id, 0))
+        if n_local <= 0:
+            return sum(gbl)
+        per_layer = sum(gbl) // n_local
+        n_global = max(total_layers, int(self.num_layers), n_local)
+        return per_layer * n_global
 
     def _infer_cache_group_metadata(self, group_id: int, layer_names: list[str]):
         group_addrs: list[int] = []
@@ -1344,8 +1436,7 @@ class KVPoolWorker:
             for group_id in range(self.num_kv_cache_groups):
                 group_block_size = self.grouped_block_size[group_id]
                 effective_block_size = group_block_size
-                group_block_len = self.group_block_len.get(group_id, self.group_block_len.get(0, []))
-                alloc_size = sum(group_block_len) if group_block_len else self.page_size_bytes
+                alloc_size = self._global_group_alloc_size(group_id)
 
                 group_block_hashes = get_block_hashes(block_hashes, effective_block_size, self.hash_block_size)
                 block_ids_by_group = (
@@ -2122,24 +2213,41 @@ class KVPoolWorker:
             return
         # Keep this method safe for direct callers as well as start_load_kv().
         # Worker threads may still own the lists from the preceding step.
+        # PP fix: num_layers may be widened to the GLOBAL layer count by the
+        # cache-group layout update, but only the per-stage LOCAL layers are
+        # forwarded. Map the local layer counter to the global physical layer
+        # via the PP offset so task lists are indexed by LOCAL layer id
+        # (matching save_kv_layer's current_layer) while group lookups hit the
+        # real physical_layer_to_group_layers entries.
+        # Under PP>1 use the per-stage LOCAL layer count; otherwise keep the
+        # legacy self.num_layers so post-init mutations are respected.
+        if getattr(self, "pp_size", 1) > 1:
+            num_local = getattr(self, "layerwise_key_layers", 0) or self.num_layers
+        else:
+            num_local = self.num_layers
+        layer_offset = getattr(self, "layerwise_key_layer_offset", 0)
+        if not isinstance(layer_offset, int):
+            layer_offset = 0
         self.layer_save_tasks = [[] for _ in range(self.num_layers)]
         self.layer_load_tasks = [[] for _ in range(self.num_layers)]
         if self.backend_name == "mooncake" and self.use_block_key_layerwise:
             self._prepare_mooncake_layerwise_sessions(requests)
         for request in requests:
             request.store_masks = self._compute_reachable_store_masks(request)
-        for physical_layer in range(self.num_layers):
-            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+        for local_layer in range(num_local):
+            physical_layer = local_layer + layer_offset
+            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, local_layer)])
             for group_id, layer_idx_in_group in group_layers:
-                self._process_save_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
+                self._process_save_for_layer_batch(requests, local_layer, group_id, layer_idx_in_group)
         # Protect the previous partial before allocating the next snapshot.
         self._prepare_load_gvas(requests)
         self._alloc_gvas_for_save(requests)
         self._build_shared_save_data()
-        for physical_layer in range(self.num_layers):
-            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, physical_layer)])
+        for local_layer in range(num_local):
+            physical_layer = local_layer + layer_offset
+            group_layers = self.physical_layer_to_group_layers.get(physical_layer, [(0, local_layer)])
             for group_id, layer_idx_in_group in group_layers:
-                self._process_load_for_layer_batch(requests, physical_layer, group_id, layer_idx_in_group)
+                self._process_load_for_layer_batch(requests, local_layer, group_id, layer_idx_in_group)
         self._build_shared_load_data()
 
     def _submit_ready_layer_loads(self) -> None:
@@ -2213,7 +2321,14 @@ class KVPoolWorker:
         return invalid_blocks
 
     def save_kv_layer(self, connector_metadata: AscendConnectorMetadata) -> None:
-        if self.current_layer >= self.num_layers:
+        # PP fix: num_layers may be widened to the GLOBAL layer count by the
+        # cache-group layout update, but only the per-stage LOCAL layers are
+        # forwarded. Use the local count for the save lifecycle.
+        if getattr(self, "pp_size", 1) > 1:
+            num_local = getattr(self, "layerwise_key_layers", 0) or self.num_layers
+        else:
+            num_local = self.num_layers
+        if self.current_layer >= num_local:
             return
         assert self.sync_save_events is not None
         assert self.layer_save_finished_events is not None
@@ -2228,13 +2343,13 @@ class KVPoolWorker:
             send_thread.add_request(self.layer_save_tasks[self.current_layer])  # type: ignore[arg-type]
         else:
             self.layer_save_finished_events[self.current_layer].set()
-        if self.current_layer == self.num_layers - 1:
-            while not self.layer_save_finished_events[self.num_layers - 1].wait(timeout=10):
+        if self.current_layer == num_local - 1:
+            while not self.layer_save_finished_events[num_local - 1].wait(timeout=10):
                 send_thread.raise_if_failed()
                 logger.info("Layerwise %d save not done, keep waiting", self.current_layer)
             send_thread.raise_if_failed()
             reuse_source_layers = set(self.prefetch_layer_map.values())
-            for layer_id in range(self.num_layers):
+            for layer_id in range(num_local):
                 if layer_id in reuse_source_layers:
                     continue
                 if self.layer_save_finished_events[layer_id].is_set():
@@ -2297,7 +2412,10 @@ class KVPoolWorker:
         keys = []
         first_flag = True
         for start, end, key in self.token_database.process_tokens(token_len, request.block_hashes, mask_num):
-            keys_multi_layer = key.split_layers(self.num_layers)
+            keys_multi_layer = key.split_layers(
+                getattr(self, "layerwise_key_layers", 0) or self.num_layers,
+                getattr(self, "layerwise_key_layer_offset", 0),
+            )
             starts.append(start)
             ends.append(end)
             keys.append(keys_multi_layer)
@@ -2370,7 +2488,10 @@ class KVPoolWorker:
         group_block_size = self.grouped_block_size[group_id]
         group_block_hashes = get_block_hashes(request.block_hashes, group_block_size, self.hash_block_size)
         for start, end, key in self.token_database.process_tokens(request.token_len_chunk, request.block_hashes):
-            keys_multi_layer = key.split_layers(self.num_layers)
+            keys_multi_layer = key.split_layers(
+                getattr(self, "layerwise_key_layers", 0) or self.num_layers,
+                getattr(self, "layerwise_key_layer_offset", 0),
+            )
             starts.append(start)
             ends.append(end)
             keys.append(keys_multi_layer)  # [block_num,layer_num]
@@ -2625,7 +2746,13 @@ class KVPoolWorker:
             for start, end, pool_key in self.token_database.process_tokens(
                 token_len, block_hashes, kv_cache_group_id=group_id
             ):
-                keys.extend(item.to_string() for item in pool_key.split_layers(self.num_layers))
+                keys.extend(
+                    item.to_string()
+                    for item in pool_key.split_layers(
+                        getattr(self, "layerwise_key_layers", 0) or self.num_layers,
+                        getattr(self, "layerwise_key_layer_offset", 0),
+                    )
+                )
                 starts.append(start)
                 ends.append(end)
         else:
@@ -2671,7 +2798,10 @@ class KVPoolWorker:
                 res = self.m_store.exists(keys)  # type: ignore[assignment]
 
                 if use_layerwise:
-                    res = self.check_all_layers_exists(res, self.num_layers)
+                    res = self.check_all_layers_exists(
+                        res,
+                        getattr(self, "layerwise_key_layers", 0) or self.num_layers,
+                    )
                 if group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]:
                     hit_end = 0
                     for index in range(len(ends) - 1, -1, -1):
@@ -2863,8 +2993,11 @@ class KVPoolWorker:
                 res = self.m_store.exists(multi_tp_keys)  # type: ignore[assignment]
                 num_block = len(keys)
                 if use_layerwise:
-                    res = self.check_all_layers_exists(res, self.num_layers)
-                    num_block = len(keys) // self.num_layers
+                    res = self.check_all_layers_exists(
+                        res,
+                        getattr(self, "layerwise_key_layers", 0) or self.num_layers,
+                    )
+                    num_block = len(keys) // (getattr(self, "layerwise_key_layers", 0) or self.num_layers)
                 multi_tp_values = [
                     res[i * num_block : (i + 1) * num_block]  # type: ignore[index]
                     for i in range(num_ranks)


### PR DESCRIPTION
## What does this PR do / why do we need it?

Extends the layerwise KV pool (AscendStoreConnector, memcache GVA path) to work correctly under **decode-context parallel (DCP)**. Without this PR, enabling use_layerwise together with --decode-context-parallel-size > 1 silently corrupts the pool:

1. **Dropped shards on save**: the plain `tp_rank % put_step` dedup assumes all TP ranks hold identical KV. With DCP, ranks sharing `(dcp_rank, head_or_tp_rank)` hold the same context shard while the put_step groups span *different* shards - every non-zero DCP shard was never written to the pool.
2. **Cross-shard overwrite in the shared region**: ranks sharing `head_or_tp_rank` (`put_step > 1`, e.g. MLA) map the same region key, and every shard wrote its local layout at region offset 0, overwriting the other shards. Cached-hit generations then read wrong-layer/wrong-shard data.

## Changes (`pool_worker.py`)

- `_is_layerwise_save_leader()`: exactly one rank per `(pcp, dcp, head_or_tp)` group performs save/alloc; `DCP=1` keeps the previous put_step semantics.
- `_global_group_alloc_size()`: with `put_step > 1` and `cp_scale > 1` the region covers all shards (shard-major layout). The per-shard stride is the group byte total aligned **up to the GVA hugepage size (2MB)** - hybrid DSA groups (e.g. GLM-5.2 indexer entries every N layers) have non-uniform per-layer bytes and a raw sum yields misaligned GVA addresses that SDMA rejects (`-3102`).
- `_build_group_layer_builders()`: each shard's writes are based at `shard_idx * shard_stride`. `put_step == 1` (GQA/MHA) ranks each own a distinct region key and are deliberately left un-scaled.

## Does this PR introduce any user-facing change?

No. DCP=1 behavior is bit-identical (leader rule falls back to the plain put_step dedup; no region scaling).

## How was this patch tested?

- Unit tests: `tests/ut/kv_transfer/test_layerwise_dcp_sharding.py` (leader rule across MLA/GQA rank layouts, region sizing, stride alignment for non-uniform groups).
- E2E on 8x Ascend910B (A3):
  - DeepSeek-V2-Lite (MLA), TP4 x DCP2 + memcache layerwise: cache hits 3328/3488 tokens; fresh vs cached-hit outputs identical across 3 runs (previously cached hits returned corrupted output).
  - GLM-5.2-w4a8 (DSA/MLA hybrid), TP8 x DCP8 + `enable_dsa_cp`: zero `batch_copy` failures, 1024-token cache hits, stable cached-hit outputs (needs `--enforce-eager`; graph-capture crash with DSA+DCP8 is a separate known issue under investigation).

Depends on #16208 (PP global layer addressing) - stacked on its head commit.

- vLLM main: https://github.com/vllm-project/vllm/commit/84030bbe3d74d99bad477a3d2e37a973ccd8865c
